### PR TITLE
Fix missing transmit profile function in min-sdk.

### DIFF
--- a/lib/pal/universal/WindowsRuntimeDeviceInformationImpl.cpp
+++ b/lib/pal/universal/WindowsRuntimeDeviceInformationImpl.cpp
@@ -44,7 +44,8 @@ namespace PAL_NS_BEGIN {
                 }
 
                 ///// IDeviceInformation API
-                DeviceInformationImpl::DeviceInformationImpl() :m_registeredCount(0),
+                DeviceInformationImpl::DeviceInformationImpl(MAT::IRuntimeConfig& /*configuration*/) :
+                    m_registeredCount(0),
                     m_info_helper()
                 {
                     m_os_architecture = WindowsEnvironmentInfo::GetProcessorArchitecture();

--- a/lib/pal/universal/WindowsRuntimeSystemInformationImpl.cpp
+++ b/lib/pal/universal/WindowsRuntimeSystemInformationImpl.cpp
@@ -21,12 +21,12 @@ namespace PAL_NS_BEGIN {
     const string WindowsPhoneOSName = "Windows for Phones";
     const string DeviceFamily_Mobile = "Windows.Mobile";
 
-    std::shared_ptr<ISystemInformation> SystemInformationImpl::Create()
+    std::shared_ptr<ISystemInformation> SystemInformationImpl::Create(IRuntimeConfig& configuration)
     {
-        return std::make_shared<SystemInformationImpl>();
+        return std::make_shared<SystemInformationImpl>(configuration);
     }
 
-    SystemInformationImpl::SystemInformationImpl(IRuntimeConfig& configuration)
+    SystemInformationImpl::SystemInformationImpl(IRuntimeConfig& /*configuration*/)
         : m_info_helper()
     {
         auto version = Package::Current->Id->Version;


### PR DESCRIPTION
[PR 321](https://github.com/microsoft/cpp_client_telemetry/pull/321) added a strongly typed function for TransmitProfile loading, but didn't update the stub header.