### PR TITLE
Remove deleted LogManager from clients table

### DIFF
--- a/lib/api/capi.cpp
+++ b/lib/api/capi.cpp
@@ -41,6 +41,15 @@ capi_client * MAT::capi_get_client(evt_handle_t handle)
     return (it != clients.cend()) ? &(it->second) : nullptr;
 }
 
+/// <summary>
+/// Remove C API handle from active client tracking struct.
+/// </summary>
+void remove_client(evt_handle_t handle)
+{
+    LOCKGUARD(mtx);
+    clients.erase(handle);
+}
+
 #define VERIFY_CLIENT_HANDLE(client, ctx)                       \
     if (ctx==nullptr)                                           \
     {                                                           \
@@ -189,7 +198,7 @@ evt_status_t mat_close(evt_context_t *ctx)
 {
     VERIFY_CLIENT_HANDLE(client, ctx);
     const auto result = static_cast<evt_status_t>(LogManagerProvider::Release(client->logmanager->GetLogConfiguration()));
-    clients.erase(ctx->handle);
+    remove_client(ctx->handle);
     ctx->result = result;
     return result;
 }

--- a/tests/functests/APITest.cpp
+++ b/tests/functests/APITest.cpp
@@ -668,6 +668,7 @@ TEST(APITest, C_API_Test)
     };
 
     evt_handle_t handle = evt_open(config);
+    ASSERT_NE(handle, 0);
 
     capi_client *client = capi_get_client(handle);
     ASSERT_NE(client, nullptr);
@@ -692,6 +693,18 @@ TEST(APITest, C_API_Test)
     // Must remove event listener befor closing the handle!
     client->logmanager->RemoveEventListener(EVT_LOG_EVENT, debugListener);
     evt_close(handle);
+    ASSERT_EQ(capi_get_client(handle), nullptr);
+
+    // Re-open with the same configuration
+    handle = evt_open(config);
+    ASSERT_NE(handle, 0);
+    client = capi_get_client(handle);
+    ASSERT_NE(client, nullptr);
+    ASSERT_NE(client->logmanager, nullptr);
+
+    // Re-close
+    evt_close(handle);
+    ASSERT_EQ(capi_get_client(handle), nullptr);
 }
 
 #ifdef HAVE_MAT_JSONHPP


### PR DESCRIPTION
If a logger with the same configuration is opened, closed, then re-opened, it will fail because the clients table that tracks open LogManagers isn't updated when a client is removed.

This affects a MIP scenario where we wish to freely load and unload LogManagers at will.