### PR TITLE
Move string conversion methods into a separate file

### DIFF
--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -97,9 +97,9 @@ namespace ARIASDK_NS_BEGIN
     }
 
     LogManagerImpl::LogManagerImpl(ILogConfiguration& configuration, bool deferSystemStart)
-        : m_bandwidthController(nullptr),
-        m_offlineStorage(nullptr),
-        m_logConfiguration(configuration)
+        : m_logConfiguration(configuration),
+        m_bandwidthController(nullptr),
+        m_offlineStorage(nullptr)
     {
         m_httpClient = std::static_pointer_cast<IHttpClient>(configuration.GetModule(CFG_MODULE_HTTP_CLIENT));
         m_taskDispatcher = std::static_pointer_cast<ITaskDispatcher>(configuration.GetModule(CFG_MODULE_TASK_DISPATCHER));

--- a/lib/offline/MemoryStorage.cpp
+++ b/lib/offline/MemoryStorage.cpp
@@ -8,9 +8,9 @@ namespace ARIASDK_NS_BEGIN {
     MATSDK_LOG_INST_COMPONENT_CLASS(MemoryStorage, "EventsSDK.MemoryStorage", "Events telemetry client - MemoryStorage class");
 
     MemoryStorage::MemoryStorage(ILogManager & logManager, IRuntimeConfig & runtimeConfig) :
+        m_observer(nullptr),
         m_config(runtimeConfig),
         m_logManager(logManager),
-        m_observer(nullptr),
         m_size(0),
         m_lastReadCount(0)
     {

--- a/lib/offline/OfflineStorageHandler.cpp
+++ b/lib/offline/OfflineStorageHandler.cpp
@@ -24,6 +24,7 @@ namespace ARIASDK_NS_BEGIN {
         m_taskDispatcher(taskDispatcher),
         m_killSwitchManager(),
         m_clockSkewManager(),
+        m_flushPending(false),
         m_offlineStorageMemory(nullptr),
         m_offlineStorageDisk(nullptr),
         m_readFromMemory(false),
@@ -31,8 +32,7 @@ namespace ARIASDK_NS_BEGIN {
         m_shutdownStarted(false),
         m_memoryDbSize(0),
         m_queryDbSize(0),
-        m_isStorageFullNotificationSend(false),
-        m_flushPending(false)
+        m_isStorageFullNotificationSend(false)
     {
         // FIXME: [MG] - this code seems redundant / suspicious because OfflineStorage_SQLite.cpp is doing the same thing...
         uint32_t percentage = m_config[CFG_INT_RAMCACHE_FULL_PCT];

--- a/lib/offline/OfflineStorage_SQLite.cpp
+++ b/lib/offline/OfflineStorage_SQLite.cpp
@@ -56,8 +56,8 @@ namespace ARIASDK_NS_BEGIN {
     }
 
     OfflineStorage_SQLite::OfflineStorage_SQLite(ILogManager & logManager, IRuntimeConfig& runtimeConfig, bool inMemory)
-        : m_logManager(logManager),
-        m_config(runtimeConfig)
+        : m_config(runtimeConfig)
+        , m_logManager(logManager)
     {
         uint32_t percentage = (inMemory) ? m_config[CFG_INT_RAMCACHE_FULL_PCT] : m_config[CFG_INT_STORAGE_FULL_PCT];
         m_DbSizeLimit = (inMemory) ? static_cast<uint32_t>(m_config[CFG_INT_RAM_QUEUE_SIZE]) : static_cast<uint32_t>(m_config[CFG_INT_CACHE_FILE_SIZE]);

--- a/lib/stats/Statistics.cpp
+++ b/lib/stats/Statistics.cpp
@@ -10,11 +10,11 @@
 namespace ARIASDK_NS_BEGIN {
 
     Statistics::Statistics(ITelemetrySystem& telemetrySystem, ITaskDispatcher& taskDispatcher) :
+        m_metaStats(telemetrySystem.getConfig()),
         m_iTelemetrySystem(telemetrySystem),
         m_taskDispatcher(taskDispatcher),
-        m_logManager(telemetrySystem.getLogManager()),
-        m_metaStats(telemetrySystem.getConfig()),
         m_config(telemetrySystem.getConfig()),
+        m_logManager(telemetrySystem.getLogManager()),
         m_baseDecorator(m_logManager),
         m_semanticContextDecorator(m_logManager),
         m_isStarted(false)

--- a/tests/common/MockILogManagerInternal.hpp
+++ b/tests/common/MockILogManagerInternal.hpp
@@ -10,11 +10,6 @@
 
 namespace testing {
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4263) // Method does not override base function doesn't play nice with googlemock macros.
-#pragma warning(disable:4264) // Method does not override base function doesn't play nice with googlemock macros.
-#endif
     class MockILogManagerInternal : public MAT::ILogManagerInternal
     {
     public:
@@ -46,10 +41,9 @@ namespace testing {
         MOCK_METHOD3(SetContext, MAT::status_t(const std::string&, bool, MAT::PiiKind));
         MOCK_METHOD3(SetContext, MAT::status_t(const std::string&, MAT::time_ticks_t, MAT::PiiKind));
         MOCK_METHOD3(SetContext, MAT::status_t(const std::string&, MAT::GUID_t, MAT::PiiKind));
+        using MAT::ILogManagerInternal::GetLogger;
         MOCK_METHOD4(GetLogger, MAT::ILogger * (std::string const &, MAT::ContextFieldsProvider*, std::string const &, std::string const &));
         MOCK_METHOD1(sendEvent, void(MAT::IncomingEventContextPtr const &));
     };
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+
 } // namespace testing

--- a/tests/unittests/CompliantByDefaultEventFilterModuleTests.cpp
+++ b/tests/unittests/CompliantByDefaultEventFilterModuleTests.cpp
@@ -12,7 +12,7 @@ class CompliantByDefaultEventFilterModuleTests : public CompliantByDefaultEventF
 {
 public:
     CompliantByDefaultEventFilterModuleTests() noexcept
-        : m_logManager(m_logConfiguration, nullptr) { }
+        : m_logManager(m_logConfiguration, static_cast<bool>(nullptr)) { }
     ILogConfiguration m_logConfiguration;
     LogManagerImpl m_logManager;
 


### PR DESCRIPTION
These two methods are only ever used on win32, and wstring_convert causes problems for Office on other platforms.  Rather than #ifdef _WIN32 them, I've moved them into a new file.