### PR TITLE
Add clang-format to automagically enforce coding style

### DIFF
--- a/tests/unittests/CompliantByDefaultEventFilterModuleTests.cpp
+++ b/tests/unittests/CompliantByDefaultEventFilterModuleTests.cpp
@@ -32,7 +32,7 @@ TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_ParentValid_SetsPare
 
 TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_AllowedLevelsSizeOne)
 {
-    ASSERT_EQ(m_allowedLevels.GetSize(), 1);
+    ASSERT_EQ(m_allowedLevels.GetSize(), size_t { 1 });
 }
 
 TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_AllowedLevelValueIsRequired)
@@ -45,9 +45,15 @@ TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_HooksIsNotNullptr)
     ASSERT_TRUE(m_hooks != nullptr);
 }
 
-TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_HooksSizeIsTwo)
+TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_HooksSizeSet)
 {
-    ASSERT_EQ(m_hooks->GetSize(), 2); // This, and the default filter initialized by LogManager.
+#ifdef HAVE_MAT_DEFAULT_FILTER
+    constexpr const size_t expected = 2;  // This, and the default filter initialized by LogManager.
+#else
+    constexpr const size_t expected = 1;  // Just this hook.
+#endif // HAVE_MAT_DEFAULT_FILTER
+
+    ASSERT_EQ(m_hooks->GetSize(), expected);
 }
 
 TEST_F(CompliantByDefaultEventFilterModuleTests, Initialize_ThisPointerIsInHooksCollection)

--- a/tests/unittests/DataViewerCollectionTests.cpp
+++ b/tests/unittests/DataViewerCollectionTests.cpp
@@ -81,7 +81,7 @@ TEST(DataViewerCollectionTests, RegisterViewer_MultiplesharedDataViewersRegister
     ASSERT_NO_THROW(dataViewerCollection.RegisterViewer(viewer3));
     ASSERT_NO_THROW(dataViewerCollection.RegisterViewer(viewer4));
 
-    ASSERT_EQ(dataViewerCollection.GetCollection().size(), 4);
+    ASSERT_EQ(dataViewerCollection.GetCollection().size(), size_t { 4 });
     ASSERT_TRUE(dataViewerCollection.IsViewerEnabled(viewer1->GetName()));
     ASSERT_TRUE(dataViewerCollection.IsViewerEnabled(viewer2->GetName()));
     ASSERT_TRUE(dataViewerCollection.IsViewerEnabled(viewer3->GetName()));

--- a/tests/unittests/EventFilterCollectionTests.cpp
+++ b/tests/unittests/EventFilterCollectionTests.cpp
@@ -34,7 +34,7 @@ public:
 TEST(EventFilterCollectionTests, Constructor_DefaultConstructed_NoRegisteredFilters)
 {
     TestEventFilterCollection collection;
-    EXPECT_EQ(collection.m_filters.size(), 0);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 0 });
 }
 
 TEST(EventFilterCollectionTests, RegisterEventFilter_NullptrFilter_ThrowsArgumentException)
@@ -47,7 +47,7 @@ TEST(EventFilterCollectionTests, RegisterEventFilter_ValidFilter_FilterSizeIsOne
 {
     TestEventFilterCollection collection;
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
-    EXPECT_EQ(collection.m_filters.size(), 1);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 1 });
 }
 
 TEST(EventFilterCollectionTests, RegisterEventFilter_TwoValidFiltersWithTheSameName_FilterSizeIsTwo)
@@ -55,7 +55,7 @@ TEST(EventFilterCollectionTests, RegisterEventFilter_TwoValidFiltersWithTheSameN
     TestEventFilterCollection collection;
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
-    EXPECT_EQ(collection.m_filters.size(), 2);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 2 });
 }
 
 TEST(EventFilterCollectionTests, UnregisterEventFilter_NullptrName_ThrowsArgumentException)
@@ -69,7 +69,7 @@ TEST(EventFilterCollectionTests, UnregisterEventFilter_EventNameNotRegistered_Do
     TestEventFilterCollection collection;
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
     collection.UnregisterEventFilter("NotTheDroidsYoureLookingFor");
-    EXPECT_EQ(collection.m_filters.size(), 1);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 1 });
 }
 
 TEST(EventFilterCollectionTests, UnregisterEventFilter_EventNameRegistered_ModifiesCollection)
@@ -77,7 +77,7 @@ TEST(EventFilterCollectionTests, UnregisterEventFilter_EventNameRegistered_Modif
     TestEventFilterCollection collection;
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
     collection.UnregisterEventFilter(DefaultTestEventFilterName);
-    EXPECT_EQ(collection.m_filters.size(), 0);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 0 });
 }
 
 TEST(EventFilterCollectionTests, UnregisterEventFilter_EventNameRegisteredTwice_RemovesBoth)
@@ -86,7 +86,7 @@ TEST(EventFilterCollectionTests, UnregisterEventFilter_EventNameRegisteredTwice_
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
     collection.UnregisterEventFilter(DefaultTestEventFilterName);
-    EXPECT_EQ(collection.m_filters.size(), 0);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 0 });
 }
 
 TEST(EventFilterCollectionTests, UnregisterEventFilter_TwoDifferentlyNamedFilters_RemovesOne)
@@ -95,7 +95,7 @@ TEST(EventFilterCollectionTests, UnregisterEventFilter_TwoDifferentlyNamedFilter
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter("One")));
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter("Two")));
     collection.UnregisterEventFilter("One");
-    EXPECT_EQ(collection.m_filters.size(), 1);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 1 });
     EXPECT_EQ(strcmp(collection.m_filters[0]->GetName(), "Two"), 0);
 }
 
@@ -104,7 +104,7 @@ TEST(EventFilterCollectionTests, UnregisterAllFilters_OneRegistered_ModifiesColl
     TestEventFilterCollection collection;
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter()));
     collection.UnregisterAllFilters();
-    EXPECT_EQ(collection.m_filters.size(), 0);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 0 });
 }
 
 TEST(EventFilterCollectionTests, UnregisterAllFilters_TwoRegistered_RemovesBoth)
@@ -113,7 +113,7 @@ TEST(EventFilterCollectionTests, UnregisterAllFilters_TwoRegistered_RemovesBoth)
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter("One")));
     collection.RegisterEventFilter(std::unique_ptr<IEventFilter>(new TestEventFilter("Two")));
     collection.UnregisterAllFilters();
-    EXPECT_EQ(collection.m_filters.size(), 0);
+    EXPECT_EQ(collection.m_filters.size(), size_t { 0 });
 }
 
 TEST(EventFilterCollectionTests, CanEventPropertiesBeSent_ZeroRegisteredFilters_ReturnsTrue)

--- a/tests/unittests/HttpClientCAPITests.cpp
+++ b/tests/unittests/HttpClientCAPITests.cpp
@@ -138,11 +138,11 @@ TEST(HttpClientCAPITests, SendAsync)
     responseCallback.SetResponseValidation([&wasReceived](IHttpResponse* response) {
         wasReceived = true;
         EXPECT_EQ(response->GetResult(), HttpResult_OK);
-        EXPECT_EQ(response->GetBody().size(), 3);
+        EXPECT_EQ(response->GetBody().size(), size_t { 3 });
         EXPECT_EQ(response->GetBody()[0], 'y');
         EXPECT_EQ(response->GetBody()[1], 'e');
         EXPECT_EQ(response->GetBody()[2], 's');
-        EXPECT_EQ(response->GetHeaders().size(), 1);
+        EXPECT_EQ(response->GetHeaders().size(), size_t { 1 });
         EXPECT_EQ(response->GetHeaders().has("response_key1"), true);
         EXPECT_EQ(response->GetHeaders().get("response_key1"), string("response_value1"));
     });
@@ -215,11 +215,11 @@ TEST(HttpClientCAPITests, CancelAllThenSend)
     responseCallback.SetResponseValidation([&wasReceived](IHttpResponse* response) {
         wasReceived = true;
         EXPECT_EQ(response->GetResult(), HttpResult_OK);
-        EXPECT_EQ(response->GetBody().size(), 3);
+        EXPECT_EQ(response->GetBody().size(), size_t { 3 });
         EXPECT_EQ(response->GetBody()[0], 'y');
         EXPECT_EQ(response->GetBody()[1], 'e');
         EXPECT_EQ(response->GetBody()[2], 's');
-        EXPECT_EQ(response->GetHeaders().size(), 1);
+        EXPECT_EQ(response->GetHeaders().size(), size_t { 1 });
         EXPECT_EQ(response->GetHeaders().has("response_key1"), true);
         EXPECT_EQ(response->GetHeaders().get("response_key1"), string("response_value1"));
     });

--- a/tests/unittests/LevelCheckingEventFilterTests.cpp
+++ b/tests/unittests/LevelCheckingEventFilterTests.cpp
@@ -14,7 +14,7 @@ public:
 
 TEST_F(LevelCheckingEventFilterTests, Constructor_Default_AllowedLevelsSizeZero)
 {
-    EXPECT_EQ(0, AllowedLevels.GetSize());
+    EXPECT_EQ(size_t { 0 }, AllowedLevels.GetSize());
 }
 
 TEST_F(LevelCheckingEventFilterTests, GetName_ReturnsExpectedName)
@@ -30,13 +30,13 @@ TEST_F(LevelCheckingEventFilterTests, CanEventPropertiesBeSent_NoLevelSet_Return
 TEST_F(LevelCheckingEventFilterTests, UpdateAllowedLevels_EmptySet_SetsAllowedLevelsToSize0)
 {
     Filter.UpdateAllowedLevels(std::vector<uint8_t>{});
-    EXPECT_EQ(0, AllowedLevels.GetSize());
+    EXPECT_EQ(size_t { 0 }, AllowedLevels.GetSize());
 }
 
 TEST_F(LevelCheckingEventFilterTests, UpdateAllowedLevels_SizeTwo_SetsAllowedLevelsToSize2)
 {
     Filter.UpdateAllowedLevels(std::vector<uint8_t>{42, 97});
-    EXPECT_EQ(2, AllowedLevels.GetSize());
+    EXPECT_EQ(size_t { 2 }, AllowedLevels.GetSize());
 }
 
 TEST_F(LevelCheckingEventFilterTests, UpdateAllowedLevels_SizeTwo_AllowedValuesAreSetProperly)


### PR DESCRIPTION
First stab at automating the clang-format:
- IDE: works seamlessly with Visual Studio 2017 and 2019
- Command-line: script for Windows only (for now, will add POSIX later)
- basic style that is more or less in alignment with the current coding style
- instruction guide on how to use the command line tool
- list of references mentioning existing commonly used IDE plugins that respect the .clang-format file

Further TODO in a separate commit:
- add POSIX scripts
- explore how to integrate the smarter version of 'git cl format' from Chromium that performs auto-formatting of files that were touched in a pending commit