### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @kindbe @maxgolov @mkoscumb @reyang
+*       @kindbe @maxgolov @mkoscumb @reyang @bliptec @larvacea


### PR DESCRIPTION
I'd like to propose adding Jason and Martin as code owners for reviews:
- @bliptec   - Jason is the key point of contact and contributor for Edge Data Client.
- @larvacea  - Martin is the key point of contact for Office Telemetry on Android.

What's your opinion on this?