### PR TITLE
Add extra header check for 3P scenario

### DIFF
--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -16,7 +16,16 @@
 #include "http/HttpClientFactory.hpp"
 
 #ifdef HAVE_MAT_UTC
+#if defined __has_include
+#  if __has_include ("modules/utc/UtcTelemetrySystem.hpp")
+#    include "modules/utc/UtcTelemetrySystem.hpp"
+#  else
+   /* Compiling without UTC support because UTC private header is unavailable */
+#  undef HAVE_MAT_UTC
+#  endif
+#  else
 #include "modules/utc/UtcTelemetrySystem.hpp"
+#endif
 #endif
 
 namespace ARIASDK_NS_BEGIN


### PR DESCRIPTION
lib/modules is an optional 1P submodule for UTC transport layer. It may not be available to 3P customers. Our "common core" code in _LogManagerImpl.cpp_ has to include a private header _lib/modules/utc/UtcTelemetrySystem.hpp_ . Our current default build configuration assumes that the UTC is available, and so **HAVE_MAT_UTC** is defined. However, that would break the build if lib/modules isn't mounted. Instead of introducing yet another 3P build configuration - rely on ___has_include_ preprocessor directive, if it's available. It is available starting from Visual Studio 2015 Update 2 (we require vs2017 as a minimum), as well as on all recent versions of clang and gcc, becoming part of C++17.. So we use it if it's available. That pretty much covers all Windows UTC scenarios and all possible compilers, so that we don't need to add a custom build config for 3P.