### PR TITLE
Fix unittest and clang/gcc build break

### DIFF
--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -488,7 +488,12 @@ namespace PAL_NS_BEGIN {
     {
         if (g_palStarted.fetch_add(1) == 0)
         {
-            std::string traceFolderPath = configuration.HasConfig(CFG_STR_TRACE_FOLDER_PATH) ? configuration[CFG_STR_TRACE_FOLDER_PATH] : MAT::GetTempDirectory();
+            std::string traceFolderPath = MAT::GetTempDirectory();
+            if (configuration.HasConfig(CFG_STR_TRACE_FOLDER_PATH))
+            {
+                traceFolderPath = static_cast<std::string&>(configuration[CFG_STR_TRACE_FOLDER_PATH]);
+            }
+
             detail::isLoggingInited = detail::log_init(configuration[CFG_BOOL_ENABLE_TRACE], traceFolderPath);
             LOG_TRACE("Initializing...");
             g_workerThread = WorkerThreadFactory::Create();

--- a/tests/unittests/Main.cpp
+++ b/tests/unittests/Main.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 #include "common/Common.hpp"
+#include "config/RuntimeConfig_Default.hpp"
 #include "utils/Utils.hpp"
 
 #if defined(_DEBUG) && defined(_WIN32) && !defined(_INC_WINDOWS)
@@ -31,8 +32,9 @@ int MAIN_CDECL main(int argc, char** argv)
     ::testing::InitGoogleMock(&argc, argv);
     ::testing::UnitTest::GetInstance()->listeners().Append(new TestStatusLogger());
 
-    ILogConfiguration configuration;
-    PAL::initialize(configuration);
+    ILogConfiguration logConfig;
+    RuntimeConfig_Default runtimeConfig(logConfig);
+    PAL::initialize(runtimeConfig);
     int result = RUN_ALL_TESTS();
     PAL::shutdown();
 


### PR DESCRIPTION
- Recent change #55 broke unittest project build
- Same change also broke clang build (ambiguous call)

I (almost?) always run a [full CI build](https://msazure.visualstudio.com/One/_build?definitionId=87012&_a=summary) prior to checkin but must have missed it for that change. We should get a similar CI configured for PR validation to avoid this in the future.