### PR TITLE
Remove unused function.

### DIFF
--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -429,11 +429,6 @@ namespace PAL_NS_BEGIN {
         }
     }
 
-    void unregisterSemanticContext(ISemanticContext* context)
-    {
-        UNREFERENCED_PARAMETER(context);
-    }
-
 #undef OS_NAME
 #if defined(_WIN32)
     #define OS_NAME     "Windows"


### PR DESCRIPTION
Self evident, `unregisterSemanticContext` is never used, and the function body is uninteresting (a single unused parameter macro invocation).