### PR TITLE
Parse json objects, fix SDK creation

### DIFF
--- a/lib/api/LogConfiguration.cpp
+++ b/lib/api/LogConfiguration.cpp
@@ -92,8 +92,12 @@ namespace ARIASDK_NS_BEGIN {
                     dst[it.key()] = (uint64_t)(it.value());
                     break;
                 case json::value_t::object:
-                    parse(it.value(), dst[it.key()]);
+                {
+                    VariantMap sub;
+                    parse(it.value(), sub);
+                    dst[it.key()] = sub;
                     break;
+                }
                 case json::value_t::string:
                     std::string val = it.value();
                     dst[it.key()] = std::move(val);

--- a/lib/include/public/VariantType.hpp
+++ b/lib/include/public/VariantType.hpp
@@ -185,7 +185,10 @@ public:
     Variant(VariantMap& m) :
         type(TYPE_OBJ)
     {
-        assign(m);
+        for (const auto& kv : m)
+        {
+            mV[kv.first] = kv.second;
+        }
     };
 
     // C++11 initializer list support for maps

--- a/tools/sdk-create.cmd
+++ b/tools/sdk-create.cmd
@@ -46,4 +46,4 @@ call sku-create.cmd win32-lib-vs2015-md  win32-lib
 call sku-create.cmd win32-lib-vs2015-md  sqlite
 call sku-create.cmd win32-lib-vs2015-md  zlib
 
-copy /Y %ROOT%\docs\release-notes.md %OUTDIR%\
+copy /Y %ROOT%\CHANGELOG.md %OUTDIR%\

--- a/tools/sku-create.cmd
+++ b/tools/sku-create.cmd
@@ -19,20 +19,28 @@ echo Debug   = %DBG_SRC%
 
 if exist "%REL_SRC%\Win32\%SRC_NAME%" (
   robocopy %REL_SRC%\Win32\%SRC_NAME%   "%OUTDIR%\lib\%DST_NAME%\x86\Release" *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
+)
+if exist "%DBG_SRC%\Win32\%SRC_NAME%" (
   robocopy %DBG_SRC%\Win32\%SRC_NAME%   "%OUTDIR%\lib\%DST_NAME%\x86\Debug"   *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
 )
 
 if exist "%REL_SRC%\x64\%SRC_NAME%" (
   robocopy %REL_SRC%\x64\%SRC_NAME%     "%OUTDIR%\lib\%DST_NAME%\x64\Release" *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
+)
+if exist "%DBG_SRC%\x64\%SRC_NAME%" (
   robocopy %DBG_SRC%\x64\%SRC_NAME%     "%OUTDIR%\lib\%DST_NAME%\x64\Debug"   *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
 )
 
 if exist "%REL_SRC%\ARM\%SRC_NAME%" (
   robocopy %REL_SRC%\ARM\%SRC_NAME%     "%OUTDIR%\lib\%DST_NAME%\ARM\Release" *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
+)
+if exist "%DBG_SRC%\ARM\%SRC_NAME%" (
   robocopy %DBG_SRC%\ARM\%SRC_NAME%     "%OUTDIR%\lib\%DST_NAME%\ARM\Debug"   *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
 )
 
 if exist "%REL_SRC%\ARM64\%SRC_NAME%" (
   robocopy %REL_SRC%\ARM64\%SRC_NAME%     "%OUTDIR%\lib\%DST_NAME%\ARM64\Release" *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
+)
+if exist "%DBG_SRC%\ARM64\%SRC_NAME%" (
   robocopy %DBG_SRC%\ARM64\%SRC_NAME%     "%OUTDIR%\lib\%DST_NAME%\ARM64\Debug"   *.pri *.winmd *.dll *.pdb *.lib *.map *.exp
 )


### PR DESCRIPTION
This change merges in some minor fixes from MIP's custom branch:
- Fixes broken sdk-create.cmd
- Improves sku-create.cmd to allow per-config publishing (necessary for parallelized VSO pipelines)
- Fixes a bug in json parsing where objects where incorrectly being parsed to null.

The json parsing bug is applicable when passing a log configuration via C API. For example:
```
{
  "name":"mip-sdk-for-cpp",
  "maxTeardownUploadTimeInSec": 3,
  "config": { "host": "someHostNameOverride" }
}
```

The "config" property would get parsed incorrectly as a NULL object.