### PR TITLE
Fix header issue and main threading concerns in Win32 NetworkDetector

### DIFF
--- a/lib/pal/desktop/NetworkDetector.hpp
+++ b/lib/pal/desktop/NetworkDetector.hpp
@@ -26,9 +26,15 @@
 #include <windows.networking.h>
 #include <windows.networking.connectivity.h>
 
+// ATL exceptions expose header incompatibilities with Edge's build, using libc++
+#ifndef _ATL_NO_EXCEPTIONS
+#define _ATL_NO_EXCEPTIONS
+#endif
+
+#include <atlbase.h>
+
 #include <Netlistmgr.h>
 #include <OCIdl.h>
-#include <atlbase.h>
 #include <oaidl.h>
 
 #include <cstdio>


### PR DESCRIPTION
Added mutex around m_listener_tid and isRunning. Removed seemingly useless mutex from _GetCurrentNetworkCost; if a mutex is needed there, it should be a recursive mutex. Also disabled ATL exceptions, which don't seem to be used, since they cause issues with Edge's build.

These changes have been running in Edge for several weeks, and we haven't any NetworkDetector bugs promoted. Should resolve #24 