### PR TITLE
Sample app that shows how to obtain Mac OS X proxy settings and pass to libcurl

### DIFF
--- a/examples/cpp/MacProxy/.gitignore
+++ b/examples/cpp/MacProxy/.gitignore
@@ -1,0 +1,8 @@
+include
+lib
+offlinestorage*
+Release
+x64
+/build/
+/.externalToolBuilders/
+/out/

--- a/examples/cpp/MacProxy/CMakeLists.txt
+++ b/examples/cpp/MacProxy/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.1.0)
+project(MacProxy)
+
+# Uncomment for building i386 binary on x86_64 system
+#set(CMAKE_SYSTEM_PROCESSOR i386)
+
+# For ARM / Raspberry Pi 3 cross-compile
+# set(MAT_SDK_LIB       /usr/local/lib/armv7l-linux-gnu)
+
+# Point example to SDK dirs for x86_64 Desktop
+if(EXISTS "/usr/local/lib/libmat.a")
+# Use local libmat.a
+set(MAT_SDK_LIB	/usr/local/lib/)
+else()
+# Use architecture-specific libmat.a
+set(MAT_SDK_LIB	/usr/local/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+endif()
+
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -O0 -ggdb -gdwarf-2 -std=c11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -ggdb -gdwarf-2 -std=c++11")
+
+find_package (Threads)
+
+set(MAT_SDK_INCLUDE	/usr/local/include/mat)
+
+# Aria SDK to include dirs
+include_directories( . ${MAT_SDK_INCLUDE} )
+
+# Link main.cpp to executable
+add_executable(MacProxy main.cpp DebugCallback.cpp)
+source_group(" " REGULAR_EXPRESSION "")
+
+# Prefer linking to more recent local sqlite3
+if(EXISTS "/usr/local/lib/libsqlite3.a")
+set (SQLITE3_LIB "/usr/local/lib/libsqlite3.a")
+else()
+set (SQLITE3_LIB "sqlite3")
+endif()
+
+set (PLATFORM_LIBS "")
+# Add flags for obtaining system UUID via IOKit
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set (PLATFORM_LIBS "-framework CoreFoundation -framework IOKit -framework CFNetwork")
+endif()
+
+# Raspberry Pi 4 with gcc-8 on ARMv7l requires -latomic
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7l")
+  set (PLATFORM_LIBS "atomic")
+endif()
+
+target_link_libraries(MacProxy ${MAT_SDK_LIB}/libmat.a curl z ${CMAKE_THREAD_LIBS_INIT} ${SQLITE3_LIB} ${PLATFORM_LIBS} dl)

--- a/examples/cpp/MacProxy/DebugCallback.cpp
+++ b/examples/cpp/MacProxy/DebugCallback.cpp
@@ -1,0 +1,204 @@
+#include "DebugCallback.hpp"
+#include "IHttpClient.hpp"
+
+//Use this option below to enforce SSL certificate validation:
+// #define HAVE_SSL_VERIFY
+
+#if !defined(_WIN32) && !defined(NO_LIBCURL)
+/* At the moment we allow to build part of this test debug callback with
+ * libcurl only on POSIX platforms, e.g. Linux, Mac, etc. Code below shows
+ * how to enforce SSL verification with curl
+ */
+#include <unistd.h>
+#if defined(__has_include) && __has_include(<curl/curl.h>)
+# include <curl/curl.h>
+#define HAVE_LIBCURL
+#endif
+#endif
+
+unsigned   latency[MAX_LATENCY_SAMPLES] = { 0 };
+
+std::atomic<size_t>   eps(0);
+std::atomic<size_t>   numLogged0(0);
+std::atomic<size_t>   numLogged(0);
+std::atomic<size_t>   numSent(0);
+std::atomic<size_t>   numDropped(0);
+std::atomic<size_t>   numReject(0);
+std::atomic<size_t>   numCached(0);
+std::atomic<size_t>   logLatMin(100);
+std::atomic<size_t>   logLatMax(0);
+unsigned long         testStartMs;
+
+/// <summary>
+/// The network cost names
+/// </summary>
+const char* networkCostNames[] = {
+    "Unknown",
+    "Unmetered",
+    "Metered",
+    "Roaming",
+};
+
+/// <summary>
+/// Resets this instance.
+/// </summary>
+void MyDebugEventListener::reset()
+{
+    testStartMs = (unsigned long) (std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1));
+    eps = 0;
+    numLogged0 = 0;
+    numLogged = 0;
+    numSent = 0;
+    numDropped = 0;
+    numReject = 0;
+    numCached = 0;
+    logLatMin = 100;
+    logLatMax = 0;
+}
+
+void MyDebugEventListener::OnHttpStateEvent(DebugEvent& evt)
+{
+    HttpStateEvent state = HttpStateEvent(evt.param1);
+    static std::map<HttpStateEvent, std::string> labels =
+    {
+        { OnCreated,       "OnCreated"       },
+        { OnCreateFailed,  "OnCreateFailed"  },
+        { OnConnecting,    "OnConnecting"    },
+        { OnConnectFailed, "OnConnectFailed" },
+        { OnConnected,     "OnConnected"     },
+        { OnSendFailed,    "OnSendFailed"    },
+        { OnSending,       "OnSending"       },
+        { OnResponse,      "OnResponse"      },
+        { OnDestroy,       "OnDestroy"       }
+    };
+    auto it = labels.find(state);
+    printf("HTTP state=%20s, handle=0x%p\n", (it!= labels.end()) ? it->second.c_str() : "unknown", evt.data);
+#if defined(HAVE_LIBCURL) && defined(HAVE_SSL_VERIFY)
+    /* Enforce SSL verification if built with libcurl */
+    CURL* handle = static_cast<CURL*>(evt.data);
+    if (handle!=nullptr)
+    {
+        curl_easy_setopt(handle, CURLOPT_PROXY_SSL_VERIFYHOST, true);
+        curl_easy_setopt(handle, CURLOPT_PROXY_SSL_VERIFYPEER, true);
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, true);
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, true);
+        curl_easy_setopt(handle, CURLOPT_SSL_VERIFYSTATUS, true);
+    }
+#endif
+}
+
+/// <summary>
+/// The DebugEventListener constructor.
+/// </summary>
+/// <param name="evt"></param>
+void MyDebugEventListener::OnDebugEvent(DebugEvent& evt)
+{
+    // lock for the duration of the print, so that we don't mess up the prints
+    std::lock_guard<std::mutex> lock(dbg_callback_mtx);
+    unsigned long ms;
+
+    switch (evt.type) {
+    case EVT_LOG_EVENT:
+        // Track LogEvent latency here
+        if (evt.param1 < logLatMin)
+            logLatMin = evt.param1;
+        if (evt.param1 > logLatMax)
+            logLatMax = evt.param1;
+    case EVT_LOG_LIFECYCLE:
+    case EVT_LOG_FAILURE:
+    case EVT_LOG_PAGEVIEW:
+    case EVT_LOG_PAGEACTION:
+    case EVT_LOG_SAMPLEMETR:
+    case EVT_LOG_AGGRMETR:
+    case EVT_LOG_TRACE:
+    case EVT_LOG_USERSTATE:
+    case EVT_LOG_SESSION:
+        // printf("OnEventLogged:      seq=%llu, ts=%llu, type=0x%08x, p1=%u, p2=%u\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        numLogged++;
+        ms = (unsigned long) (std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1));
+        {
+            eps = (1000 * numLogged) / (ms - testStartMs);
+            if ((numLogged % 500) == 0)
+            {
+                printf("EPS=%zu\n", eps.load() );
+            }
+        }
+        break;
+    case EVT_REJECTED:
+        numReject++;
+        if ((numReject % 10) == 0)
+            printf("R10\n");
+        // printf("OnEventRejected:    seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+    case EVT_ADDED:
+        printf("+");
+        // printf("OnEventAdded:       seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+    case EVT_CACHED:
+        numCached += evt.param1;
+        printf("OnEventCached:      seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+    case EVT_DROPPED:
+        numDropped += evt.param1;
+        if ((numDropped % 1000) == 0)
+            printf("D1000\n");
+        // printf("OnEventDropped:     seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+    case EVT_SENT:
+        numSent += evt.param1;
+        printf("OnEventsSent:       seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+    case EVT_STORAGE_FULL:
+        printf("OnStorageFull:      seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        if (evt.param1 >= 75) {
+            // UploadNow must NEVER EVER be called from SDK callback thread, so either use this structure below
+            // or notify the main app that it has to do the profile timers housekeeping / force the upload...
+            std::thread([]() { LogManager::UploadNow(); }).detach();
+        }
+        break;
+
+    case EVT_CONN_FAILURE:
+    case EVT_HTTP_FAILURE:
+    case EVT_COMPRESS_FAILED:
+    case EVT_UNKNOWN_HOST:
+    case EVT_SEND_FAILED:
+        printf("OnEventsSendFailed: seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+
+    case EVT_HTTP_STATE:
+        {
+            OnHttpStateEvent(evt);
+        }
+        break;
+
+    case EVT_HTTP_ERROR:
+        printf("OnHttpError:        seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu, data=%p, size=%zu\n",
+            evt.seq, evt.ts, evt.type, evt.param1, evt.param2, evt.data, evt.size);
+        break;
+    case EVT_HTTP_OK:
+        printf("OnHttpOK:           seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu, data=%p, size=%zu\n",
+            evt.seq, evt.ts, evt.type, evt.param1, evt.param2, evt.data, evt.size);
+        break;
+    case EVT_SEND_RETRY:
+        printf("OnSendRetry:        seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu, data=%p, size=%zu\n",
+            evt.seq, evt.ts, evt.type, evt.param1, evt.param2, evt.data, evt.size);
+        break;
+    case EVT_SEND_RETRY_DROPPED:
+        printf("OnSendRetryDropped: seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu, data=%p, size=%zu\n",
+            evt.seq, evt.ts, evt.type, evt.param1, evt.param2, evt.data, evt.size);
+        break;
+    case EVT_NET_CHANGED:
+        printf("OnNetChanged:       seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu [%s]\n",
+            evt.seq, evt.ts, evt.type, evt.param1, evt.param2, networkCostNames[evt.param1]);
+        if (evt.param2)
+        {
+            printf("Malwarebytes Antiexploit has been detected! Network cost is unknown.\n");
+        }
+        break;
+    case EVT_UNKNOWN:
+    default:
+        printf("OnEventUnknown:     seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", evt.seq, evt.ts, evt.type, evt.param1, evt.param2);
+        break;
+    };
+
+};

--- a/examples/cpp/MacProxy/DebugCallback.hpp
+++ b/examples/cpp/MacProxy/DebugCallback.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "LogManager.hpp"
+#include "IHttpClient.hpp"
+
+#include <mutex>
+#include <atomic>
+#include <cstdint>
+#include <thread>
+
+using namespace MAT;
+
+static const constexpr size_t MAX_LATENCY_SAMPLES = 10;
+
+class MyDebugEventListener : public DebugEventListener {
+    std::mutex dbg_callback_mtx;
+
+public:
+    MyDebugEventListener() : DebugEventListener()
+    {
+        reset();
+    }
+    virtual void OnHttpStateEvent(DebugEvent& evt);
+    virtual void OnDebugEvent(DebugEvent &evt);
+    virtual void reset();
+};

--- a/examples/cpp/MacProxy/build.sh
+++ b/examples/cpp/MacProxy/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+export PATH=/usr/local/bin:$PATH
+mkdir -p out
+cd out
+cmake ..
+make
+# Strip for release
+# strip SampleCpp

--- a/examples/cpp/MacProxy/main.cpp
+++ b/examples/cpp/MacProxy/main.cpp
@@ -1,0 +1,165 @@
+#include <memory>
+#include <chrono>
+#include <thread>
+#include <cstdio>
+#include <cstdlib>
+
+#include <algorithm>
+#include <future>
+#include <cassert>
+#include <string>
+
+// Apple OS-specific headers
+#include <CoreFoundation/CFDictionary.h>
+#include <CoreFoundation/CFURL.h>
+#include <CoreFoundation/CFNumber.h>
+#include <CFNetwork/CFProxySupport.h>
+
+// 1DS SDK header
+#include "LogManager.hpp"
+
+// Custom debug event callback
+#include "DebugCallback.hpp"
+
+LOGMANAGER_INSTANCE
+
+//#define USE_LOCAL_URL /* <- uncomment this to send to local test server */
+#define TOKEN            "99999999999999999999999999999999-99999999-9999-9999-9999-999999999999-9999"
+#define MAX_URL_LENGTH  2048
+
+using namespace MAT;
+
+/**
+ * This function allows to auto-detect the proxy setting for a given target URL
+ */
+std::string GetProxyForURL(std::string targetURL)
+{
+    std::string result = "";
+    CFURLRef urlRef = NULL;
+    CFDictionaryRef proxyDicRef = NULL;
+    CFArrayRef urlProxArrayRef = NULL;
+    CFDictionaryRef defProxyDic = NULL;
+    int port = 0;
+    CFStringRef hostNameRef = NULL;
+    CFNumberRef portNumberRef = NULL;
+    char hostNameBuffer[MAX_URL_LENGTH + 1] = { 0 };
+
+    urlRef = CFURLCreateWithBytes(kCFAllocatorDefault, (const UInt8*) (targetURL.c_str()), targetURL.size(), kCFStringEncodingASCII, NULL);
+    if(!urlRef)
+        goto cleanup;
+
+    proxyDicRef = CFNetworkCopySystemProxySettings();
+    if(!proxyDicRef)
+        goto cleanup;
+
+    urlProxArrayRef = CFNetworkCopyProxiesForURL(urlRef, proxyDicRef);
+    if(!urlProxArrayRef)
+        goto cleanup;
+
+    defProxyDic = (CFDictionaryRef)CFArrayGetValueAtIndex(urlProxArrayRef, 0);
+    if(!defProxyDic)
+        goto cleanup;
+
+    portNumberRef = (CFNumberRef)CFDictionaryGetValue(defProxyDic, (const void*) kCFProxyPortNumberKey);
+    if(!portNumberRef)
+        goto cleanup;
+    if(!CFNumberGetValue(portNumberRef, kCFNumberSInt32Type, &port))
+        goto cleanup;
+
+    hostNameRef = (CFStringRef)CFDictionaryGetValue(defProxyDic, (const void*) kCFProxyHostNameKey);
+    if(!hostNameRef)
+        goto cleanup;
+
+    if(!CFStringGetCString(hostNameRef, hostNameBuffer, sizeof(hostNameBuffer), kCFStringEncodingASCII))
+        goto cleanup;
+
+    result += (const char *) (hostNameBuffer);
+    result += ":";
+    result += std::to_string(port);
+
+cleanup:
+
+    if(hostNameRef)
+    {
+        CFRelease(hostNameRef);
+        hostNameRef = NULL;
+    }
+    if(urlProxArrayRef)
+    {
+        CFRelease(urlProxArrayRef);
+        urlProxArrayRef = NULL;
+    }
+    if(proxyDicRef)
+    {
+        CFRelease(proxyDicRef);
+        proxyDicRef = NULL;
+    }
+    if(urlRef)
+    {
+        CFRelease(urlRef);
+        urlRef = NULL;
+    }
+
+    return result;
+}
+
+MyDebugEventListener listener;
+
+int main(int argc, char* argv[])
+{
+    printf("Setting up configuration...\n");
+    auto& config = LogManager::GetLogConfiguration();
+
+    printf("Auto-detecting proxy settings...\n");
+    auto proxy = GetProxyForURL(COLLECTOR_URL_PROD);
+    printf("Proxy: %s\n", (proxy.empty())?"no proxy":proxy.c_str());
+    if(!proxy.empty())
+    {
+        /* libcurl HTTP stack respects this environment variable */
+        proxy.insert(0, "HTTPS_PROXY=");
+        putenv((char *)(proxy.c_str()));
+    }
+
+    config["name"] = "MacProxyExample";
+    config["version"] = "1.0.0";
+    config[CFG_INT_SDK_MODE] = SdkModeTypes::SdkModeTypes_CS;
+    config[CFG_INT_MAX_TEARDOWN_TIME] = 10;
+    config[CFG_INT_RAM_QUEUE_SIZE] = 32 * 1024 * 1024;  // 32 MB heap limit for sqlite3
+    config[CFG_INT_CACHE_FILE_SIZE] = 16 * 1024 * 1024;  // 16 MB storage file limit
+
+    printf("Adding debug event listeners...\n");
+    auto eventsList = {
+            DebugEventType::EVT_LOG_EVENT,
+            DebugEventType::EVT_LOG_SESSION,
+            DebugEventType::EVT_REJECTED,
+            DebugEventType::EVT_SEND_FAILED,
+            DebugEventType::EVT_SENT,
+            DebugEventType::EVT_DROPPED,
+            DebugEventType::EVT_HTTP_STATE,
+            DebugEventType::EVT_HTTP_OK,
+            DebugEventType::EVT_HTTP_ERROR,
+            DebugEventType::EVT_SEND_RETRY,
+            DebugEventType::EVT_SEND_RETRY_DROPPED,
+            DebugEventType::EVT_CACHED,
+            DebugEventType::EVT_NET_CHANGED,
+            DebugEventType::EVT_STORAGE_FULL
+    };
+
+    // Add event listeners
+    for(auto evt : eventsList)
+    {
+        LogManager::AddEventListener(evt, listener);
+    }
+
+    ILogger *logger = LogManager::Initialize(TOKEN);
+    logger->LogEvent("testEvent");
+    LogManager::FlushAndTeardown();
+
+    // Remove event listeners
+    for(auto evt : eventsList)
+    {
+        LogManager::RemoveEventListener(evt, listener);
+    }
+
+    return 0;
+}

--- a/examples/cpp/MacProxy/run-tests.sh
+++ b/examples/cpp/MacProxy/run-tests.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+##
+## Clean-up previous results
+##
+#sudo rm /tmp/aria*.log
+#sudo rm offline*
+#sudo rm -f heap*
+
+BIN=./out/MacProxy
+
+case $1 in
+
+"")
+  echo "Running basic test..."
+  $BIN
+  ;;
+
+1)
+  echo "Running heap check..."
+  export PPROF_PATH=/usr/local/bin
+  export HEAPCHECK=normal
+  $BIN
+  ;;
+
+2)
+  echo "Running gdb..."
+  gdb -ex=r --args $BIN
+  ;;
+
+3)
+  echo "Running valgrind..."
+  valgrind -v $BIN
+  ;;
+
+4)
+  echo "Running valgrind leak check..."
+  valgrind -v --track-origins=yes --leak-check=full $BIN
+  ;;
+
+5)
+  echo "Running cgroups 300MB memory test..."
+  cgcreate -g memory:/300MB
+  echo $(( 300 * 1024 * 1024 )) > /sys/fs/cgroup/memory/300MB/memory.limit_in_bytes
+  cgexec -g memory:/300MB $BIN
+  ;;
+
+esac


### PR DESCRIPTION
Creating it as a diff vs. base branch (maxgolov/libcurl_options) to minimize the change (the other one is already too big). I will merge this in the master after the libcurl_options branch merge: sample code depends on http state callback from the other branch for enforcing SSL verification option.

This is a trivial example that showcases how to configure _libcurl_ with Mac OS X system proxy settings. The example due to its intrinsic nature requires:
- **Mac OS X** - as host OS
- **libcurl** - as HTTP stack

The app is trying to detect the proxy in C++ using Apple SDK Core Foundation + CFNetwork:
- if proxy found, we populate HTTPS_PROXY environment variable and libcurl uses that one.
- if no proxy found, then by default we go direct upload with no proxy in between.

Verified with Fiddler on Mac.