### PR TITLE
Temporarily disable Debug CI

### DIFF
--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         arch: [Win32, x64]
-        config: [Release, Debug]
+        config: [Release]
         os: [windows-2016]
     
     steps:


### PR DESCRIPTION
There is an ongoing issue with x64-Debug "Bad Network" test failure on GitHub Actions infra. 
The issue is being tracked here - #92 
Temporarily remove Debug test runs from CI to avoid blocking PRs.
Can't push this directly unfortunately, it requires a review :)