### PR TITLE
Fix package folder name version

### DIFF
--- a/tools/sdk-create.cmd
+++ b/tools/sdk-create.cmd
@@ -8,7 +8,7 @@ set PATH=%CD%;%PATH%
 cd ..
 
 set ROOT=%CD%
-set /p PackageVersion=<%ROOT%\Solutions\version.txt
+set /p PackageVersion=<%ROOT%\Solutions\out\version.txt
 set SRCDIR=%ROOT%\Solutions\out
 set OUTDIR=%ROOT%\dist\aria-windows-sdk\%PackageVersion%
 set ProjectName=Microsoft.Applications.Telemetry.Windows

--- a/tools/version.js
+++ b/tools/version.js
@@ -67,4 +67,18 @@ function generateVersionHpp() {
   console.log("Version.hpp "+ver1+" generated (clean build)\n");
 }
 
+function generateVersionTxt() {
+  // Read base version and replace '999' with nightly build number
+  var version = readAll("..\\Solutions\\version.txt").replace("999", dayNumber());
+
+  // Write version.txt with updated build number
+  var versionTxt = "..\\Solutions\\out\\version.txt";
+  var f = fso.OpenTextFile(versionTxt, 8, true);
+  f.WriteLine(version);
+  f.Close();
+
+  console.log("version.txt " + version + " generated\n");
+}
+
 generateVersionHpp();
+generateVersionTxt();


### PR DESCRIPTION
Prior to this change, `gen-version.cmd` and `sdk-create.cmd` would always produce a package with the following folder structure:
```
%ROOT%\dist\aria-windows-sdk\3.2.999.1\lib\win32-dll-vs2015\x64\Debug
```

With this change, the version number is now correct:
```
%ROOT%\dist\aria-windows-sdk\3.2.217.1\lib\win32-dll-vs2015\x64\Debug
```

It does this by creating a modified `version.txt` file in the `out` folder and reading the package version from that rather than from the base version file.