### PR TITLE
iOS: Add support for arm64e and configurable deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,26 +17,30 @@ endif()
 
 # iOS build options
 option(BUILD_IOS           "Build for iOS"               NO)
-option(BUILD_SIMULATOR     "Build using simulator SDK"   NO)
-
-# Begin Uncomment for iOS Device build
-#set(BUILD_SIMULATOR NO)
-# End of iOS Device build
 
 if(BUILD_IOS)
   set(TARGET_ARCH "APPLE")
   set(IOS True)
   set(APPLE True)
-  set (CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
 
-  if(BUILD_SIMULATOR)
+  if(${IOS_ARCH} STREQUAL "x86_64")
     set(IOS_PLATFORM "iphonesimulator")
     set(CMAKE_SYSTEM_PROCESSOR x86_64)
-  else()
+  elseif(${IOS_ARCH} STREQUAL "arm64")
     set(IOS_PLATFORM "iphoneos")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch arm64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch arm64")
     set(CMAKE_SYSTEM_PROCESSOR arm64)
+  elseif(${IOS_ARCH} STREQUAL "arm64e")
+    set(IOS_PLATFORM "iphoneos")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch arm64e")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch arm64e")
+    set(CMAKE_SYSTEM_PROCESSOR arm64e)
+  else()
+    message(FATAL_ERROR "Unrecognized iOS architecture '${IOS_ARCH}'")
   endif()
 
   execute_process(COMMAND xcodebuild -version -sdk ${IOS_PLATFORM} Path
@@ -47,7 +51,7 @@ if(BUILD_IOS)
 endif()
 
 message("-- BUILD_IOS:              ${BUILD_IOS}")
-message("-- BUILD_SIMULATOR:        ${BUILD_SIMULATOR}")
+message("-- IOS_ARCH:               ${IOS_ARCH}")
 message("-- CMAKE_SYSTEM_INFO_FILE: ${CMAKE_SYSTEM_INFO_FILE}")
 message("-- CMAKE_SYSTEM_NAME:      ${CMAKE_SYSTEM_NAME}")
 message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -1,10 +1,23 @@
 #!/bin/sh
 
-if [ "$1" == "release" ] || [ "$2" == "release" ]; then
+if [ "$1" == "release" ]; then
 BUILD_TYPE="Release"
 else
 BUILD_TYPE="Debug"
 fi
+
+if [ "$2" == "arm64" ]; then
+IOS_ARCH="arm64"
+elif [ "$2" == "arm64e" ]; then
+IOS_ARCH="arm64e"
+elif [ "$2" == "x86_64" ] || "$2" == "simulator" ]; then
+IOS_ARCH="x86_64"
+else
+IOS_ARCH="x86_64"
+fi
+
+# Set target iOS minver
+IOS_DEPLOYMENT_TARGET=10.10
 
 # Install build tools and recent sqlite3
 FILE=.buildtools
@@ -28,7 +41,7 @@ cd out
 
 CMAKE_PACKAGE_TYPE=tgz
 
-cmake -DBUILD_IOS=YES -DBUILD_SIMULATOR=YES -DBUILD_UNIT_TESTS=YES -DBUILD_FUNC_TESTS=YES -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
+cmake -DBUILD_IOS=YES -DIOS_ARCH=$IOS_ARCH -DIOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET -DBUILD_UNIT_TESTS=YES -DBUILD_FUNC_TESTS=YES -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
 make
 
 make package


### PR DESCRIPTION
Support arm64e architecture:
- Replaced `BUILD_SIMULATOR` CMake option with `IOS_ARCH` parameter
- Updated `C_FLAGS` and `CXX_FLAGS` in makefile
- Added architecture parameter to build-ios.sh

Support deployment target:
- Added `miphoneos-version-min=xxx` flag to `C_FLAGS` and `CXX_FLAGS` in makefile
- Defaulted to 10.10 (same as MacOS) which is Office's current minver