### PR TITLE
Make TaskDispatcher tests less rigid on timing

### DIFF
--- a/examples/cpp/SampleCpp/main.cpp
+++ b/examples/cpp/SampleCpp/main.cpp
@@ -157,7 +157,7 @@ ILogConfiguration testConfiguration()
     return result;
 }
 
-#define MAX_EVENTS_TO_LOG       100000L 
+#define MAX_EVENTS_TO_LOG       100L 
 
 extern "C" int OfficeTest();
 extern "C" void test_c_api();
@@ -303,10 +303,11 @@ int main()
     for (auto evt : eventsList)
         LogManager::AddEventListener(evt, listener);
 
+    ILogger *logger = LogManager::Initialize(TOKEN);
+
 #ifdef _WIN32
     printf("LogManager::Initialize in UTC\n");
     config[CFG_INT_SDK_MODE] = SdkModeTypes::SdkModeTypes_UTCCommonSchema;
-    ILogger *logger = LogManager::Initialize(TOKEN);
     logPiiMark();   // UTC upload
     LogManager::FlushAndTeardown();
 #endif
@@ -314,12 +315,12 @@ int main()
     printf("LogManager::Initialize in direct\n");
     config[CFG_INT_SDK_MODE] = SdkModeTypes::SdkModeTypes_CS;
     logger = LogManager::Initialize(TOKEN);
-    
+
     logPiiMark();   // Direct upload
 
     // This global context variable will not be seen by C API client
     LogManager::SetContext("GlobalContext.Var", 12345);
-     
+
     printf("LogManager::GetSemanticContext \n"); 
     ISemanticContext* semanticContext = LogManager::GetSemanticContext();
 

--- a/lib/offline/SQLiteWrapper.hpp
+++ b/lib/offline/SQLiteWrapper.hpp
@@ -357,7 +357,7 @@ namespace ARIASDK_NS_BEGIN {
             }
             return 0;
         }
-        
+
         /// <summary>
         /// Check if return code is OK
         /// </summary>
@@ -380,12 +380,12 @@ namespace ARIASDK_NS_BEGIN {
 
         int sqlite3_exec(const char *sql, int(*callback)(void*, int, char**, char**) = sqlite3_noop_callback, void *arg = nullptr) {
             static size_t failureCount = 0;
-            char *errmsg;
+            char *errmsg = nullptr;
             int result = 0;
             LOG_DEBUG("%s", sql);
             // TODO: [MG] - expose sqlite3_exec via g_sqlite3Proxy
             result = ::sqlite3_exec(m_db, sql, callback, arg, &errmsg);
-            if (!isOK(result))
+            if (!isOK(result, errmsg))
             {
                 LOG_DEBUG("Failed to execute query: %s [rc=%d]", sql, result);
             }


### PR DESCRIPTION
I saw a failure once in `TaskDispatcherCAPITests` where the test expected a very specific delay value. However, this can sometimes vary +/- 1 ms since the value is generated based on `getMonotonicTimeMs()`. The interesting thing to test is whether or not the delay has been set--not what its _exact_ value is.