### PR TITLE
Update build-android.yml to resolve GitHub Action build issue

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Chocolatey
       run: |
+        $Env:ANDROID_SDK_ROOT = "C:\Android\android-sdk"
         gci env:* | sort-object name
         choco install --no-progress -y android-sdk
         choco install --no-progress -y ninja
@@ -32,12 +33,19 @@ jobs:
         cd "$Env:GITHUB_WORKSPACE\lib\android_build"
         .\gradlew.bat assemble
       env:
-        ANDROID_NDK: "C:\\Android\\android-ndk-r21"
-        ANDROID_NDK_HOME: "C:\\Android\\android-ndk-r21"
+        ANDROID_SDK_ROOT: "C:\\Android\\android-sdk"
+        ANDROID_HOME: "C:\\Android\\android-sdk"
+        ANDROID_NDK: "C:\\Android\\android-ndk-r20"
+        ANDROID_NDK_HOME: "C:\\Android\\android-ndk-r20"
     - name: Java Unit test
       run: |
         cd "$Env:GITHUB_WORKSPACE\lib\android_build"
         .\gradlew.bat maesdk:test
+      env:
+        ANDROID_SDK_ROOT: "C:\\Android\\android-sdk"
+        ANDROID_HOME: "C:\\Android\\android-sdk"
+        ANDROID_NDK: "C:\\Android\\android-ndk-r20"
+        ANDROID_NDK_HOME: "C:\\Android\\android-ndk-r20"
     - name: Upload Reports
       if: failure()
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
Android NDK installation patch. This is just a stab in the dark. We already marked Android-Windows build as OPTIONA: so broken Android build loop does not prevent the merges BUT marks all PRs as "Failed" with a Red checkmark. This triggers OCD in me. The goal is to get back to all CI loops having Green checkmark.