### PR TITLE
Issue #500: Fix handing of int64 values at Obj-C wrapper when sending event

### DIFF
--- a/lib/pal/desktop/WindowsDesktopNetworkInformationImpl.cpp
+++ b/lib/pal/desktop/WindowsDesktopNetworkInformationImpl.cpp
@@ -55,19 +55,6 @@ namespace PAL_NS_BEGIN {
         virtual NetworkType GetNetworkType() override
         {
             m_type = NetworkType_Unknown;
-            DWORD flags;
-            DWORD reserved = 0;
-            if (::InternetGetConnectedState(&flags, reserved)) {
-                switch (flags) {
-                case INTERNET_CONNECTION_MODEM:
-                case INTERNET_CONNECTION_LAN:
-                    m_type = NetworkType_Wired;
-                    break;
-                default:
-                    m_type = NetworkType_Unknown;
-                    break;
-                }
-            }
             return m_type;
         }
 


### PR DESCRIPTION
Update objCType testing to consider all variants for float type variants.