### PR TITLE
Flexible Windows build script

### DIFF
--- a/build-win.ps1
+++ b/build-win.ps1
@@ -1,0 +1,110 @@
+param (
+  [string[]]$configs = @("Debug", "Release"),
+  [string[]]$archs = @("x64", "Win32", "ARM", "ARM64"),
+  [string[]]$binTypes = @("dll", "lib"),
+  [string[]]$enableWin10 = "true",
+  [string]$enableTests = "true",
+  [string]$customProps = ""
+)
+
+$vsDevCmdBat = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+
+$solution = "Solutions\MSTelemetrySDK.sln"
+$cpuCount = $env:NUMBER_OF_PROCESSORS
+
+$actualCustomProps = ""
+if ($customProps -ne "") {
+  $actualCustomProps = "/p:ForceImportBeforeCppTargets=$customProps"
+}
+
+$coreTargets = @("zlib")
+$testTargets = @("Tests\gmock", "Tests\gtest", "Tests\UnitTests", "Tests\FuncTests")
+$win10DllTargets = @("sqlite-uwp", "win10-cs", "win10-dll")
+$win32DllTargets = @("sqlite", "win32-dll")
+$win32LibTargets = @("sqlite", "win32-lib")
+
+# Update version headers
+& "tools\gen-version.cmd"
+
+# Import variables from developer command prompt
+if (-not $env:DevEnvDir) {
+  echo "Running VsDevCmd.bat..."
+  & cmd /s /c """$vsDevCmdBat"" -no_logo && set" | foreach-object {
+    $name, $value = $_ -split '=', 2
+    set-content env:\"$name" $value
+  }
+  echo "...Done!"
+}
+
+foreach ($arch in $archs) {
+  # Normalize architecture
+  $actualArch = $arch
+  if ($arch -eq "amd64") {
+    $actualArch = "x64"
+  } elseif ($arch -ceq "win32") {
+    $actualArch = "Win32"
+  } elseif ($arch -ceq "arm") {
+    $actualArch = "ARM"
+  } elseif ($arch -ceq "arm64") {
+    $actualArch = "ARM64"
+  }
+
+  foreach ($binType in $binTypes) {
+    foreach ($config in $configs) {
+      $actualConfig = $config
+      if ($binType -eq "lib") {
+        $actualConfig += ".vs2015.MT-sqlite"
+      }
+
+      echo "Building $actualArch|$actualConfig|$binType..."
+      
+      $targets = $coreTargets
+
+      # Bail out if dependencies aren't met:
+      # 1) ARM requires win10
+      # 2) Static libs are only supported on x64/x86
+      if ($actualArch -eq "ARM" -and $enableWin10 -ne "true") {
+        echo "   ARM requires ""-enableWin10 true"""
+        echo "...Skipped!"
+        echo ""
+        continue
+      }
+      if ($binType -eq "lib" -and ($actualArch -eq "ARM" -or $actualArch -eq "ARM64")) {
+        if ($binType -eq "lib") {
+          echo "   static .libs are not supported for $actualArch architecture"
+          echo "...Skipped!"
+          echo ""
+          continue
+        }
+      }
+
+      # Ignore irrelevant parameters
+      # 1) Tests are only supported on x64/x86
+      if ($enableTests -eq "true") {
+        if ($actualArch -eq "x64" -or $actualArch -eq "Win32") {
+          $targets += $testTargets
+        } else {
+          echo "   NOTE: Automation tests are not supported for $actualArch architecture"
+        }
+      }
+
+      if ($binType -eq "lib") {
+        $targets += $win32LibTargets
+      } elseif ($binType -eq "dll") {
+        if ($actualArch -eq "x64" -or $actualArch -eq "Win32" -or $actualArch -eq "ARM64") {
+          $targets += $win32DllTargets
+        }
+        if ($enableWin10 -eq "true") {
+          $targets += $win10DllTargets
+        }
+      }
+
+      $targetStr = $targets -join ","
+      echo "   Targets: $targetStr"
+      echo "   Configuration: $actualConfig"
+      & cmd /c "msbuild $solution /target:$targetStr /p:BuildProjectReferences=true /maxcpucount:$cpuCount /p:Configuration=$actualConfig /p:Platform=$actualArch $actualCustomProps"
+      echo "...Done!"
+      echo ""
+    }
+  }
+}


### PR DESCRIPTION
The existing Windows build scripts (`build-all.bat`, `build-Win32Debug.bat`, `build-Win32Release.bat`, `build-x64Debug.bat`, and `build-x64Release.bat`) are not flexible enough to be suitable to be called from an Azure Pipeline.

Currently, the [MIP Azure Pipeline](https://msazure.visualstudio.com/One/_build?definitionId=87012) uses a custom inline script and pipeline variables to build each flavor. For example:
```
@setlocal ENABLEEXTENSIONS
call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"

msbuild $(SolutionFile) /target:$(DllLib.MD.Targets) /p:BuildProjectReferences=true /maxcpucount:%NUMBER_OF_PROCESSORS% /detailedsummary /p:Configuration=$(BuildConfiguration) /p:Platform=$(NonArmBuildPlatform)
```

However, that is clunky, and others could benefit from a robust script to build from the command line. For example, to build debug|x64 non-UAP binaries and tests, you would call:
```
.\build-win.ps1 -configs Debug -archs x64 -binTypes dll -enableWin10 false -enableTests true
```

The script will automatically determine the targets based on the parameters, including error checking, and kick off `msbuild.exe`.