### PR TITLE
Better "build type" parameterization for MacOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,12 @@ if [ "$1" == "noroot" ] || [ "$2" == "noroot" ]; then
 export NOROOT=true
 fi
 
+if [ "$1" == "release" ] || [ "$2" == "release" ]; then
+BUILD_TYPE="Release"
+else
+BUILD_TYPE="Debug"
+fi
+
 # Install build tools and recent sqlite3
 FILE=.buildtools
 OS_NAME=`uname -a`
@@ -64,13 +70,10 @@ fi
 # Fail on error
 set -e
 
-if [ "$2" == "release" ]; then
+
 # TODO: pass custom build flags?
-  cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
-# TODO: strip symbols to minimize
-else
-  cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
-fi
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
+# TODO: strip symbols to minimize (release-only)
 
 # Build all
 # TODO: what are the pros and cons of using 'make' vs 'cmake --build' ?


### PR DESCRIPTION
MIP uses an [Azure Pipeline](https://msazure.visualstudio.com/One/_build?definitionId=87012) to generate official builds, so 1DS build scripts need to be parameterizable. The existing `build.sh` can only customize the build type as the second parameter, but it's unclear what the first parameter would be in that case. I have updated the script to follow the same pattern as the "noroot" parameter.

I have verified that the above-mentioned pipeline successfully builds 1DS and uploads the .tar.gz package as an artifact.