### PR TITLE
JSON-Pointer-Properties.md design document

### DIFF
--- a/lib/pal/desktop/WindowsDesktopNetworkInformationImpl.cpp
+++ b/lib/pal/desktop/WindowsDesktopNetworkInformationImpl.cpp
@@ -55,19 +55,6 @@ namespace PAL_NS_BEGIN {
         virtual NetworkType GetNetworkType() override
         {
             m_type = NetworkType_Unknown;
-            DWORD flags;
-            DWORD reserved = 0;
-            if (::InternetGetConnectedState(&flags, reserved)) {
-                switch (flags) {
-                case INTERNET_CONNECTION_MODEM:
-                case INTERNET_CONNECTION_LAN:
-                    m_type = NetworkType_Wired;
-                    break;
-                default:
-                    m_type = NetworkType_Unknown;
-                    break;
-                }
-            }
             return m_type;
         }
 

--- a/wrappers/obj-c/ODWLogger.mm
+++ b/wrappers/obj-c/ODWLogger.mm
@@ -64,10 +64,10 @@ using namespace MAT;
             if(strcmp([num objCType], @encode(BOOL))==0 ) {
                 event.SetProperty(strPropertyName, [num boolValue] ? true : false, piiKind);
             }
-            else if( strcmp([num objCType], @encode(int))==0 ){
-                event.SetProperty(strPropertyName, [num intValue], piiKind);
-            }else{
+            else if( (strcmp([num objCType], @encode(float))==0) || (strcmp([num objCType], @encode(double))==0) || (strcmp([num objCType], @encode(long double))==0) ){
                 event.SetProperty(strPropertyName, [num floatValue], piiKind);
+            }else{
+                event.SetProperty(strPropertyName, [num longLongValue], piiKind);
             }
         }
         else if([value isKindOfClass: [NSDate class]])


### PR DESCRIPTION
This document describes the foundation framework to address the following requirements:
- ability to pass any tree object (Part A/B) to UTC via flat EventProperties list C++ API
- same concept can be used for C API as well
- applies to UTC-ETW (Windows Telemetry), Direct, and Geneva-ETW (Azure Telemetry)
- document mentions JSON, but the concept described also applies to transform from 'flat' properties list to 'hierarchical' CsRecord bond structure. Code to provide that mapping from flat to CsRecord is not provided in this PR.
- example code that illustrates how the Agent would extract from flat list to JSON is provided in this PR.

Related issues:
#381 
#303 
#302 
#310