### PR TITLE
Ubuntu 20.04-LTS support

### DIFF
--- a/build-gtest.sh
+++ b/build-gtest.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+if [ "$1" == "ios" ]; then
+  IOS_BUILD="YES"
+  # Skip building tests on iOS as there is no way to run them
+  BUILD_TESTS="OFF"
+else
+  IOS_BUILD="NO"
+  BUILD_TESTS="ON"
+fi
+
 cd `dirname $0`
 
 # Use latest Google Test
@@ -21,9 +30,10 @@ mkdir -p build || true
 cd build
 cmake -Dgtest_build_samples=OFF \
       -Dgmock_build_samples=OFF \
-      -Dgtest_build_tests=OFF \
-      -Dgmock_build_tests=OFF \
+      -Dgtest_build_tests=$BUILD_TESTS \
+      -Dgmock_build_tests=$BUILD_TESTS \
       -DCMAKE_CXX_FLAGS="-fPIC $CXX_FLAGS" \
+      -DBUILD_IOS=$IOS_BUILD \
       ..
 make
 # CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -1,16 +1,23 @@
 #!/bin/sh
 
-if [ "$1" == "release" ]; then
+if [ "$1" == "clean" ]; then
+ rm -f CMakeCache.txt *.cmake
+ rm -rf out
+ rm -rf .buildtools
+# make clean
+fi
+
+if [ "$1" == "release" ] || [ "$2" == "release" ]; then
 BUILD_TYPE="Release"
 else
 BUILD_TYPE="Debug"
 fi
 
-if [ "$2" == "arm64" ]; then
+if [ "$2" == "arm64" ] || [ "$3" == "arm64" ]; then
 IOS_ARCH="arm64"
-elif [ "$2" == "arm64e" ]; then
+elif [ "$2" == "arm64e" ] || [ "$3" == "arm64e" ]; then
 IOS_ARCH="arm64e"
-elif [ "$2" == "x86_64" ] || "$2" == "simulator" ]; then
+elif [ "$2" == "x86_64" ] || [ "$2" == "simulator" ] || [ "$3" == "x86_64" ] || [ "$3" == "simulator" ]; then
 IOS_ARCH="x86_64"
 else
 IOS_ARCH="x86_64"
@@ -23,7 +30,7 @@ IOS_DEPLOYMENT_TARGET=10.0
 FILE=.buildtools
 OS_NAME=`uname -a`
 if [ ! -f $FILE ]; then
-  tools/setup-buildtools-mac.sh
+  tools/setup-buildtools-apple.sh ios
 # Assume that the build tools have been successfully installed
 echo > $FILE
 fi

--- a/build-tests-ios.sh
+++ b/build-tests-ios.sh
@@ -6,12 +6,6 @@ SIMULATOR=${2:-iPhone 8}
 set -e
 ./build-ios.sh ${SKU}
 
-if [ -d "/Applications/Xcode_11.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/" ] 
-then
-  echo "Xcode 11.4.1 test build is not supported yet (see https://forums.developer.apple.com/thread/130684 )"
-  exit 0
-fi
-
 cd tests/unittests
 xcodebuild test -scheme iOSUnitTests -destination "platform=iOS Simulator,name=$SIMULATOR"
 

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ FILE=.buildtools
 OS_NAME=`uname -a`
 if [ ! -f $FILE ]; then
 case "$OS_NAME" in
- *Darwin*) tools/setup-buildtools-mac.sh ;;
+ *Darwin*) tools/setup-buildtools-apple.sh ;;
  *Linux*)  [[ -z "$NOROOT" ]] && sudo tools/setup-buildtools.sh || echo "No root: skipping build tools installation." ;;
  *)        echo "WARNING: unsupported OS $OS_NAME , skipping build tools installation.."
 esac

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required(VERSION 2.6.4)
 
+# If building for iOS, set all the iOS options
+if(BUILD_IOS)
+  set(TARGET_ARCH "APPLE")
+  set(IOS True)
+  set(APPLE True)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=10.0")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=10.0 -std=c++11")
+  set(IOS_PLATFORM "iphonesimulator")
+  set(CMAKE_SYSTEM_PROCESSOR x86_64)
+  execute_process(COMMAND xcodebuild -version -sdk ${IOS_PLATFORM} Path
+    OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  message("-- CMAKE_OSX_SYSROOT       ${CMAKE_OSX_SYSROOT}")
+endif()
+
 project( googletest-distribution )
 
 enable_testing()

--- a/tools/setup-buildtools-apple.sh
+++ b/tools/setup-buildtools-apple.sh
@@ -26,6 +26,6 @@ cd $SQLITE_PKG
 cd ..
 
 ## Build Google Test framework
-./build-gtest.sh
+./build-gtest.sh $1
 
 ## Install dotnet for test server


### PR DESCRIPTION
**Why it is important for us to support this environment**

We run on **ubuntu-latest** , which ironically not exactly the latest yet, because GitHub Actions upgrade is a bit behind the latest. Now recently we saw how the 'latest' is breaking iOS Simulator (#330). So if we don't proactively get Ubuntu 20.04 support added right now --- soon enough our CI on Linux is gonna break.. I don't want it to break.

Thus... since long-term supported version of latest **Ubuntu 20.04 LTS (Focal Fossa)** has been released. It's also available on Windows 10 WSL - people might start using it soon, **let's start supporting it** before our GitHub Actions runner is upgraded to it.

There are several issues:
- compiler warnings with new gcc-9
- older Google Test no longer compiles under gcc-9 - have to replace by latest from their master. Doing it selectively right now just for Ubuntu 20.04 to avoid regressions on other OS.
- adding base Dockerfile for Ubuntu 20.04

What's covered by this commit:
- SDK builds successfully
- .deb package gets created
- SDK works
- All tests run
- _Almost_ all tests pass

What's not covered yet:
- 2-3 'non-essential' tests are occasionally flaky (some timing issue)
- gcc-9 compiler warnings cleanup might require 20-30 lines of code clean-up

I don't have time to cover the tests yet, neither have time to clean the gcc-9 specific warnings. These warnings are not observed on msvc2019 and recent clang.

Manually verified the build in Win 10 WSL with Ubuntu 20.04. And on Mac OS X using Docker:
```
bash-3.2$ ./build-docker.sh ubuntu20.04
[...several cups of coffee later...]
CPack: - package: /build/out/mat-sdk-3.3.123-ubuntu-20.04-x86_64.deb generated.
...
```

All builds. SDK works. No changes to other builds. Not adding as part of official build loop yet.

