### PR TITLE
AriaDecoderV3: isolate OneDS internal defines and include paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ bld/
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
+# Visual Studio Code's cache/options directory
+.vscode/
 
 # Visual Studio 2017 auto generated files
 Generated\ Files/

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -5,10 +5,11 @@ docker info
 docker version
 
 export IMAGE_NAME=$1
+export BUILD_TYPE=$2
 echo Running in container $IMAGE_NAME
 
 echo Building docker image...
 docker build --rm -t $IMAGE_NAME docker/$IMAGE_NAME
 
 echo Starting build...
-docker run -it -v `pwd`:/build $IMAGE_NAME /build/build.sh
+docker run -v `pwd`:/build -w /build $IMAGE_NAME ./build.sh $BUILD_TYPE

--- a/build-win.ps1
+++ b/build-win.ps1
@@ -33,9 +33,12 @@ $win32MiniLibTargets = @("win32-mini-lib")
 if (-not $env:DevEnvDir) {
   echo "Running VsDevCmd.bat..."
   & cmd /s /c """$vsDevCmdBat"" -no_logo && set" | foreach-object {
+    echo "Reading $_"
     $name, $value = $_ -split '=', 2
-    echo "Setting $name = $value"
-    set-content env:\"$name" $value
+    if ($name -and $value) {
+      echo "   Setting $name = $value"
+      set-content env:\"$name" $value
+    }
   }
   echo "...Done!"
 }

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,10 +1,12 @@
-FROM centos:centos7
+FROM centos/devtoolset-7-toolchain-centos7
+
+USER 0
 
 # Package installation
 RUN yum update -y
 
 ## Common packages for linux build environment
-RUN yum install -y gcc gcc-c++ automake libtool-bin curl libcurl4-openssl-dev zlib1g-dev build-essential libssl-dev clang python pkg-config git curl bzip2 unzip make wget sudo centos-release-scl devtoolset-7 devtoolset-7-valgrind
+RUN yum install -y gcc gcc-c++ automake libtool-bin curl libcurl4-openssl-dev zlib1g-dev zlib-static build-essential libssl-dev clang python pkg-config git curl bzip2 unzip make wget sudo centos-release-scl devtoolset-7 devtoolset-7-valgrind
 
 ## Add docker user
 RUN useradd -m docker
@@ -13,8 +15,8 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN mkdir -p /tmp
 ## RUN mount -t tmpfs -o size=512M tmpfs /tmp
+## USER docker
 
-USER docker
 RUN echo "scl enable devtoolset-7 bash" >> ~/.bash_profile
 RUN sudo yum update -y
 

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM debian:9
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/docker/ubuntu14.04/Dockerfile
+++ b/docker/ubuntu14.04/Dockerfile
@@ -12,8 +12,7 @@ RUN adduser --disabled-password --gecos '' docker
 RUN adduser docker sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 ## RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
-
-USER docker
+## USER docker
 
 # this is where I was running into problems with the other approaches
 RUN sudo apt-get update

--- a/docker/ubuntu16.04/Dockerfile
+++ b/docker/ubuntu16.04/Dockerfile
@@ -12,8 +12,7 @@ RUN adduser --disabled-password --gecos '' docker
 RUN adduser docker sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 ## RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
-
-USER docker
+## USER docker
 
 # this is where I was running into problems with the other approaches
 RUN sudo apt-get update


### PR DESCRIPTION
This isolates OneDS internal defines and include paths into a separate internal header. Edge relies on the decoder for several build targets, but ce1e345b9b396118341c787404d8a7b3454a8847 updated the AriaDecoderV3 header to rely on the `HAVE_MAT_JSONHPP` define and several different internal include paths.

This will unblock Edge taking updated versions of OneDS.