### PR TITLE
Move an on-load heap allocation to magic static

### DIFF
--- a/lib/include/public/IHttpClient.hpp
+++ b/lib/include/public/IHttpClient.hpp
@@ -112,7 +112,7 @@ namespace ARIASDK_NS_BEGIN
         /// <summary>
         /// The IHttpRequest class destructor.
         /// </summary>
-        virtual ~IHttpRequest() noexcept {}
+        virtual ~IHttpRequest() noexcept = default;
 
         /// <summary>
         /// Gets the request ID.
@@ -176,7 +176,7 @@ namespace ARIASDK_NS_BEGIN
         /// <summary>
         /// The IHttpResponse class destructor.
         /// </summary>
-        virtual ~IHttpResponse() noexcept {}
+        virtual ~IHttpResponse() noexcept = default;
 
         /// <summary>
         /// Gets the response ID.
@@ -258,14 +258,6 @@ namespace ARIASDK_NS_BEGIN
             : m_id(id),
             m_method("GET"),
             m_latency(EventLatency_Unspecified)
-        {
-        }
-
-
-        /// <summary>
-        /// The SimpleHttpRequest destructor.
-        /// </summary>
-        virtual ~SimpleHttpRequest() noexcept
         {
         }
 
@@ -387,13 +379,6 @@ namespace ARIASDK_NS_BEGIN
         }
 
         /// <summary>
-        /// The SimpleHttpResponse class destructor.
-        /// </summary>
-       virtual ~SimpleHttpResponse() noexcept
-       {
-       }
-
-        /// <summary>
         /// Gets the HTTP response message Id.
         /// </summary>
         /// <returns>A string that contains the response message ID.</returns>
@@ -481,7 +466,7 @@ namespace ARIASDK_NS_BEGIN
         /// <summary>
         /// The IHttpResponseCallback class destructor.
         /// </summary>
-        virtual ~IHttpResponseCallback() {}
+        virtual ~IHttpResponseCallback() noexcept = default;
 
         /// <summary>
         /// Called when an HTTP request completes.
@@ -515,7 +500,7 @@ namespace ARIASDK_NS_BEGIN
     class IHttpClient : public IModule
     {
     public:
-        virtual ~IHttpClient() noexcept {}
+        virtual ~IHttpClient() noexcept = default;
 
         /// <summary>
         /// Creates an empty HTTP request object.


### PR DESCRIPTION
Constructing a namespace scoped std::string will involve a heap allocation on load for strings longer than 8 characters (with MSVC, about 10 characters last I checked for libc++ and libstdc++). Move the sdkVersion string to a method scoped magic static so it's only constructed on the first call to that method.

Perhaps a larger scale fix here is to use a std::string_view (or take a dependency on the GSL for gsl::string_view), rather than a string, but this at least makes the world a slightly better place.