### PR TITLE
[Objective-C] Specify return value in ODWLogManager

### DIFF
--- a/wrappers/obj-c/ODWLogManager.h
+++ b/wrappers/obj-c/ODWLogManager.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param tenantToken A string that contains the tenant token.
  @return An ODWLogger instance
  */
-+(nullable id)loggerWithTenant:(NSString *)tenantToken;
++(nullable ODWLogger *)loggerWithTenant:(NSString *)tenantToken;
 
 /*!
  @brief Initializes the telemetry logging system with the default configuration, using the specified tenant token and source.
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param source A string that contains the name of the source of events.
  @return An ODWLogger pointer that points to the logger for the specified tenantToken and source.
  */
-+(nullable id)loggerWithTenant:(NSString *)tenantToken
++(nullable ODWLogger *)loggerWithTenant:(NSString *)tenantToken
                   source:(NSString *)source;
 
 /*!
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param source A string that contains the name of the source of events sent by this logger instance.
  @return An ODWLogger instance that points to the logger for source.
  */
-+(nullable id)loggerForSource:(NSString *)source;
++(nullable ODWLogger *)loggerForSource:(NSString *)source;
 
 /*!
  @brief Attempts to send any pending telemetry events that are currently cached either in memory, or on disk. Use this method if your event can't wait for automatic timed upload

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -10,12 +10,12 @@ LOGMANAGER_INSTANCE
 
 @implementation ODWLogManager
 
-+(nullable id)loggerWithTenant:(nonnull NSString *)tenantToken
++(nullable ODWLogger *)loggerWithTenant:(nonnull NSString *)tenantToken
 {
     return [ODWLogManager loggerWithTenant:tenantToken source:@""];
 }
 
-+(nullable id)loggerWithTenant:(nonnull NSString *)tenantToken
++(nullable ODWLogger *)loggerWithTenant:(nonnull NSString *)tenantToken
                   source:(nonnull NSString *)source
 {
     static const BOOL initialized = [ODWLogManager initializeLogManager:tenantToken];
@@ -67,7 +67,7 @@ LOGMANAGER_INSTANCE
     return logger != NULL;
 }
 
-+(nullable id)loggerForSource:(nonnull NSString *)source
++(nullable ODWLogger *)loggerForSource:(nonnull NSString *)source
 {
     std::string strSource = std::string([source UTF8String]);
     ILogger* logger = LogManager::GetLogger(strSource);


### PR DESCRIPTION
We can specify the return value in ODWLogManager functions in order to make it easier to use the object that will be returned. Currently the Swift projection of these functions returns an object of type `Any?`, and with this change it will return an object of type `ODWLogger?`.