### PR TITLE
Android NetworkCost and PowerState, #234 #238

### DIFF
--- a/lib/http/httpClient.java
+++ b/lib/http/httpClient.java
@@ -1,5 +1,16 @@
 package com.microsoft.office.ariasdk;
 
+import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.ConnectivityManager.NetworkCallback;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.os.BatteryManager;
+import android.os.Build;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -23,16 +34,49 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Created by maharrim on 8/21/2019.
  */
 
+class PowerReceiver extends android.content.BroadcastReceiver {
+    final httpClient m_parent;
+    boolean m_charging = true;
+    boolean m_low_battery = false;
+
+    PowerReceiver(httpClient parent)
+    {
+        m_parent = parent;
+    }
+
+    final public void onReceive(android.content.Context context, android.content.Intent intent) {
+        final int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+        final boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING
+                || status == BatteryManager.BATTERY_STATUS_FULL;
+        final boolean isLow = intent.getBooleanExtra(BatteryManager.EXTRA_BATTERY_LOW, false);
+        m_parent.onPowerChange(isCharging, isLow);
+    }
+}
+
+// See below: we test build version before instantiating this.
+@TargetApi(24)
+class ConnectivityCallback extends android.net.ConnectivityManager.NetworkCallback {
+    ConnectivityCallback(httpClient parent, boolean metered) {
+        m_parent = parent;
+        m_metered = metered;
+    }
+
+    final public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+        final boolean new_metered = !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED);
+        if (new_metered != m_metered) {
+            m_metered = new_metered;
+            m_parent.onCostChange(m_metered);
+        }
+    }
+
+    final httpClient m_parent;
+    boolean m_metered;
+}
+
 class Request implements Runnable {
 
-    Request(String url,
-            String method,
-            byte[] body,
-            String request_id,
-            int[] header_length,
-            byte[] header_buffer
-    ) throws java.net.MalformedURLException, java.io.IOException
-    {
+    Request(String url, String method, byte[] body, String request_id, int[] header_length, byte[] header_buffer)
+            throws java.net.MalformedURLException, java.io.IOException {
         m_url = new URL(url);
         m_connection = (HttpURLConnection) m_url.openConnection();
         m_connection.setRequestMethod(method);
@@ -46,14 +90,13 @@ class Request implements Runnable {
         for (int i = 0; i + 1 < header_length.length; i += 2) {
             String k = new String(header_buffer, offset, header_length[i], UTF_8);
             offset += header_length[i];
-            String v = new String(header_buffer, offset, header_length[i+1], UTF_8);
-            offset += header_length[i+1];
+            String v = new String(header_buffer, offset, header_length[i + 1], UTF_8);
+            offset += header_length[i + 1];
             m_connection.setRequestProperty(k, v);
         }
     }
 
-    public void run()
-    {
+    public void run() {
         String[] headerArray = {};
         byte[] body = {};
         int response = 0;
@@ -77,8 +120,7 @@ class Request implements Runnable {
             BufferedInputStream in;
             if (response >= 300) {
                 in = new BufferedInputStream(m_connection.getErrorStream());
-            }
-            else {
+            } else {
                 in = new BufferedInputStream(m_connection.getInputStream());
             }
             byte[] buffer = new byte[1024];
@@ -108,27 +150,16 @@ class Request implements Runnable {
         } finally {
             m_connection.disconnect();
         }
-        dispatchCallback(
-                m_request_id,
-                response,
-                headerArray,
-                body);
+        dispatchCallback(m_request_id, response, headerArray, body);
     }
 
-    public void dispatchCallback(String id,
-                                 int response,
-                                 Object[] headers,
-                                 byte[] body)
-    {
+    public void dispatchCallback(String id, int response, Object[] headers, byte[] body) {
         // this stub makes it easier to mock this method in
         // Java unit tests.
         nativeDispatchCallback(id, response, headers, body);
     }
 
-    public native void nativeDispatchCallback(String id,
-                                              int response,
-                                              Object[] headers,
-                                              byte[] body);
+    public native void nativeDispatchCallback(String id, int response, Object[] headers, byte[] body);
 
     private URL m_url;
     private HttpURLConnection m_connection;
@@ -136,47 +167,69 @@ class Request implements Runnable {
     public String m_request_id;
 }
 
-public class httpClient{
+public class httpClient {
     private static final int MAX_HTTP_THREADS = 2; // Collector wants no more than 2 at a time
-    public httpClient()
-    {
+
+    public httpClient(android.content.Context context) {
+        m_context = context;
         String path = System.getProperty("java.io.tmpdir");
         setCacheFilePath(path);
         m_executor = Executors.newFixedThreadPool(MAX_HTTP_THREADS);
         createClientInstance();
+        // We need API 24 to follow changes in network status
+        if (Build.VERSION.SDK_INT >= 24) {
+            m_connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+            boolean is_metered = m_connectivityManager.isActiveNetworkMetered();
+            m_callback = new ConnectivityCallback(this, is_metered);
+            onCostChange(is_metered); // set initial value in C++ side
+            m_connectivityManager.registerDefaultNetworkCallback(m_callback);
+        }
+        m_power_receiver = new PowerReceiver(this);
+        IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        Intent status = context.registerReceiver(m_power_receiver, filter);
+        m_power_receiver.onReceive(context, status);
     }
 
-    public void finalize()
-    {
+    public void finalize() {
+        if (m_callback != null) {
+            m_connectivityManager.unregisterNetworkCallback(m_callback);
+            m_callback = null;
+        }
+        m_context.unregisterReceiver(m_power_receiver);
+        m_power_receiver = null;
         deleteClientInstance();
         m_executor.shutdown();
     }
 
     public native void createClientInstance();
+
     public native void deleteClientInstance();
+
     public native void setCacheFilePath(String path);
-    public FutureTask<Boolean> createTask(String url,
-                                String method,
-                                byte[] body,
-                                String request_id,
-                                                int[] header_index,
-                                                byte[] header_buffer)
-    {
+
+    public native void onCostChange(boolean isMetered);
+
+    public native void onPowerChange(boolean isCharging, boolean isLow);
+
+    public FutureTask<Boolean> createTask(String url, String method, byte[] body, String request_id, int[] header_index,
+            byte[] header_buffer) {
         try {
             Request r = new Request(url, method, body, request_id, header_index, header_buffer);
             FutureTask<Boolean> t = new FutureTask<Boolean>(r, true);
             m_executor.execute(t);
             return t;
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             return null;
         }
     }
 
-    public void executeTask(FutureTask<Boolean> t)
-    {
+    public void executeTask(FutureTask<Boolean> t) {
         m_executor.execute(t);
     }
 
     ExecutorService m_executor;
+    ConnectivityCallback m_callback;
+    android.net.ConnectivityManager m_connectivityManager;
+    PowerReceiver m_power_receiver;
+    Context m_context;
 }

--- a/lib/pal/DeviceInformationImpl.hpp
+++ b/lib/pal/DeviceInformationImpl.hpp
@@ -44,13 +44,16 @@ namespace PAL_NS_BEGIN {
         std::string m_model;
         std::string m_deviceTicket;
         OsArchitectureType m_os_architecture;
+    protected:
         PowerSource m_powerSource;
         InformatonProviderImpl m_info_helper;
+    private:
         int m_registredCount;
         // Disable copy constructor and assignment operator.
         DeviceInformationImpl(DeviceInformationImpl const& other);
         DeviceInformationImpl& operator=(DeviceInformationImpl const& other);
 
+        protected:
         DeviceInformationImpl();
         virtual ~DeviceInformationImpl();
     };

--- a/lib/pal/posix/DeviceInformationImpl_Android.cpp
+++ b/lib/pal/posix/DeviceInformationImpl_Android.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+#define LOG_MODULE DBG_API
+#include "pal/PAL.hpp"
+#include "pal/DeviceInformationImpl.hpp"
+
+#include <jni.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <locale>
+#include <codecvt>
+
+#include "sysinfo_sources.hpp"
+
+#define DEFAULT_DEVICE_ID       "{deadbeef-fade-dead-c0de-cafebabefeed}"
+
+namespace PAL_NS_BEGIN {
+
+    class AndroidDeviceInformation;
+
+    class AndroidPowerSourceConnector {
+        private:
+
+        static PowerSource s_power_source;
+        static std::mutex s_registered_mutex;
+        static std::vector<AndroidDeviceInformation *> s_registered;
+        
+        public:
+
+        static void registerDI(AndroidDeviceInformation &di);
+        static void unregisterDI(AndroidDeviceInformation &di);
+        static void updatePowerSource(PowerSource new_power_source);
+    };
+
+    PowerSource AndroidPowerSourceConnector::s_power_source = PowerSource_Unknown;
+    std::mutex AndroidPowerSourceConnector::s_registered_mutex;
+    std::vector<AndroidDeviceInformation *> AndroidPowerSourceConnector::s_registered;
+
+    ///// IDeviceInformation API
+    DeviceInformationImpl::DeviceInformationImpl() :
+                                m_info_helper()
+    {
+        // Since nothing looks at this, let's just say unknown
+        m_os_architecture = OsArchitectureType_Unknown;
+
+        std::string devId = aria_hwinfo.get("devId");
+        m_device_id = (devId.empty()) ? DEFAULT_DEVICE_ID : devId;
+
+        m_manufacturer = aria_hwinfo.get("devMake");
+
+        m_model = aria_hwinfo.get("devModel");
+
+        m_powerSource = PowerSource_Battery;
+
+    }
+
+    std::string DeviceInformationImpl::GetDeviceTicket() const
+    {
+        return m_deviceTicket;
+    }
+
+#ifdef ENABLE_LEGACY_CODE
+    size_t DeviceInformationImpl::GetMemorySize() const
+    {
+        return 0;
+    }
+#endif
+
+    class AndroidDeviceInformation : public DeviceInformationImpl {
+        public:
+        AndroidDeviceInformation()
+        {
+            AndroidPowerSourceConnector::registerDI(*this);
+        }
+
+        ~AndroidDeviceInformation()
+        {
+            AndroidPowerSourceConnector::unregisterDI(*this);
+        }
+
+        void UpdatePowerSource(PowerSource new_power_source)
+        {
+            m_powerSource = new_power_source;
+            m_info_helper.OnChanged(POWER_SOURCE, std::to_string(m_powerSource));
+        }
+    };
+
+    IDeviceInformation* DeviceInformationImpl::Create()
+    {
+        return new AndroidDeviceInformation();
+    }
+
+    DeviceInformationImpl::~DeviceInformationImpl() {}
+
+    void AndroidPowerSourceConnector::registerDI(AndroidDeviceInformation &di)
+    {
+        std::lock_guard<std::mutex> lock(s_registered_mutex);
+        for (auto&& e : s_registered)
+        {
+            if (e == &di)
+            {
+                // only register di once
+                return;
+            }
+        }
+        s_registered.push_back(&di);
+        di.UpdatePowerSource(s_power_source);
+    }
+
+    void AndroidPowerSourceConnector::unregisterDI(AndroidDeviceInformation &di)
+    {
+        std::lock_guard<std::mutex> lock(s_registered_mutex);
+        auto new_end = std::remove_if(s_registered.begin(), s_registered.end(), [&di] (AndroidDeviceInformation *r)->bool
+        {
+            return r == &di;
+        });
+        s_registered.erase(new_end, s_registered.end());
+    }
+
+    void AndroidPowerSourceConnector::updatePowerSource(PowerSource new_power_source)
+    {
+        std::lock_guard<std::mutex> lock(s_registered_mutex);
+        s_power_source = new_power_source;
+        for (auto && di : s_registered) {
+            di->UpdatePowerSource(s_power_source);
+        }
+    }
+    
+} PAL_NS_END
+
+extern "C"
+JNIEXPORT void
+
+JNICALL
+Java_com_microsoft_office_ariasdk_httpClient_onPowerChange(JNIEnv* env,
+	jobject /* java_client */,
+    jboolean isCharging, 
+    jboolean isLow)
+    {
+        PowerSource new_power_source = PowerSource_Charging;
+        if (!isCharging)
+        {
+            if (isLow)
+            {
+                new_power_source = PowerSource_LowBattery;
+            }
+            else
+            {
+                new_power_source = PowerSource_Battery;
+            }
+            PAL::AndroidPowerSourceConnector::updatePowerSource(new_power_source);
+        }
+    }

--- a/lib/pal/posix/NetworkInformationImpl_Android.cpp
+++ b/lib/pal/posix/NetworkInformationImpl_Android.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+#define LOG_MODULE DBG_PAL
+#include "pal/PAL.hpp"
+#include "pal/NetworkInformationImpl.hpp"
+#include <algorithm>
+#include <mutex>
+#include <vector>
+#include <jni.h>
+
+namespace PAL_NS_BEGIN {
+
+    class NetworkInformation;
+
+    class AndroidNetcostConnector {
+    private:
+
+        static std::vector<NetworkInformation *> s_registered;
+        static std::mutex s_registered_mutex;
+        static NetworkCost s_cost;
+
+    public:
+
+        static void RegisterNI(NetworkInformation &thing);
+
+        static void UnregisterNI(NetworkInformation &thing)
+        {
+            std::lock_guard<std::mutex> lock(s_registered_mutex);
+            auto end = std::remove_if(s_registered.begin(), s_registered.end(), [&thing] (NetworkInformation *element)->bool {
+                return element == &thing;
+            });
+            s_registered.erase(end, s_registered.end());
+        }
+
+        static void UpdateCost(NetworkCost new_cost);
+    };
+
+    std::vector<NetworkInformation*> AndroidNetcostConnector::s_registered;
+    std::mutex AndroidNetcostConnector::s_registered_mutex;
+    NetworkCost AndroidNetcostConnector::s_cost = NetworkCost_Unknown;
+
+    NetworkInformationImpl::NetworkInformationImpl(bool isNetDetectEnabled) :
+        m_info_helper(),
+        m_cost(NetworkCost_Unknown),
+        m_isNetDetectEnabled(isNetDetectEnabled){};
+
+    NetworkInformationImpl::~NetworkInformationImpl() {};
+
+    class NetworkInformation : public NetworkInformationImpl
+    {
+        std::string m_network_provider;
+
+    public:
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="isNetDetectEnabled"></param>
+        NetworkInformation(bool isNetDetectEnabled);
+
+        /// <summary>
+        ///
+        /// </summary>
+        virtual ~NetworkInformation();
+
+        /// <summary>
+        /// Gets the current network provider for the device
+        /// </summary>
+        /// <returns>The current network provider for the device</returns>
+        virtual std::string const& GetNetworkProvider()
+        {
+            return m_network_provider;
+        }
+
+        /// <summary>
+        /// Gets the current network type for the device
+        /// E.g. Wifi, 3G, Ethernet
+        /// </summary>
+        /// <returns>The current network type for the device</returns>
+        virtual NetworkType GetNetworkType()
+        {
+            return NetworkType_Unknown;
+        }
+
+        /// <summary>
+        /// Gets the current network cost for the device:
+        /// OVER_DATA_LIMIT
+        /// METERED
+        /// UNMETERED
+        /// </summary>
+        /// <returns>The current network cost for the device</returns>
+        virtual NetworkCost GetNetworkCost()
+        {
+            return m_cost;
+        }
+
+        virtual void UpdateCost(NetworkCost cost)
+        {
+            m_cost = cost;
+            m_info_helper.OnChanged(NETWORK_COST, std::to_string(cost));
+        }
+    };
+
+    void AndroidNetcostConnector::RegisterNI(NetworkInformation& thing)
+    {
+        std::lock_guard<std::mutex> lock(s_registered_mutex);
+        for (auto&& e : s_registered)
+        {
+            if (e == &thing)
+            {
+                return;
+            }
+        }
+        s_registered.push_back(&thing);
+        // inform thing of the current network cost
+        thing.UpdateCost(s_cost);
+    }
+
+    void AndroidNetcostConnector::UpdateCost(NetworkCost new_cost)
+    {
+        std::lock_guard<std::mutex> lock(s_registered_mutex);
+        s_cost = new_cost;
+        for (auto&& e : s_registered)
+        {
+            // inform each e of the (changed) network cost
+            e->UpdateCost(new_cost);
+        }
+    }
+
+    NetworkInformation::NetworkInformation(bool isNetDetectEnabled) :
+        NetworkInformationImpl(isNetDetectEnabled)
+    {
+        AndroidNetcostConnector::RegisterNI(*this);
+    }
+
+    NetworkInformation::~NetworkInformation()
+    {
+        AndroidNetcostConnector::UnregisterNI(*this);
+    }
+
+    INetworkInformation* NetworkInformationImpl::Create(bool isNetDetectEnabled)
+    {
+        return new NetworkInformation(isNetDetectEnabled);
+    }
+
+} PAL_NS_END
+
+extern "C"
+JNIEXPORT void
+
+JNICALL
+Java_com_microsoft_office_ariasdk_httpClient_onCostChange(JNIEnv* env,
+	jobject /* java_client */,
+    jboolean isMetered)
+{
+    PAL::AndroidNetcostConnector::UpdateCost(isMetered ? NetworkCost_Metered : NetworkCost_Unmetered);
+}


### PR DESCRIPTION
Replace the default posix implementations with an Android version.

Manual testing shows that both NetworkCost and PowerState see the desired changes as the emulator's state changes, and that both receive the desired initial state from the Java side.