### PR TITLE
Solve architecture info on Windows

### DIFF
--- a/Solutions/build.MSIPC.props
+++ b/Solutions/build.MSIPC.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(RootNamespace)'=='ClientTelemetry'">
+    <TargetName>MsipcTelemetry</TargetName>
+  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)build.spectr.props" />
+</Project>


### PR DESCRIPTION
Fixing x86 version of OneDS has wrong architecture information in ext_os_ver when running in 64-bit version of Windows.
Using **RRF_RT_REG_SZ | RRF_SUBKEY_WOW6464KEY** for dwFlags appears to solve this issue.