### PR TITLE
Fix default configuration for PAL initialization

### DIFF
--- a/lib/api/IRuntimeConfig.hpp
+++ b/lib/api/IRuntimeConfig.hpp
@@ -19,6 +19,7 @@ namespace ARIASDK_NS_BEGIN
     public:
 
         virtual Variant & operator[](const char* key) = 0;
+        virtual bool HasConfig(const char* key) = 0;
 
         /// <summary>
         /// Gets the URI of the collector (where telemetry events are sent).

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -92,10 +92,12 @@ namespace ARIASDK_NS_BEGIN
         m_offlineStorage(nullptr),
         m_logConfiguration(configuration)
     {
+        m_config = std::unique_ptr<IRuntimeConfig>(new RuntimeConfig_Default(m_logConfiguration));
+
         setLogLevel(configuration);
         LOG_TRACE("New LogManager instance");
 
-        PAL::initialize(configuration);
+        PAL::initialize(*m_config);
         PAL::registerSemanticContext(&m_context);
 
         std::string cacheFilePath = MAT::GetAppLocalTempDirectory();
@@ -146,8 +148,6 @@ namespace ARIASDK_NS_BEGIN
                 SetTransmitProfile(transmitProfile);
             }
         }
-
-        m_config = std::unique_ptr<IRuntimeConfig>(new RuntimeConfig_Default(m_logConfiguration));
 
         // TODO: [MG] - LogSessionData must utilize sqlite3 DB interface instead of filesystem
         m_logSessionData.reset(new LogSessionData(cacheFilePath));

--- a/lib/config/RuntimeConfig_Default.hpp
+++ b/lib/config/RuntimeConfig_Default.hpp
@@ -197,6 +197,11 @@ namespace ARIASDK_NS_BEGIN {
             return config[key]; // FIXME: [MG] - Error #116: LEAK 32 bytes
         }
 
+        virtual bool HasConfig(const char* key) override
+        {
+            return config.count(key) != 0;
+        }
+
     };
 
 } ARIASDK_NS_END

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -484,11 +484,11 @@ namespace PAL_NS_BEGIN {
 
     static volatile std::atomic<long> g_palStarted(0);
 
-    void initialize(ILogConfiguration& configuration)
+    void initialize(IRuntimeConfig& configuration)
     {
         if (g_palStarted.fetch_add(1) == 0)
         {
-            std::string traceFolderPath = configuration.count(CFG_STR_TRACE_FOLDER_PATH) ? configuration[CFG_STR_TRACE_FOLDER_PATH] : MAT::GetTempDirectory();
+            std::string traceFolderPath = configuration.HasConfig(CFG_STR_TRACE_FOLDER_PATH) ? configuration[CFG_STR_TRACE_FOLDER_PATH] : MAT::GetTempDirectory();
             detail::isLoggingInited = detail::log_init(configuration[CFG_BOOL_ENABLE_TRACE], traceFolderPath);
             LOG_TRACE("Initializing...");
             g_workerThread = WorkerThreadFactory::Create();

--- a/lib/pal/PAL.hpp
+++ b/lib/pal/PAL.hpp
@@ -52,7 +52,7 @@
 #include <chrono>
 #include <thread>
 
-#include "ILogConfiguration.hpp"
+#include "api/IRuntimeConfig.hpp"
 #include "typename.hpp"
 #include "WorkerThread.hpp"
 
@@ -119,7 +119,7 @@ namespace PAL_NS_BEGIN
     //
     // Startup/shutdown
     //
-    void initialize(ILogConfiguration& configuration);
+    void initialize(IRuntimeConfig& configuration);
     void shutdown();
 
     INetworkInformation* GetNetworkInformation();


### PR DESCRIPTION
My [recent change](https://github.com/microsoft/cpp_client_telemetry/pull/50) to add configuration support for network and trace options introduced a bug where applications that don't explicitly set these new config options will not get the default values, resulting in network detector and trace logging disabled.

This was caused by the fact that default values as defined in `defaultRuntimeConfig` in RuntimeConfig_Default.hpp aren't applied to the `ILogConfiguration` directly. Rather, an `IRuntimeConfig` is a merging of the default values with the `ILogConfiguration` values provided by an application. Therefore, we must read values from the `IRuntimeConfig` instead of `ILogConfiguration` if we want to pick up default values.