### PR TITLE
Build and documentation fixes

### DIFF
--- a/docs/Privacy-Settings.md
+++ b/docs/Privacy-Settings.md
@@ -1,9 +1,4 @@
----
-layout: page
-title: Privacy Settings on 1DS C++ SDK
-sub_title:
 
----
 # **1. Using privacy tags on UTC mode **
 
 In order to set privacy tags to an event on UTC mode, the C++ SDK exposes the functionality on it's API.
@@ -58,7 +53,7 @@ PDT_SoftwareSetupAndInventory           0x0000000080000000u
 
 The tag set on your event will show it the field ext.metadata.privTags. You can validate that using Telemetry Real Time Tool **[TRTT](https://osgwiki.com/wiki/Telemetry_Real-Time_Tool_(TRTT)**
 
-![UTC Privacy Tags example](/images/14154-utc.png)
+![UTC Privacy Tags example](/docs/images/14154-utc.png)
 
 
 # **2. Diagnostic level filtering**

--- a/docs/building-custom-SKU.md
+++ b/docs/building-custom-SKU.md
@@ -1,9 +1,4 @@
----
-layout: page
-title: Building your custom SKU
-sub_title:
 
----
 # Custom build
 
 SDK customers may build their own custom SKU tuned to their liking, tailoring SDK for a specific need. Sometimes it is important to optimize the SDK for size, turning non-essential features off. Some customers would like to build SDK with UTC channel only and exclude the rest of unwanted features, such as Offlien Storage. While other customers would like to build SKU without UTC channel. We give our SDK customers the choice of building custom SKU based on their own build recipe, with just the subset of features our specific customer needs.

--- a/docs/cpp-start-linux.md
+++ b/docs/cpp-start-linux.md
@@ -1,9 +1,4 @@
----
-layout: page
-title: Getting started with the 1DS SDK (Beta) for Linux (C++)
-sub_title:
 
----
 This tutorial guides you through the process of integrating the 1DS SDK (Beta) into your existing C++ Linux app or service.
 
 ## 1. Linux Prerequisites for building from source
@@ -16,6 +11,16 @@ This tutorial guides you through the process of integrating the 1DS SDK (Beta) i
 {% include_relative linux-setup-build.md %}
 
 {% include contents/tutorial-create-api-key.md %}
+
+## 2. Clone the repository
+
+1. Run `git clone https://github.com/microsoft/cpp_client_telemetry.git` to clone the repo.
+
+	If your project requires UTC to send telemetry, you need to add `--recurse-submodules` when cloning to tell git to add `lib/modules` repo.
+
+2. You will be asked your credentials to clone the repo, use your username and password as entered on Github
+	
+    If you do not have those credentials, generate them and use the username and password that you enabled.
 
 ## 3. Get the 1DS SDK (Beta) for C++
 

--- a/docs/cpp-start-macosx.md
+++ b/docs/cpp-start-macosx.md
@@ -1,9 +1,4 @@
----
-layout: page
-title: Getting started with the 1DS SDK (Beta) for Mac OS X (C++)
-sub_title:
 
----
 This tutorial guides you through the process of integrating the 1DS SDK (Beta) into your existing C++ Mac OS X app or service.
 
 ## **Mac OS X prerequisites and dependencies for building from source**
@@ -25,9 +20,11 @@ _**Note:** Preferably use Homebrew to install missing packages._
 
 ## **Clone the repository**
 
-1. Run `git clone https://msasg.visualstudio.com/DefaultCollection/Shared%20Data/_git/Aria.SDK.Cpp` to clone the repo.
+1. Run `git clone https://github.com/microsoft/cpp_client_telemetry.git` to clone the repo.
 
-2. You will be asked your credentials to clone the repo, use your username and password as entered on https://msasg.visualstudio.com/DefaultCollection/_usersSettings/altcreds 
+	If your project requires UTC to send telemetry, you need to add `--recurse-submodules` when cloning to tell git to add `lib/modules` repo.
+
+2. You will be asked your credentials to clone the repo, use your username and password as entered on Github
 	
     If you do not have those credentials, generate them and use the username and password that you enabled.
     
@@ -53,7 +50,7 @@ _**Note:** Preferably use Homebrew to install missing packages._
 
 	_**Note:** In order to build from scratch all dependencies along with the SDK you need to run:_ ` ./build.sh clean`
     
-3. The SDK will be installed under `usr/local/libaria.a`
+3. The SDK will be installed under `usr/local/libmat.a`
 
 ## **Instrument your code to send a telemetry event**
 

--- a/docs/cpp-start-windows.md
+++ b/docs/cpp-start-windows.md
@@ -1,16 +1,13 @@
----
-layout: page
-title: Getting started with the 1DS SDK (Beta) for Windows (C++)
-sub_title:
 
----
 This tutorial guides you through the process of integrating the 1DS SDK (Beta) into your existing C++ Windows app or service.
 
 ## **Clone the repository**
 
-1. Run `git clone https://msasg.visualstudio.com/DefaultCollection/Shared%20Data/_git/Aria.SDK.Cpp` to clone the repo.
+1. Run `git clone https://github.com/microsoft/cpp_client_telemetry.git` to clone the repo.
 
-2. You will be asked your credentials to clone the repo, use your username and password as entered on https://msasg.visualstudio.com/DefaultCollection/_usersSettings/altcreds 
+	If your project requires UTC to send telemetry, you need to add `--recurse-submodules` when cloning to tell git to add `lib/modules` repo.
+
+2. You will be asked your credentials to clone the repo, use your username and password as entered on Github
 	
     If you do not have those credentials, generate them and use the username and password that you enabled.
     
@@ -21,22 +18,22 @@ This tutorial guides you through the process of integrating the 1DS SDK (Beta) i
     
 ## **Build the SDK from source using Visual Studio 2017**
 
-* Navigate to the folder where the SDK was cloned and open the Aria.SDK.Cpp/Solutions folder
+* Navigate to the folder where the SDK was cloned and open the cpp_client_telemetry/Solutions folder
 
-* Open the AriaSDK.sln file to open the project with Visual Studio 2017.
+* Open the MSTelemetrySDK.sln file to open the project with Visual Studio 2017.
 
-* Expand the Samples folder, the project HelloAria should be located there
+* Expand the Samples folder, the project SampleCpp should be located there
 
-![SampleCpp](/images/SampleCpp.png)
+![SampleCpp](/docs/images/SampleCpp.PNG)
 
-* Go to the HelloAria project properties and make sure that Visual Studio 2017 is set as Platform Toolset
+* Go to the SampleCpp project properties and make sure that Visual Studio 2017 is set as Platform Toolset
 
-![SampleCppProperties](/images/SampleCppProperties.png)
+![SampleCppProperties](/docs/images/SampleCppProperties.PNG)
 
-* When you build the HelloAria sample app Visual studio will also build the SDK, as it is listed as a dependency.
+* When you build the SampleCpp sample app Visual Studio will also build the SDK, as it is listed as a dependency.
     The win32-dll project is the SDK dll, when Visual Studio builds it, it will also build all it's references, including sqlite, zlib and all the headers for the SDK to work.
 	
-![win32-dll](/images/87016-win32lib.png)
+![win32-dll](/docs/images/87016-win32lib.png)
 
 ## **Windows prerequisites and dependencies for building from source using LLVM compiler**
 

--- a/docs/using-fiddler-macosx.md
+++ b/docs/using-fiddler-macosx.md
@@ -1,9 +1,4 @@
----
-layout: page
-title: Using Fiddler inspector on Mac OS X
-sub_title:
 
----
 This tutorial guides you through the process of downloading and configuring Fiddler inspector on Mac OS X in order to see events sent with 1DS C++ Client SDK.
 
 ### **Installation instructions for 1DS Events protocol decoder / inspector for Fiddler**
@@ -39,11 +34,11 @@ For realtime monitoring of events flow, for one particular process (assuming the
 ```
 export ALL_PROXY=127.0.0.1:8888
 ./yourAppName.bin
-``
+```
 
 That would redirect all the HTTPS traffic via Fiddler.
 
 
 Now the events should be decrypted and formated to JSON when clicked on Fiddler:
 
-![Fiddler example Mac](/images/22867-fiddler_example.png)
+![Fiddler example Mac](/docs/images/22867-fiddler_example.png)

--- a/docs/using-fiddler-windows.md
+++ b/docs/using-fiddler-windows.md
@@ -1,9 +1,4 @@
----
-layout: page
-title: Using Fiddler inspector on Windows
-sub_title:
 
----
 This tutorial guides you through the process of downloading and configuring Fiddler inspector on Windows in order to see events sent with 1DS C++ Client SDK.
 
 ### **Installation instructions for 1DS Events protocol decoder / inspector for Fiddler**
@@ -29,4 +24,4 @@ That would redirect all the HTTPS traffic via Fiddler
 Now the events should be decrypted and formated to JSON when clicked on Fiddler.
 
 
-![Fiddler example Windows](/images/fiddlerWindows.png)
+![Fiddler example Windows](/docs/images/fiddlerWindows.png)

--- a/lib/http/HttpClient_CAPI.cpp
+++ b/lib/http/HttpClient_CAPI.cpp
@@ -109,7 +109,7 @@ namespace ARIASDK_NS_BEGIN {
                     response->m_body = std::vector<uint8_t>(capiResponse->body, capiResponse->body + capiResponse->bodySize);
                 }
 
-                for (size_t i = 0; i < (size_t)(capiResponse->headersCount); ++i)
+                for (size_t i = 0; i < static_cast<size_t>(capiResponse->headersCount); ++i)
                 {
                     const http_header_t* capiHeader = &capiResponse->headers[i];
                     response->m_headers.emplace(capiHeader->name, capiHeader->value);


### PR DESCRIPTION
HttpClient_CAPI.cpp requires cast, this broke the build on Windows

Update documentation to use MSTelemetrySDK and libmat.a names, fix file paths to show images