### PR TITLE
Fix for Pii tags

### DIFF
--- a/examples/cpp/EventSender/EventSender.cpp
+++ b/examples/cpp/EventSender/EventSender.cpp
@@ -115,7 +115,10 @@ int main(int argc, char *argv[])
     printf("%s\n", json.c_str());
 #endif
 
-    // Log simple event without any properties
+    // Log simple event without any properties.
+    //
+    // Note that this event will be blocked in UTC mode on most recent versions of
+    // Windows as it has no privacy tag.
     printf("Sending My.Simple.Event\n");
     logger->LogEvent("My.Simple.Event");
 
@@ -155,6 +158,12 @@ int main(int argc, char *argv[])
                 { "guidKey2", GUID_t("00010203-0405-0607-0809-0A0B0C0D0E0F") },
                 { "timeKey1", time_ticks_t((uint64_t)0) },     // time in .NET ticks
             });
+
+        if (utcActive)
+        {
+            // Add privacy tags to avoid the event being dropped at UTC layer
+            evt.SetProperty(COMMONFIELDS_EVENT_PRIVTAGS, PDT_ProductAndServicePerformance);
+        }
 
         if (std::string("My.Detailed.Event.PiiMark") == eventName)
         {

--- a/lib/include/public/DebugEvents.hpp
+++ b/lib/include/public/DebugEvents.hpp
@@ -83,6 +83,8 @@ namespace ARIASDK_NS_BEGIN
         EVT_SEND_RETRY          = 0x04000002,
         /// <summary>Event(s) retry drop.</summary>
         EVT_SEND_RETRY_DROPPED  = 0x04000003,
+        /// <summary>Event(s) skip UTC registration.</summary>
+        EVT_SEND_SKIP_UTC_REGISTRATION = 0x04000004,
         /// <summary>Event(s) rejected, e.g.
         /// Failed regexp check or missing event name.
         /// </summary>


### PR DESCRIPTION
Unfortunately the flags passed via API surface do not match the flags to be sent in record.flags on wire. This is an interesting feature of CS2.1 protocol that is not described anywhere in CS4.x docs. We should also update the docs to reflect this behavior.

Populate record.flags in Bond similar to what UTC is doing in ext.utc.event.Flags

Ran event sender tool to confirm that:

- **record.flags** in Direct upload (used 1DS Fiddler inspector to inspect)

  matches

- **ext.utc.eventFlags** in UTC mode (used TRTT/DDV to inspect)

