### PR TITLE
Bugfix - leaking file descriptors #217

### DIFF
--- a/lib/http/HttpClient_Curl.cpp
+++ b/lib/http/HttpClient_Curl.cpp
@@ -74,6 +74,7 @@ namespace ARIASDK_NS_BEGIN {
         auto curlOperation = std::make_shared<CurlHttpOperation>(curlRequest->m_method, curlRequest->m_url, callback, requestHeaders, curlRequest->m_body);
         curlRequest->SetOperation(curlOperation);
 
+        /*
         // Make sure 'curlOperation' is valid before executing the lambda. 
         // The liftime of curlOperation is guarnteed by the curlRequest.  
         curlOperation->SendAsync([this, op = std::weak_ptr<CurlHttpOperation>(curlOperation), callback, requestId](CurlHttpOperation& operation) {
@@ -82,7 +83,9 @@ namespace ARIASDK_NS_BEGIN {
             {
                 LOG_WARN("The curl operation no longer exists.");
                 return;
-            }
+            }*/
+        // Hold on to 'curlOperation' in lambda to ensure its lifetime until operation completes
+         curlOperation->SendAsync([this, curlOperation, callback, requestId](CurlHttpOperation& operation) {
             this->EraseRequest(requestId);
 
             auto response = std::unique_ptr<SimpleHttpResponse>(new SimpleHttpResponse(requestId));


### PR DESCRIPTION
#217 

Don't capture the curlOperation inside the lambda.
It increase the ref count of the curlOperation and makes the operation to never be released.