### PR TITLE
Fix device and system info for iOS and iOS simulators

### DIFF
--- a/lib/pal/posix/sysinfo_utils_apple.mm
+++ b/lib/pal/posix/sysinfo_utils_apple.mm
@@ -9,6 +9,11 @@ NSDictionary* copy_system_plist_dictionary(void)
     NSData *versionData = nil;
     NSString *systemVersFile = @"/System/Library/CoreServices/SystemVersion.plist";
     NSString *serverVersFile = @"/System/Library/CoreServices/ServerVersion.plist";
+#if TARGET_IPHONE_SIMULATOR
+    NSString *simulatorRoot = NSProcessInfo.processInfo.environment[@"IPHONE_SIMULATOR_ROOT"] ?: @"";
+    systemVersFile = [simulatorRoot stringByAppendingPathComponent:systemVersFile];
+    serverVersFile = [simulatorRoot stringByAppendingPathComponent:serverVersFile];
+#endif
     
     if([fileManager isReadableFileAtPath:systemVersFile])
         versionData = [NSData dataWithContentsOfFile:systemVersFile];
@@ -50,7 +55,11 @@ std::string GetDeviceOsVersion()
 
 std::string GetDeviceOsRelease()
 {
+#if TARGET_OS_IPHONE
+    NSString* value = get_system_value(@"ProductVersion");
+#else
     NSString* value = get_system_value(@"ProductUserVisibleVersion");
+#endif
     return std::string([value UTF8String]);
 }
 

--- a/lib/pal/posix/sysinfo_utils_ios.mm
+++ b/lib/pal/posix/sysinfo_utils_ios.mm
@@ -3,11 +3,18 @@
 #include "sysinfo_utils_ios.hpp"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#include <sys/utsname.h>
 
 std::string GetDeviceModel()
 {
-    std::string deviceModel { [[[UIDevice currentDevice] model] UTF8String] };
-    return deviceModel;
+#if TARGET_IPHONE_SIMULATOR
+    NSString* modelId = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
+    return std::string([modelId UTF8String]);
+#else
+    utsname name;
+    uname(&name);
+    return std::string(name.machine);
+#endif
 }
 
 std::string GetDeviceId()


### PR DESCRIPTION
* iOS doesn't have `ProductUserVisibleVersion` key in `SystemVersion.plist`.
* Things are quite different on iOS simulators.
* `UIDevice.currentDevice.model` only returns a general `"iPhone"` or `"iPad"` device class but not a specific model.