### PR TITLE
Update GetDeviceOsName on Mac and iOS to align with common schema

### DIFF
--- a/lib/include/public/TransmitProfiles.hpp
+++ b/lib/include/public/TransmitProfiles.hpp
@@ -48,40 +48,61 @@ namespace ARIASDK_NS_BEGIN
         /// <summary>
         /// The network cost, as one of the MAT::NetworkCost enumeration values.
         /// </summary>
-        NetworkCost      netCost;         // any|unknown|low|high|restricted
+        NetworkCost      netCost = NetworkCost_Any;         // any|unknown|low|high|restricted
 
         /// <summary>
         /// The power state, as one of the MAT::PowerSource enumeration values.
         /// </summary>
-        PowerSource      powerState;      // any|unknown|battery|charging
+        PowerSource      powerState = PowerSource_Any;      // any|unknown|battery|charging
 
         /// <summary>
         /// The type of network, as one of the MAT::NetworkType enumeration values.
         /// <b>Note:</b> This member is reserved for future use.
         /// </summary>
-        NetworkType      netType;         // reserved for future use
+        NetworkType      netType = NetworkType_Any;         // reserved for future use
 
         /// <summary>
         /// The speed of the network.
         /// <b>Note:</b> This member is reserved for future use.
         /// </summary>
-        unsigned         netSpeed;        // reserved for future use
+        unsigned         netSpeed = 0;                      // reserved for future use
 
         /// <summary>
-        /// A vector on integers that contain per-priority transmission timers.
+        /// A vector of integers that contain per-priority transmission timers.
         /// </summary>
-        std::vector<int> timers;          // per-priority transmission timers
+        std::vector<int> timers;                            // per-priority transmission timers
 
         /// <summary>
         /// The TransmitProfileRule structure default constructor.
         /// </summary>
-        TransmitProfileRule() {
-            netCost = NetworkCost_Any;
-            netType = NetworkType_Any;
-            netSpeed = 0;
-            powerState = PowerSource_Any;
-            timers.clear();
-        }
+        TransmitProfileRule() noexcept = default;
+
+        /// <summary>
+        /// TransmitProfileRule constructor taking a collection of timers.
+        /// </summary>
+        /// <param name="timers">A vector of integers that contain per-priority transmission timers.</param>
+        TransmitProfileRule(std::vector<int>&& timers)
+           : timers(std::move(timers)) { }
+
+        /// <summary>
+        /// TransmitProfileRule constructor taking a NetworkCost and a collection of timers.
+        /// </summary>
+        /// <param name="networkCost">The network cost, as one of the MAT::NetworkCost enumeration values.</param>
+        /// <param name="timers">A vector of integers that contain per-priority transmission timers.</param>
+        TransmitProfileRule(NetworkCost networkCost, std::vector<int>&& timers)
+           : netCost(networkCost)
+           , timers(std::move(timers)) { }
+
+        /// <summary>
+        /// TransmitProfileRule constructor taking a NetworkCost, PowerSource, and a collection of timers.
+        /// </summary>
+        /// <param name="networkCost">The network cost, as one of the MAT::NetworkCost enumeration values.</param>
+        /// <param name="powerSource">The power state, as one of the MAT::PowerSource enumeration values.</param>
+        /// <param name="timers">A vector of integers that contain per-priority transmission timers.</param>
+        TransmitProfileRule(NetworkCost networkCost, PowerSource powerSource, std::vector<int>&& timers)
+           : netCost(networkCost)
+           , powerState(powerSource)
+           , timers(std::move(timers)) { }
 
     } TransmitProfileRule;
 

--- a/lib/tpm/TransmitProfiles.cpp
+++ b/lib/tpm/TransmitProfiles.cpp
@@ -11,72 +11,23 @@
 
 using namespace MAT;
 using namespace std;
-using nlohmann::json;
 
 #ifdef _WIN32
 #include <windows.h> // for EXCEPTION_ACCESS_VIOLATION
 #include <excpt.h>
 #endif
 
-/// <summary>
-/// Default JSON config for Transmit Profiles
-/// </summary>
-static const char* const defaultProfiles = R"(
-[{
-    "name": "REAL_TIME",
-    "rules": [
-    { "netCost": "restricted",                              "timers": [ -1, -1, -1 ] },
-    { "netCost": "high",        "powerState": "unknown",    "timers": [ 16,  8,  4 ] },
-    { "netCost": "high",        "powerState": "battery",    "timers": [ 16,  8,  4 ] },
-    { "netCost": "high",        "powerState": "charging",   "timers": [ 12,  6,  3 ] },
-    { "netCost": "low",         "powerState": "unknown",    "timers": [  8,  4,  2 ] },
-    { "netCost": "low",         "powerState": "battery",    "timers": [  8,  4,  2 ] },
-    { "netCost": "low",         "powerState": "charging",   "timers": [  4,  2,  1 ] },
-    { "netCost": "unknown",     "powerState": "unknown",    "timers": [  8,  4,  2 ] },
-    { "netCost": "unknown",     "powerState": "battery",    "timers": [  8,  4,  2 ] },
-    { "netCost": "unknown",     "powerState": "charging",   "timers": [  4,  2,  1 ] },
-    {                                                       "timers": [ -1, -1, -1 ] }
-    ]
-}, {
-    "name": "NEAR_REAL_TIME",
-    "rules": [
-    { "netCost": "restricted",                              "timers": [ -1, -1, -1 ] },
-    { "netCost": "high",        "powerState": "unknown",    "timers": [ -1, 24, 12 ] },
-    { "netCost": "high",        "powerState": "battery",    "timers": [ -1, 24, 12 ] },
-    { "netCost": "high",        "powerState": "charging",   "timers": [ -1, 18,  9 ] },
-    { "netCost": "low",         "powerState": "unknown",    "timers": [ 24, 12,  6 ] },
-    { "netCost": "low",         "powerState": "battery",    "timers": [ 24, 12,  6 ] },
-    { "netCost": "low",         "powerState": "charging",   "timers": [ 12,  6,  3 ] },
-    { "netCost": "unknown",     "powerState": "unknown",    "timers": [ 24, 12,  6 ] },
-    { "netCost": "unknown",     "powerState": "battery",    "timers": [ 24, 12,  6 ] },
-    { "netCost": "unknown",     "powerState": "charging",   "timers": [ 12,  6,  3 ] },
-    {                                                       "timers": [ -1, -1, -1 ] }
-    ]
-}, {
-    "name": "BEST_EFFORT",
-    "rules": [
-    { "netCost": "restricted",                              "timers": [ -1, -1, -1 ] },
-    { "netCost": "high",        "powerState": "unknown",    "timers": [ -1, 72, 36 ] },
-    { "netCost": "high",        "powerState": "battery",    "timers": [ -1, 72, 36 ] },
-    { "netCost": "high",        "powerState": "charging",   "timers": [ -1, 54, 27 ] },
-    { "netCost": "low",         "powerState": "unknown",    "timers": [ 72, 36, 18 ] },
-    { "netCost": "low",         "powerState": "battery",    "timers": [ 72, 36, 18 ] },
-    { "netCost": "low",         "powerState": "charging",   "timers": [ 36, 18,  9 ] },
-    { "netCost": "unknown",     "powerState": "unknown",    "timers": [ 72, 36, 18 ] },
-    { "netCost": "unknown",     "powerState": "battery",    "timers": [ 72, 36, 18 ] },
-    { "netCost": "unknown",     "powerState": "charging",   "timers": [ 36, 18,  9 ] },
-    {                                                       "timers": [ -1, -1, -1 ] }
-    ]
-}]
-)";
+static const char* const defaultRealTimeProfileName = "REAL_TIME";
+static const char* const defaultNearRealTimeProfileName = "NEAR_REAL_TIME";
+static const char* const defaultBestEffortProfileName = "BEST_EFFORT";
 
-static set<string, std::greater<string>> defaultProfileNames = {
-    "REAL_TIME",
-    "NEAR_REAL_TIME",
-    "BEST_EFFORT"
+static const set<string, std::greater<string>> defaultProfileNames = {
+    string{defaultRealTimeProfileName},
+    string{defaultNearRealTimeProfileName},
+    string{defaultBestEffortProfileName}
 };
 
-static const char* DEFAULT_PROFILE = "REAL_TIME";
+static const char* DEFAULT_PROFILE = defaultRealTimeProfileName;
 
 /// <summary>
 /// Compile-time map of text fields to struct fields and their types.
@@ -208,13 +159,13 @@ namespace ARIASDK_NS_BEGIN {
 
 	 void TransmitProfiles::EnsureDefaultProfiles() noexcept
 	 {
-         LOCK_PROFILES;
+        LOCK_PROFILES;
         if (profiles.size() == 0)
         {
             LOG_TRACE("Loading default profiles...");
             reset();
         }
-	 }
+    }
 
     /// <summary>
     /// Parse JSON configration describing transmit profiles
@@ -228,6 +179,7 @@ namespace ARIASDK_NS_BEGIN {
         // Temporary storage for the new profiles that we use before we copy to current profiles
         std::vector<TransmitProfileRules> newProfiles;
 
+        using nlohmann::json;
         try
         {
             json temp = json::parse(profiles_json.c_str());
@@ -390,7 +342,52 @@ namespace ARIASDK_NS_BEGIN {
     /// Reset transmit profiles to defaults.
     /// </summary>
     void TransmitProfiles::reset() {
-        parse(defaultProfiles);
+        const TransmitProfileRules realTimeProfile{ std::string{ defaultRealTimeProfileName },
+        {
+            { NetworkCost::NetworkCost_Roaming, {-1, -1, -1} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {16, 8, 4} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {16, 8, 4} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {12, 6, 3} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {8, 4, 2} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {8, 4, 2} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {4, 2, 1} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {8, 4, 2} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {8, 4, 2} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {4, 2, 1} },
+            { {-1, -1, -1} }
+        }};
+
+        const TransmitProfileRules nearRealTimeProfile{ std::string{ defaultNearRealTimeProfileName },
+        {
+            { NetworkCost::NetworkCost_Roaming, {-1, -1, -1} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 24, 12} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 24, 12} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 18, 9} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {24, 12, 6} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {24, 12, 6} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {12, 6, 3} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {24, 12, 6} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {24, 12, 6} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {12, 6, 3} },
+            { {-1, -1, -1} }
+        }};
+
+        const TransmitProfileRules bestEffortProfile{ std::string{ defaultBestEffortProfileName },
+        {
+            { NetworkCost::NetworkCost_Roaming, {-1, -1, -1} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 72, 36} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 72, 36} },
+            { NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 54, 27} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {72, 36, 18} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {72, 36, 18} },
+            { NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {36, 18, 9} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {72, 36, 18} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {72, 36, 18} },
+            { NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {36, 18, 9} },
+            { {-1, -1, -1} }
+        }};
+
+        UpdateProfiles({realTimeProfile, nearRealTimeProfile, bestEffortProfile});
     }
 
     bool TransmitProfiles::setDefaultProfile(const TransmitProfile profileName)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SRCS
   StringUtilsTests.cpp
   TaskDispatcherCAPITests.cpp
   TransmissionPolicyManagerTests.cpp
+  TransmitProfileRuleTests.cpp
   TransmitProfilesTests.cpp
   UtilsTests.cpp
 )

--- a/tests/unittests/TransmitProfileRuleTests.cpp
+++ b/tests/unittests/TransmitProfileRuleTests.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+#include "common/Common.hpp"
+#include <TransmitProfiles.hpp>
+
+using namespace testing;
+using namespace MAT;
+
+TEST(TransmitProfileRuleTests, DefaultConstructor_NetworkCostIsAny)
+{
+    TransmitProfileRule rule;
+    ASSERT_EQ(rule.netCost, NetworkCost_Any);
+}
+
+TEST(TransmitProfileRuleTests, DefaultConstructor_PowerStateIsAny)
+{
+    TransmitProfileRule rule;
+    ASSERT_EQ(rule.powerState, PowerSource_Any);
+}
+
+TEST(TransmitProfileRuleTests, DefaultConstructor_NetworkTypeIsAny)
+{
+    TransmitProfileRule rule;
+    ASSERT_EQ(rule.netType, NetworkType_Any);
+}
+
+TEST(TransmitProfileRuleTests, DefaultConstructor_NetworkSpeedIsZero)
+{
+    TransmitProfileRule rule;
+    ASSERT_EQ(rule.netSpeed, unsigned{0});
+}
+
+TEST(TransmitProfileRuleTests, DefaultConstructor_TimersSizeIsZero)
+{
+    TransmitProfileRule rule;
+    ASSERT_EQ(rule.timers.size(), size_t{0});
+}
+
+TEST(TransmitProfileRuleTests, TimerConstructor_TimersSizeThree_TimersSet)
+{
+    TransmitProfileRule rule{{1, 2, 3}};
+    ASSERT_EQ(rule.timers.size(), size_t{3});
+    ASSERT_EQ(rule.timers[0], 1);
+    ASSERT_EQ(rule.timers[1], 2);
+    ASSERT_EQ(rule.timers[2], 3);
+}
+
+TEST(TransmitProfileRuleTests, TimerConstructor_TimersSizeThree_OtherValuesUnmodified)
+{
+    TransmitProfileRule rule{{1, 2, 3}};
+    ASSERT_EQ(rule.netCost, NetworkCost::NetworkCost_Any);
+    ASSERT_EQ(rule.powerState, PowerSource::PowerSource_Any);
+    ASSERT_EQ(rule.netType, NetworkType::NetworkType_Any);
+    ASSERT_EQ(rule.netSpeed, unsigned{0});
+}
+
+TEST(TransmitProfileRuleTests, NetCostAndTimerConstructor_NetCostLowTimersSizeThree_NetCostAndTimersSet)
+{
+    TransmitProfileRule rule{NetworkCost::NetworkCost_Unmetered, {1, 2, 3}};
+    ASSERT_EQ(rule.netCost, NetworkCost::NetworkCost_Unmetered);
+    ASSERT_EQ(rule.timers.size(), size_t{3});
+    ASSERT_EQ(rule.timers[0], 1);
+    ASSERT_EQ(rule.timers[1], 2);
+    ASSERT_EQ(rule.timers[2], 3);
+}
+
+TEST(TransmitProfileRuleTests, NetCostAndTimerConstructor_NetCostLowTimersSizeThree_OtherValuesUnmodified)
+{
+    TransmitProfileRule rule{NetworkCost::NetworkCost_Unmetered, {1, 2, 3}};
+    ASSERT_EQ(rule.powerState, PowerSource::PowerSource_Any);
+    ASSERT_EQ(rule.netType, NetworkType::NetworkType_Any);
+    ASSERT_EQ(rule.netSpeed, unsigned{0});
+}
+
+TEST(TransmitProfileRuleTests, NetCostPowerSourceAndTimerConstructor_NetCostLowPowerSourceBatteryTimersSizeThree_NetCostPowerSourceAndTimersSet)
+{
+    TransmitProfileRule rule{NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {1, 2, 3}};
+    ASSERT_EQ(rule.netCost, NetworkCost::NetworkCost_Unmetered);
+    ASSERT_EQ(rule.powerState, PowerSource::PowerSource_Battery);
+    ASSERT_EQ(rule.timers.size(), size_t{3});
+    ASSERT_EQ(rule.timers[0], 1);
+    ASSERT_EQ(rule.timers[1], 2);
+    ASSERT_EQ(rule.timers[2], 3);
+}
+
+TEST(TransmitProfileRuleTests, NetCostPowerSourceAndTimerConstructor_NetCostLowPowerSourceBatteryTimersSizeThree_OtherValuesUnmodified)
+{
+    TransmitProfileRule rule{NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {1, 2, 3}};
+    ASSERT_EQ(rule.netType, NetworkType::NetworkType_Any);
+    ASSERT_EQ(rule.netSpeed, unsigned{0});
+}

--- a/tests/unittests/TransmitProfilesTests.cpp
+++ b/tests/unittests/TransmitProfilesTests.cpp
@@ -7,6 +7,7 @@ using namespace MAT;
 
 class TransmitProfilesTests : public TransmitProfiles, public ::testing::Test
 {
+protected:
     virtual void SetUp() override
     {
         TransmitProfiles::profiles.clear();
@@ -15,6 +16,40 @@ class TransmitProfilesTests : public TransmitProfiles, public ::testing::Test
     virtual void TearDown() override
     {
         TransmitProfiles::profiles.clear();
+    }
+};
+
+class TransmitProfilesTests_EnsureDefaultProfiles : public TransmitProfilesTests
+{
+protected:
+    virtual void SetUp() override
+    {
+        TransmitProfilesTests::SetUp();
+        TransmitProfiles::EnsureDefaultProfiles();
+    }
+
+    const char* const defaultRealTimeProfileName = "REAL_TIME";
+    const char* const defaultNearRealTimeProfileName = "NEAR_REAL_TIME";
+    const char* const defaultBestEffortProfileName = "BEST_EFFORT";
+
+    void ValidateTransmitProfileRule(const TransmitProfileRule& rule, const std::vector<int>& expectedTimers)
+    {
+        ValidateTransmitProfileRule(rule, NetworkCost_Any, expectedTimers);
+    }
+
+    void ValidateTransmitProfileRule(const TransmitProfileRule& rule, NetworkCost expectedNetCost, const std::vector<int>& expectedTimers)
+    {
+        ValidateTransmitProfileRule(rule, expectedNetCost, PowerSource_Any, expectedTimers);
+    }
+
+    void ValidateTransmitProfileRule(const TransmitProfileRule& rule, NetworkCost expectedNetCost, PowerSource expectedPowerSource, const std::vector<int>& expectedTimers)
+    {
+        ASSERT_EQ(rule.netCost, expectedNetCost);
+        ASSERT_EQ(rule.powerState, expectedPowerSource);
+        ASSERT_EQ(rule.timers.size(), expectedTimers.size());
+        ASSERT_EQ(rule.timers[0], expectedTimers[0]);
+        ASSERT_EQ(rule.timers[1], expectedTimers[1]);
+        ASSERT_EQ(rule.timers[2], expectedTimers[2]);
     }
 };
 
@@ -31,6 +66,204 @@ TEST_F(TransmitProfilesTests, EnsureDefaultProfiles_CalledTwice_ProfilesSizeIsTh
     TransmitProfiles::EnsureDefaultProfiles();
     TransmitProfiles::EnsureDefaultProfiles();
     ASSERT_EQ(TransmitProfiles::profiles.size(), size_t{3});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeProfileEntryMatchesKey)
+{
+    ASSERT_EQ(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].name, defaultRealTimeProfileName);
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeProfileHasElevenRules)
+{
+    const auto& profile = TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}];
+    ASSERT_EQ(profile.rules.size(), size_t{11});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleZeroIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleOneIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {16, 8, 4});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleTwoIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {16, 8, 4});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleThreeIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {12, 6, 3});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleFourIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {8, 4, 2});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleFiveIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {8, 4, 2});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleSixIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {4, 2, 1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleSevenIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {8, 4, 2});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleEightIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {8, 4, 2});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleNineIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {4, 2, 1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleTenIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[10], {-1, -1, -1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeProfileEntryMatchesKey)
+{
+    ASSERT_EQ(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].name, defaultNearRealTimeProfileName);
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeProfileHasElevenRules)
+{
+    const auto& profile = TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}];
+    ASSERT_EQ(profile.rules.size(), size_t{11});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleZeroIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleOneIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 24, 12});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleTwoIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 24, 12});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleThreeIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 18, 9});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleFourIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {24, 12, 6});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleFiveIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {24, 12, 6});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleSixIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {12, 6, 3});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleSevenIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {24, 12, 6});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleEightIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {24, 12, 6});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleNineIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {12, 6, 3});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleTenIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[10], {-1, -1, -1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortProfileEntryMatchesKey)
+{
+    ASSERT_EQ(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].name, defaultBestEffortProfileName);
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortProfileHasElevenRules)
+{
+    const auto& profile = TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}];
+    ASSERT_EQ(profile.rules.size(), size_t{11});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleZeroIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleOneIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 72, 36});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleTwoIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 72, 36});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleThreeIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 54, 27});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleFourIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {72, 36, 18});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleFiveIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {72, 36, 18});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleSixIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {36, 18, 9});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleSevenIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {72, 36, 18});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleEightIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {72, 36, 18});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleNineIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {36, 18, 9});
+}
+
+TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleTenIsCorrect)
+{
+    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[10], {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests, UpdateProfiles_ProfileAlreadyAddedAndNotInNewProfiles_PreviousCustomProfilesRemoved)

--- a/tests/unittests/UnitTests.vcxproj
+++ b/tests/unittests/UnitTests.vcxproj
@@ -455,6 +455,7 @@
     <ClCompile Include="$(ProjectDir)\StringUtilsTests.cpp" />
     <ClCompile Include="$(ProjectDir)\TaskDispatcherCAPITests.cpp" />
     <ClCompile Include="$(ProjectDir)\TransmissionPolicyManagerTests.cpp" />
+    <ClCompile Include="$(ProjectDir)\TransmitProfileRuleTests.cpp" />
     <ClCompile Include="$(ProjectDir)\TransmitProfilesTests.cpp" />
     <ClCompile Include="$(ProjectDir)\UtilsTests.cpp" />
     <ClInclude Include="$(ProjectDir)..\common\Common.hpp" />

--- a/tests/unittests/UnitTests.vcxproj.filters
+++ b/tests/unittests/UnitTests.vcxproj.filters
@@ -34,6 +34,7 @@
     <ClCompile Include="$(ProjectDir)\StringUtilsTests.cpp" />
     <ClCompile Include="$(ProjectDir)\TaskDispatcherCAPITests.cpp" />
     <ClCompile Include="$(ProjectDir)\TransmissionPolicyManagerTests.cpp" />
+    <ClCompile Include="$(ProjectDir)\TransmitProfileRuleTests.cpp" />
     <ClCompile Include="$(ProjectDir)\TransmitProfilesTests.cpp" />
     <ClCompile Include="$(ProjectDir)\UtilsTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\common\Common.cpp">


### PR DESCRIPTION
Right now, on an iOS device, DeviceInfo_OSName is returned as "iPhone OS" for all versions of iOS. This is particularly vexing when used on an iPad, which is very much not an iPhone.

This change hardcodes OSName as "iOS" on iOS and "Mac OS X" on Mac per Common Schema definitions: https://github.com/microsoft/common-schema/blob/master/PartA/os.md