### PR TITLE
UserInfo_Language in Obj-C is not a BCP-47 locale tag.

### DIFF
--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -41,8 +41,14 @@ LOGMANAGER_INSTANCE
     
     // Obtain semantics values
     NSBundle* bundle = [NSBundle mainBundle];
-    std::string strUserLocale = std::string([[NSString stringWithFormat:@"%@-%@", [[NSLocale currentLocale] languageCode], [[NSLocale currentLocale] countryCode]] UTF8String]);
-    
+    NSLocale* locale = [NSLocale currentLocale];
+    std::string strUserLocale = std::string([[locale languageCode] UTF8String]);
+    NSString* countryCode = [locale countryCode];
+    if ([countryCode length] != 0)
+    {
+        strUserLocale += [[NSString stringWithFormat:@"-%@", countryCode] UTF8String];
+    }
+        
     NSString* bundleVersion = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     std::string strBundleVersion = bundleVersion == nil ? std::string {} : std::string([bundleVersion UTF8String]);
     NSArray<NSString *> *localizations = [bundle preferredLocalizations];


### PR DESCRIPTION
Per https://github.com/microsoft/common-schema/blob/master/PartA/user.md UserInfo_Language should be a BCP-47 tag. Furthermore, the legacy Aria SDK also uses a BCP-47 tag for this field.

NSLocale's localeIdentifier does not return a BCP-47 locale tag, nor does it provide a helper for that purpose (sadly), so this change formats a string to do so.