### PR TITLE
Sometimes a while loop in APITest.cpp would never manage to spawn 25 threads

### DIFF
--- a/tests/functests/APITest.cpp
+++ b/tests/functests/APITest.cpp
@@ -609,22 +609,22 @@ void StressUploadLockMultiThreaded(ILogConfiguration& config)
     while (numIterations--)
     {
         ILogger *result = LogManager::Initialize(TEST_TOKEN, config);
-        // Keep spawning UploadNow threads while the main thread is trying to perform Initialize and Teardown
-        while (threadCount++ < MAX_THREADS)
+        // Keep spawning UploadNow threads while the main thread is trying to perform
+        // Initialize and Teardown, but no more than MAX_THREADS at a time.
+        for (size_t i = 0; i < MAX_THREADS; i++)
         {
-            auto t = std::thread([&]()
+            if (threadCount++ < MAX_THREADS)
             {
-                std::this_thread::yield();
-                LogManager::UploadNow();
-                const auto randTimeSub2ms = std::rand() % 2;
-                // I believe we might be hitting an issue with std::this_thread::sleep_for on Windows with msvc++ runtime
-                // Ref.:
-                // https://developercommunity.visualstudio.com/content/problem/58530/bogus-stdthis-threadsleep-for-implementation.html
-                // The solution for Win32 is that PAL::sleep uses Win32 API instead of C++11 sleep.
-                PAL::sleep(randTimeSub2ms);
-                threadCount--;
-            });
-            t.detach();
+                auto t = std::thread([&]()
+                {
+                    std::this_thread::yield();
+                    LogManager::UploadNow();
+                    const auto randTimeSub2ms = std::rand() % 2;
+                    PAL::sleep(randTimeSub2ms);
+                    threadCount--;
+                });
+                t.detach();
+            }
         };
         EventProperties props = CreateSampleEvent("event_name", EventPriority_Normal);
         result->LogEvent(props);


### PR DESCRIPTION
Test issue on x64-Debug only, only on Windows, on the cloud runner:

- main loop tries to spawn at least 25 threads and keeps looping until 25 gets spawned.

- child threads get spawned with some sched_yield and some 0-2ms random sleep within.

- main loop scheduling is slower than the children (despite children having sched_yield and sleep), and never actually manages to get 25 threads spawned and in the running state... Because the child threads finish before the main can spawn 25... And the main loop keeps spawning, spawning, spawning, indefinitely.

Fix is to limit the total number of iterations while spawning new threads...

I need to be presenting this silly code of mine as an interview task: "What is wrong with this code..".


