### PR TITLE
Suppress a warning about deprecated API usage in iOS wrappers for temetry_ariasdk

### DIFF
--- a/tests/common/iOSWrapper.mm
+++ b/tests/common/iOSWrapper.mm
@@ -27,7 +27,20 @@ public:
         LOG_INFO("=== %s.%s [%s]", test.test_case_name(), test.name(), test.result()->Passed() ? "OK" : "FAILED");
         if(!test.result()->Passed())
         {
+#if 0
+// use something like this code after we switch to Xcode 12 and can
+// delete the deprecated code in the else block below. ADO 4251996
+            XCTSourceCodeLocation *location = [[[XCTSourceCodeLocation alloc] initWithFilePath:[NSString stringWithUTF8String:test.file()] lineNumber:test.line()] autorelease];
+            XCTSourceCodeContext *context = [[[XCTSourceCodeContext alloc] initWithLocation:location] autorelease];
+            XCTIssue *issue = [[[XCTIssue alloc] initWithType:XCTIssueTypeAssertionFailure compactDescription:[NSString stringWithUTF8String:test.test_case_name()] detailedDescription:nil sourceCodeContext:context associatedError:nil attachments:@[]] autorelease];
+
+            [m_tests recordIssue:issue];
+#else
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [m_tests recordFailureWithDescription:[NSString stringWithUTF8String:test.test_case_name()] inFile:[NSString stringWithUTF8String:test.file()] atLine:test.line() expected:true];
+#pragma clang diagnostic pop
+#endif
         }
     }
 private:


### PR DESCRIPTION
Clang in Xcode 12 complains because Apple marked this API as deprecated in Xcode 12. We cannot yet use the suggested replacement because the new APIs don't exist in Xcode 11. So, write-but-don't-use the code, and suppress the deprecated-api warning in tight scope.

error: 'method:withParam:' is deprecated: first deprecated in iOS 8.0 [-Werror,-Wdeprecated-declarations]