### PR TITLE
Fix win32 Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,15 @@ else()
   set(CMAKE_CXX_FLAGS "$ENV{CXXFLAGS} ${CMAKE_CXX_FLAGS} -std=c++11 ${DBG_FLAGS}")
 endif()
 
+#Remove /Zi for Win32 debug compiler issue
+if(MSVC)
+  string( TOLOWER "${CMAKE_VS_PLATFORM_NAME}" PLATFORM_NAME_LOWER )
+  if (PLATFORM_NAME_LOWER STREQUAL "win32")
+    string(REGEX REPLACE "/Z[iI7]" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REGEX REPLACE "/Z[iI7]" "" CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG}")
+  endif()
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # using Clang
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SRCS decorators/BaseDecorator.cpp
   pal/PAL.hpp
 )
 
-if(EXISTS "modules/exp/")
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/modules/exp/)
   list(APPEND SRCS
     modules/exp/afd/afdclient/AFDClientUtils.cpp
     modules/exp/afd/afdclient/AFDClient.cpp
@@ -88,7 +88,7 @@ remove_definitions(-D_MBCS)
     pal/desktop/WindowsEnvironmentInfo.hpp
     pal/desktop/NetworkDetector.cpp
   )
-  if(EXISTS "modules/utc/")
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/modules/utc)
     list(APPEND SRCS
       modules/utc/desktop/UtcHelpers.cpp
       modules/utc/UtcTelemetrySystem.cpp


### PR DESCRIPTION
Update cmakelists.txt to strip /Zi from Win32 Debug builds due to compiler error
Update lib/cmakelists.txt to pull in Modules if available