### PR TITLE
Fix most remaining task cancellation race conditions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -78,6 +78,10 @@ if(PAL_IMPLEMENTATION STREQUAL "CPP11")
       list(APPEND SRCS
         pal/posix/sysinfo_utils_ios.mm
       )
+    else()
+      list(APPEND SRCS
+        pal/posix/sysinfo_utils_mac.cpp
+      )
     endif()
   endif()
   list(APPEND SRCS

--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -61,12 +61,6 @@ void get_platform_uuid(char * buf, int bufSize)
 
 #endif // TARGET_MAC_OS
 
-#if TARGET_OS_IPHONE
-
-#include "sysinfo_utils_ios.hpp"
-
-#endif // TARGET_OS_IPHONE
-
 std::string get_app_name()
 {
     std::vector<char> appId(PATH_MAX+1, 0);
@@ -220,11 +214,7 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
 #if defined(__APPLE__)
     // FIXME: [MG] - This is not the most elegant way of obtaining it
     cache["devMake"] = "Apple";
-#if TARGET_OS_IPHONE
     cache["devModel"] = GetDeviceModel();
-#else
-    cache["devModel"] = Exec("sysctl hw.model | awk '{ print $2 }'");
-#endif // TARGET_OS_IPHONE
     cache["osName"] = GetDeviceOsName();
     cache["osVer"] = GetDeviceOsVersion();
     cache["osRel"] = GetDeviceOsRelease();
@@ -272,14 +262,10 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
     if (!get("devId").compare(""))
     {
 #ifdef __APPLE__
+        std::string contents = GetDeviceId();
 #if TARGET_OS_IPHONE
         cache["devId"] = "i:";
-        std::string contents = GetDeviceId();
 #else
-        // Microsoft Edge bug 21528330
-        // We were unable to use get_platform_uuid to obtain Device Id
-        // in render processes.
-        std::string contents = Exec(R"(ioreg -d2 -c IOPlatformExpertDevice | awk -F\" '/IOPlatformUUID/{print $(NF-1)}')");
         cache["devId"] = "u:";
 #endif // TARGET_OS_IPHONE
         cache["devId"] += MAT::GUID_t(contents.c_str()).to_string();

--- a/lib/pal/posix/sysinfo_utils_apple.hpp
+++ b/lib/pal/posix/sysinfo_utils_apple.hpp
@@ -12,4 +12,8 @@ std::string GetDeviceOsRelease();
 
 std::string GetDeviceOsBuild();
 
+std::string GetDeviceModel();
+
+std::string GetDeviceId();
+
 #endif /* LIB_PAL_POSIX_SYSINFO_UTILS_IOS_HPP_ */

--- a/lib/pal/posix/sysinfo_utils_ios.hpp
+++ b/lib/pal/posix/sysinfo_utils_ios.hpp
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-
-#include <string>
-
-std::string GetDeviceModel();
-
-std::string GetDeviceId();

--- a/lib/pal/posix/sysinfo_utils_ios.mm
+++ b/lib/pal/posix/sysinfo_utils_ios.mm
@@ -1,33 +1,35 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-#include "sysinfo_utils_ios.hpp"
+#include "sysinfo_utils_apple.hpp"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#include <sys/utsname.h>
 
 std::string GetDeviceModel()
 {
+    @autoreleasepool {
 #if TARGET_IPHONE_SIMULATOR
-    NSString* modelId = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
-    return std::string([modelId UTF8String]);
+        NSString* modelId = NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
+        return std::string([modelId UTF8String]);
 #else
-    utsname name;
-    uname(&name);
-    return std::string(name.machine);
+        std::string deviceModel { [[[UIDevice currentDevice] model] UTF8String] };
+        return deviceModel;
 #endif
+    }
 }
 
 std::string GetDeviceId()
 {
-    NSUUID *nsuuid = [[UIDevice currentDevice] identifierForVendor];
-    if (nsuuid)
-    {
-        std::string deviceId { [[nsuuid UUIDString] UTF8String] };
-        return deviceId;
-    }
-    else
-    {
-        std::string emptyString;
-        return emptyString;
+    @autoreleasepool {
+        NSUUID *nsuuid = [[UIDevice currentDevice] identifierForVendor];
+        if (nsuuid)
+        {
+            std::string deviceId { [[nsuuid UUIDString] UTF8String] };
+            return deviceId;
+        }
+        else
+        {
+            std::string emptyString;
+            return emptyString;
+        }
     }
 }

--- a/lib/pal/posix/sysinfo_utils_mac.cpp
+++ b/lib/pal/posix/sysinfo_utils_mac.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+#include "sysinfo_utils_apple.hpp"
+#include <sys/sysctl.h>
+#include <unistd.h>
+#include <uuid/uuid.h>
+#include <vector>
+
+#define EMPTY_GUID "00000000-0000-0000-0000-000000000000"
+
+std::string GetDeviceModel()
+{
+    static const char *query = "hw.model";
+    size_t size = 0;
+    std::vector<char> deviceModelBuffer;
+    std::string deviceModel { };
+    if (sysctlbyname(query, nullptr, &size, nullptr, 0) == 0)
+    {
+        deviceModelBuffer.resize(size);
+        if (sysctlbyname(query, deviceModelBuffer.data(), &size, nullptr, 0) == 0)
+        {
+            deviceModel = deviceModelBuffer.data();
+        }
+    }
+
+    return deviceModel;
+}
+
+std::string GetDeviceId()
+{
+    uuid_t uuidBytes;
+    const struct timespec spec = {1, 0};
+    int hostUUIDResult = gethostuuid(uuidBytes, &spec);
+    if (hostUUIDResult == 0)
+    {
+        char deviceGuid[37] = {0};
+        uuid_unparse(uuidBytes, deviceGuid);
+        std::string deviceId{deviceGuid};
+        return deviceId;
+    }
+
+    return {EMPTY_GUID};
+}


### PR DESCRIPTION
Improves worker thread task cancellation by:
1. Mostly fixing an issue where tasks wouldn't be properly canceled if they happened to be running during the cancel call. This was exacerbated by the SDK trying to pause multiple times in the process of shutting down, and the first failed cancel would incorrectly clear m_isUploadScheduled. Now, m_isUploadScheduled isn't cleared unless the task was actually canceled.
It is "mostly fixed" because there's still the possibility of multiple uploads being scheduled at one time, if the first one is currently executing when a new one tries to cancel/override it. Conceivably, we could be unlucky enough to shut down while that first event is still executing -- resulting in the second upload task getting quickly canceled, and the first continuing to run (and cause access violations) while the SDK is shutting down.
It's possible to fully fix by waiting for tasks to finish during all pause calls, but this might negatively impact SDK performance, and doesn't seem to be a likely scenario (even on many millions of devices)
2. Changing the bounded-wait-cancel to use a timed mutex, instead of putting the thread to sleep. This should provide a better hint to the operating system about what should be scheduled next (if CPU time is heavily contended) and should help alleviate unnecessary extra waiting.

I feel like there's still significant improvements that could be made here, especially as it might relate to #271, but those would require a larger refactor.

I think this should fix the rest of the access-violation-on-shutdown issues we're observing in Edge, which were originally partially fixed by #266, and is related to issue #258 