### PR TITLE
Build ClientTelemetry with MIP-specific settings

### DIFF
--- a/Solutions/build.MIP.props
+++ b/Solutions/build.MIP.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);CONFIG_CUSTOM_H="config-MIP.h"</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <PropertyGroup Condition="'$(RootNamespace)'=='ClientTelemetry'">
+    <TargetName>mip_ClientTelemetry</TargetName>
+  </PropertyGroup>
+</Project>

--- a/lib/include/mat/config-MIP.h
+++ b/lib/include/mat/config-MIP.h
@@ -1,0 +1,16 @@
+#define EVTSDK_VERSION_PREFIX "EVT"
+#if defined(_WIN32)
+#define HAVE_MAT_UTC
+#endif
+#if defined(HAVE_PRIVATE_MODULES)
+/* #define HAVE_MAT_EXP */
+#define HAVE_MAT_FIFOSTORAGE
+#endif
+#define HAVE_MAT_JSONHPP
+#define HAVE_MAT_ZLIB
+#define HAVE_MAT_LOGGING
+#define HAVE_MAT_STORAGE
+/* #define HAVE_MAT_DEFAULT_HTTP_CLIENT */
+#if defined(_WIN32) && !defined(_WINRT_DLL)
+#define HAVE_MAT_NETDETECT
+#endif


### PR DESCRIPTION
The 1DS-supported way for creating customized builds is to:
1. Add a .props file to override default .vcxproj settings
2. Add a config .h file to specify which optional components shouldn't be compiled
3. Run msbuild.exe with `/p:ForceImportBeforeCppTargets=your_props_file.props` flag

I'm assuming that it is correct and proper for MIP to check in its own custom build configuration files, but please let me know if that is not the case. (I don't know how to accomplish the same thing without checking in files.)

**Custom settings:**
 - Don't build EXP component
 - Don't build default WinInet HttpClient
 - Rename ClientTelemetry.dll to mip_ClientTelemetry.dll