### PR TITLE
Add Wincrypt header for cert pinning

### DIFF
--- a/lib/http/HttpClient_WinInet.cpp
+++ b/lib/http/HttpClient_WinInet.cpp
@@ -6,6 +6,7 @@
 #include "HttpClient_WinInet.hpp"
 #include "utils/Utils.hpp"
 
+#include <Wincrypt.h>
 #include <WinInet.h>
 
 #include <algorithm>


### PR DESCRIPTION
Edge wasn't able to build the cert pinning change; appears to have been an issue with the wincrypt header not being included.

Maybe worth noting somewhere that the cert pinning change also added a dep on crypt32.lib, but that appears to already be accounted for in the build scripts (but wasn't included on Edge, because we built fine without it before)