### PR TITLE
Fix warning in ODWDiagnosticDataViewer class

### DIFF
--- a/lib/tpm/TransmissionPolicyManager.cpp
+++ b/lib/tpm/TransmissionPolicyManager.cpp
@@ -326,7 +326,7 @@ namespace ARIASDK_NS_BEGIN {
         }
         else
         {
-            finishUpload(ctx, 0);
+            finishUpload(ctx, m_timerdelay);
         }
     }
 

--- a/tests/functests/BasicFuncTests.cpp
+++ b/tests/functests/BasicFuncTests.cpp
@@ -606,7 +606,7 @@ TEST_F(BasicFuncTests, sendSamePriorityNormalEvents)
     event2.SetProperty("cc_property", "cc_value", CustomerContentKind_GenericData);
     logger->LogEvent(event2);
 
-    waitForEvents(2, 3);
+    waitForEvents(3, 3);
     for (const auto &evt : { event, event2 })
     {
         verifyEvent(evt, find(evt.GetName()));


### PR DESCRIPTION
Closures that do not take in properties should be declared as `void (^)(void)` rather than `void (^)()`. This will silence a Xcode warning, and there isn't a code change needed on the consumption side.

[SO link for reference](https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9)