### PR TITLE
Update VS for azure pipeline image

### DIFF
--- a/tools/update-vs-azure-pipeline.ps1
+++ b/tools/update-vs-azure-pipeline.ps1
@@ -1,0 +1,50 @@
+# The current Azure Pipeline image does not contain all the Visual Studio packages necessary to build ClientTelemetry on
+# ARM64. This script updates VS 2017 Enterprise installation to include those packages. (Installation takes ~10 minutes.)
+
+$vs_exe_download_url = "https://aka.ms/vs/15/release/vs_enterprise.exe"
+$vs_exe = "vs_enterprise.exe"
+$vs_path = """C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"""
+
+# Components to install
+$components = @(
+    "Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre",
+    "Microsoft.Visualstudio.Component.VC.Runtimes.x86.x64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
+    "Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.MFC.ARM64",
+    "Microsoft.VisualStudio.Component.VC.MFC.ARM64.Spectre"
+)
+
+function Show-Configuration {
+  $installer_exe = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe"
+  $config_file = "install.vsconfig"
+  Write-Output "Reading installation configuration..."
+  Start-Process -FilePath $installer_exe -ArgumentList "export", "--installPath", $vs_path, "--config", $config_file, "--quiet" -Wait
+  Write-Output "...done!"
+  Get-Content $config_file | ForEach-Object { Write-Output $_ }
+}
+
+Write-Output "Downloading installer..."
+Invoke-WebRequest -Uri $vs_exe_download_url -OutFile $vs_exe
+Write-Output "...done!"
+
+Write-Output "Updating installer..."
+Start-Process -FilePath $vs_exe -ArgumentList "--installPath", $vs_path, "--wait", "--quiet", "--norestart", "--update" -Wait
+Write-Output "...done!"
+
+# Print configuration pre-update (useful for debugging but sometimes hangs)
+#Show-Configuration
+
+Write-Output "Adding components..."
+[System.Collections.ArrayList]$component_args = "--installPath", $vs_path, "--wait", "--quiet", "--norestart"
+foreach ($component in $components) {
+  Write-Output $component
+  $component_args.Add("--add") | Out-Null
+  $component_args.Add($component) | Out-Null
+}
+Start-Process -FilePath $vs_exe -ArgumentList $component_args -Wait
+Write-Output "...done!"
+
+# Print configuration post-update (useful for debugging but sometimes hangs)
+#Show-Configuration


### PR DESCRIPTION
The default installation of Visual Studio 2017 does not contain all the optional components necessary to build ClientTelemetry on ARM64. This was a [known issue](https://github.com/microsoft/azure-pipelines-image-generation/issues/931), but even the most [recent fix](https://github.com/microsoft/azure-pipelines-image-generation/pull/1080) doesn't completely address it.

MIP's [ClientTelemetry pipeline](https://msazure.visualstudio.com/One/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=87012) currently runs this script as an inline build step, but this may be useful to check in so any other team could also take advantage of it as well.