### PR TITLE
Retrocomputing: vs2010 (c89) example was broken some time ago

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -22,11 +22,16 @@ jobs:
         choco install --no-progress -y android-ndk
         choco install --no-progress -y android-sdk
         choco install --no-progress -y ninja
+        new-item "C:\Users\runneradmin\.android\repositories.cfg" -ItemType "file"
+        echo yes | C:\Android\android-sdk\tools\bin\sdkmanager.bat "cmake;3.10.2.4988404"
+        gci -r -i "CMake*" C:\Android
+        echo $Env:PATH
     - name: Gradle Build
       run: |
+        $Env:PATH = "C:\Android\android-sdk\cmake\3.10.2.4988404\bin;" + $Env:PATH
         cd "$Env:GITHUB_WORKSPACE\lib\android_build"
         .\gradlew.bat assemble
-    - name: Java unit tests
+    - name: Java Unit test
       run: |
         cd "$Env:GITHUB_WORKSPACE\lib\android_build"
         .\gradlew.bat maesdk:test
@@ -36,8 +41,3 @@ jobs:
       with:
         name: reports
         path: lib\android_build\maesdk\build\reports
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: maesdk
-        path: lib\android_build\maesdk\build\outputs\aar

--- a/lib/android_build/app/build.gradle
+++ b/lib/android_build/app/build.gradle
@@ -25,7 +25,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.16.4"
+            version "3.10.2"
         }
     }
 }

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -31,7 +31,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.16.4"
+            version "3.10.2"
         }
     }
 }


### PR DESCRIPTION
There's been some effort invested in mat.h to support Visual Studio 2010 (c89) standard, as in - you can actually compile the C++ SDK with vs2015-vs2017+, and then consume the resulting dynamic library from C code compiled with vs2010. The old msvcrt runtime used to be available by default in anything Windows Vista+, making it a good fit for some system code previously compiled with vs2010.

The only piece required for C89 is that local variables allocated on stack must be declared at the beginning of function. This is the only small place where it got broken by MIP SDK change. The fix is not impacting anything functionality-wise and is trying to restore the C89 example back into its functional state.

Maybe it is not as relevant in 2020, but we can still claim C89 compatibility (or at least a shim for C89) if we fix this. Sending the fix. Without that fix we'd have to upgrade the SampleC project from vs2010 to at least vs2015 (C99+), and in fact a bunch of code then can be removed.. I'd rather fix the one-liner issue than kill C89 compatibility altogether.