### PR TITLE
Enable build tests for debug and release on Linux and Mac

### DIFF
--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -18,12 +18,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        config: [release, debug]
         os: [ubuntu-latest, macOS-latest]
     
     steps:
     - uses: actions/checkout@v1
-    - name: build
+    - name: Test ${{ matrix.os }} ${{ matrix.config }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
-      run: ./build.sh
+      run: ./build-tests.sh ${{ matrix.config }}


### PR DESCRIPTION
Attempt to enable build tests for [Linux|Mac] x [release|debug].
We previously built the SDK, but the tests were ad-hoc.
This time I'd like to try to enable all the tests to happen on every PR.