### PR TITLE
Remove std::move to permit elision

### DIFF
--- a/lib/http/HttpClient_Android.hpp
+++ b/lib/http/HttpClient_Android.hpp
@@ -77,7 +77,7 @@ public:
 
         HttpRequest(HttpClient_Android &parent_)
             : m_parent(parent_)
-            , m_id(std::move(parent_.NextIdString()))
+            , m_id(parent_.NextIdString())
         {}
 
         ~HttpRequest() noexcept;


### PR DESCRIPTION
It builds (well, the old one built, too) and passes the Java unit test that does not in any way test the C++ code. I assert without proof that if it compiles and the change consists of removing std::move, then it should be functionally equivalent to the version with std::move.