### PR TITLE
Wrap C++ exceptions into NSException

### DIFF
--- a/wrappers/obj-c/ODWDiagnosticDataViewer.mm
+++ b/wrappers/obj-c/ODWDiagnosticDataViewer.mm
@@ -24,17 +24,9 @@ std::shared_ptr<DefaultDataViewer> _viewer;
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
     }
 }
 
@@ -64,17 +56,9 @@ std::shared_ptr<DefaultDataViewer> _viewer;
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
     }
 
     return result;
@@ -113,17 +97,9 @@ std::shared_ptr<DefaultDataViewer> _viewer;
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
     }
 
     return result;

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -11,53 +11,15 @@ using namespace Microsoft::Applications::Events;
 
 +(void)setMaxTeardownUploadTimeInSec:(int)maxTeardownUploadTimeInSec
 {
-    try
-    {
-        auto& config = LogManager::GetLogConfiguration();
-        config[CFG_INT_MAX_TEARDOWN_TIME] = maxTeardownUploadTimeInSec;
-	}
-    catch (const std::exception &e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
-    }
+    auto& config = LogManager::GetLogConfiguration();
+    config[CFG_INT_MAX_TEARDOWN_TIME] = maxTeardownUploadTimeInSec;
 }
 
 +(void)setEnableTrace:(bool)enableTrace
 {
-    try
-    {
-        auto& config = LogManager::GetLogConfiguration();
-        config[CFG_BOOL_ENABLE_TRACE] = enableTrace;
-        _enableTrace = enableTrace;
-    }
-    catch (const std::exception &e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
-    }
+    auto& config = LogManager::GetLogConfiguration();
+    config[CFG_BOOL_ENABLE_TRACE] = enableTrace;
+    _enableTrace = enableTrace;
 }
 
 +(bool)enableTrace

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -34,17 +34,9 @@ LOGMANAGER_INSTANCE
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
     }
 
     if(!logger) return nil;
@@ -102,17 +94,9 @@ LOGMANAGER_INSTANCE
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
     }
     
     return logger != NULL;
@@ -130,17 +114,9 @@ LOGMANAGER_INSTANCE
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what()];
     }
 
     if(!logger) return nil;

--- a/wrappers/obj-c/ODWLogger.h
+++ b/wrappers/obj-c/ODWLogger.h
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, ODWSessionState)
  @brief Logs a failure event (such as an application exception), taking a signature, failure details, and event properties.
  @param signature A string that identifies the bucket of the failure.
  @param detail A string that contains a description of the failure.
- @param properties Properties of the failure event, encapsulated within an ODWEventProperties object.
+ @param properties Properties of the failure event, encapsulated within an ODWEventProperties object. <b>Note:</b> This value can be null.
  */
 -(void)logFailureWithSignature:(NSString *)signature
                          detail:(NSString *)detail

--- a/wrappers/obj-c/ODWLogger.mm
+++ b/wrappers/obj-c/ODWLogger.mm
@@ -230,6 +230,11 @@ using namespace MAT;
     }
 }
 
++(void)raiseException:(const char *)message
+{
+    [NSException raise:@"1DSSDKException" format:[NSString stringWithFormat:@"%s", message]];
+}
+
 void PerformActionWithCppExceptionsCatch(void (^block)())
 {
     try
@@ -240,17 +245,9 @@ void PerformActionWithCppExceptionsCatch(void (^block)())
     {
         if ([ODWLogConfiguration surfaceCppExceptions])
         {
-            throw;
+            [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
-    }
-    catch (const std::exception *e)
-    {
-        if ([ODWLogConfiguration surfaceCppExceptions])
-        {
-            throw;
-        }
-        [ODWLogger traceException: e->what() ];
     }
 }
 

--- a/wrappers/obj-c/ODWLogger_private.h
+++ b/wrappers/obj-c/ODWLogger_private.h
@@ -22,7 +22,12 @@ using namespace MAT;
 /*!
  @brief Traces C++ exception message. This method might be only used internally by wrapper.
  */
-+ (void)traceException:(const char*)message;
++(void)traceException:(const char*)message;
+
+/*!
+ @brief Raises a NSException. This method might be only used internally by wrapper.
+ */
++(void)raiseException:(const char *)message;
 
 /*!
  @brief Performs block and handles inner SDK C++ exceptions. This method might be only used internally by wrapper.


### PR DESCRIPTION
Rather than throwing C++ exceptions into Obj-C callers wrap exception into NSException. This keeps Obj-C consumers worry free from catching exceptions.