### PR TITLE
[ObjC] Update data type case names

### DIFF
--- a/wrappers/obj-c/ODWEventProperties.h
+++ b/wrappers/obj-c/ODWEventProperties.h
@@ -45,12 +45,12 @@ typedef NS_ENUM(NSInteger, ODWPiiKind)
  */
 typedef NS_OPTIONS(uint64_t, ODWPrivacyDataType)
 {
-    ODWPDTBrowsingHistory                    = 0x0000000000000002u,
-    ODWPDTDeviceConnectivityAndConfiguration = 0x0000000000000800u ,
-    ODWPDTInkingTypingAndSpeechUtterance     = 0x0000000000020000u,
-    ODWPDTProductAndServicePerformance       = 0x0000000001000000u,
-    ODWPDTProductAndServiceUsage             = 0x0000000002000000u,
-    ODWPDTSoftwareSetupAndInventory          = 0x0000000080000000u
+    ODWPrivacyDataTypeBrowsingHistory                    = 0x0000000000000002u,
+    ODWPrivacyDataTypeDeviceConnectivityAndConfiguration = 0x0000000000000800u ,
+    ODWPrivacyDataTypeInkingTypingAndSpeechUtterance     = 0x0000000000020000u,
+    ODWPrivacyDataTypeProductAndServicePerformance       = 0x0000000001000000u,
+    ODWPrivacyDataTypeProductAndServiceUsage             = 0x0000000002000000u,
+    ODWPrivacyDataTypeSoftwareSetupAndInventory          = 0x0000000080000000u
 };
 
 /*!


### PR DESCRIPTION
[Based on documentation](https://developer.apple.com/documentation/swift/objective-c_and_c_code_customization/grouping_related_objective-c_constants), the prefix of an `NS_OPTIONS` case name should be the same as the `NS_OPTIONS` name. This allows Swift to remove that prefix when converting the cases.