### PR TITLE
Remove DataPackage usage in the BondSplicer

### DIFF
--- a/lib/decorators/SemanticApiDecorators.hpp
+++ b/lib/decorators/SemanticApiDecorators.hpp
@@ -5,10 +5,6 @@
 #include "BaseDecorator.hpp"
 #include "ILogger.hpp"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4100)
-#endif
 namespace ARIASDK_NS_BEGIN {
 
 #define RECORD_EXT      record.data[0].properties
@@ -295,7 +291,4 @@ namespace ARIASDK_NS_BEGIN {
     };
 
 } ARIASDK_NS_END
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 #endif

--- a/lib/include/public/ISemanticContext.hpp
+++ b/lib/include/public/ISemanticContext.hpp
@@ -12,10 +12,6 @@
 #include <string>
 #include <cassert>
 
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable : 4100 ) // unreferenced formal parameter
-#endif
 namespace ARIASDK_NS_BEGIN
 {
     /// <summary>
@@ -81,7 +77,7 @@ namespace ARIASDK_NS_BEGIN
         /// Set the experiment IDs information of the specified telemetry event.
         /// </summary>
         /// <param name="appVersion">list of IDs of experimentations into which the application is enlisted</param>
-        virtual void  SetEventExperimentIds(std::string const& eventName, std::string const& experimentIds) {};
+        virtual void  SetEventExperimentIds(std::string const& /*eventName*/, std::string const& /*experimentIds*/) {};
 
         /// <summary>
         /// Clear the experiment IDs information.
@@ -269,12 +265,9 @@ namespace ARIASDK_NS_BEGIN
         /// </summary>
         /// <param name="type">Ticket type</param>
         /// <param name="ticketValue">Ticket value.</param>
-        virtual void SetTicket(TicketType type, std::string const& ticketValue) {};
+        virtual void SetTicket(TicketType /*type*/, std::string const& /*ticketValue*/) {};
     };
 
 } ARIASDK_NS_END
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
 
 #endif //ISEMANTICCONTEXT_H

--- a/lib/include/public/LogManagerBase.hpp
+++ b/lib/include/public/LogManagerBase.hpp
@@ -11,7 +11,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4459 4100 4121 4068)
+#pragma warning(disable : 4459 4121 4068)
 #endif
 
 #pragma clang diagnostic push

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -5,10 +5,6 @@
 #include "ILogManager.hpp"
 #include "ILogger.hpp"
 
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable : 4100 ) // unreferenced formal parameter
-#endif
 namespace ARIASDK_NS_BEGIN
 {
 
@@ -16,11 +12,11 @@ namespace ARIASDK_NS_BEGIN
     {
     public:
 
-        virtual void SetNetworkCost(NetworkCost networkCost) override {};
+        virtual void SetNetworkCost(NetworkCost /*networkCost*/) override {};
 
-        virtual void SetNetworkType(NetworkType networkType) override {};
+        virtual void SetNetworkType(NetworkType /*networkType*/) override {};
 
-        virtual void SetUserId(const std::string & userId, PiiKind piiKind = PiiKind_Identity) override {};
+        virtual void SetUserId(const std::string & /*userId*/, PiiKind /*piiKind*/ = PiiKind_Identity) override { };
 
         virtual void SetTicket(TicketType, const std::string &) override {};
 
@@ -51,75 +47,75 @@ namespace ARIASDK_NS_BEGIN
             return &nullContext;
         }
 
-        virtual void SetContext(const std::string & name, const char value[], PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, const char /*value*/[], PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, const std::string & value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, const std::string & /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, double value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, double /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, int8_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, int16_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, int32_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, int64_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, uint8_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, uint16_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, uint32_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, uint64_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, bool value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, bool /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, time_ticks_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, time_ticks_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, GUID_t value, PiiKind piiKind = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, GUID_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
 
-        virtual void SetContext(const std::string & name, const EventProperty & prop) override {};
+        virtual void SetContext(const std::string & /*name*/, const EventProperty & /*prop*/) override {};
 
-        virtual void LogAppLifecycle(AppLifecycleState state, EventProperties const & properties) override {};
+        virtual void LogAppLifecycle(AppLifecycleState /*state*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogSession(SessionState state, const EventProperties & properties) override {};
+        virtual void LogSession(SessionState /*state*/, const EventProperties & /*properties*/) override {};
 
-        virtual void LogEvent(std::string const & name) override {};
+        virtual void LogEvent(std::string const & /*name*/) override {};
 
-        virtual void LogEvent(EventProperties const & properties) override {};
+        virtual void LogEvent(EventProperties const & /*properties*/) override {};
 
-        virtual void LogFailure(std::string const & signature, std::string const & detail, EventProperties const & properties) override {};
+        virtual void LogFailure(std::string const & /*signature*/, std::string const & /*detail*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogFailure(std::string const & signature, std::string const & detail, std::string const & category, std::string const & id, EventProperties const & properties) override {};
+        virtual void LogFailure(std::string const & /*signature*/, std::string const & /*detail*/, std::string const & /*category*/, std::string const & /*id*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogPageView(std::string const & id, std::string const & pageName, EventProperties const & properties) override {};
+        virtual void LogPageView(std::string const & /*id*/, std::string const & /*pageName*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogPageView(std::string const & id, std::string const & pageName, std::string const & category, std::string const & uri, std::string const & referrerUri, EventProperties const & properties) override {};
+        virtual void LogPageView(std::string const & /*id*/, std::string const & /*pageName*/, std::string const & /*category*/, std::string const & /*uri*/, std::string const & /*referrerUri*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogPageAction(std::string const & pageViewId, ActionType actionType, EventProperties const & properties) override {};
+        virtual void LogPageAction(std::string const & /*pageViewId*/, ActionType /*actionType*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogPageAction(PageActionData const & pageActionData, EventProperties const & properties) override {};
+        virtual void LogPageAction(PageActionData const & /*pageActionData*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogSampledMetric(std::string const & name, double value, std::string const & units, EventProperties const & properties) override {};
+        virtual void LogSampledMetric(std::string const & /*name*/, double /*value*/, std::string const & /*units*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogSampledMetric(std::string const & name, double value, std::string const & units, std::string const & instanceName, std::string const & objectClass, std::string const & objectId, EventProperties const & properties) override {};
+        virtual void LogSampledMetric(std::string const & /*name*/, double /*value*/, std::string const & /*units*/, std::string const & /*instanceName*/, std::string const & /*objectClass*/, std::string const & /*objectId*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogAggregatedMetric(std::string const & name, long duration, long count, EventProperties const & properties) override {};
+        virtual void LogAggregatedMetric(std::string const & /*name*/, long /*duration*/, long /*count*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogAggregatedMetric(AggregatedMetricData const & metricData, EventProperties const & properties) override {};
+        virtual void LogAggregatedMetric(AggregatedMetricData const & /*metricData*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogTrace(TraceLevel level, std::string const & message, EventProperties const & properties) override {};
+        virtual void LogTrace(TraceLevel /*level*/, std::string const & /*message*/, EventProperties const & /*properties*/) override {};
 
-        virtual void LogUserState(UserState state, long timeToLiveInMillis, EventProperties const & properties) override {};
+        virtual void LogUserState(UserState /*state*/, long /*timeToLiveInMillis*/, EventProperties const & /*properties*/) override {};
 
         virtual IEventFilterCollection& GetEventFilters() noexcept override { return m_filters; }
 
         virtual IEventFilterCollection const& GetEventFilters() const noexcept override { return m_filters; }
 
-        virtual void SetParentContext(ISemanticContext * context) override {};
+        virtual void SetParentContext(ISemanticContext * /*context*/) override {};
 
-        virtual void SetLevel(uint8_t level) override {};
+        virtual void SetLevel(uint8_t /*level*/) override {};
 
     private:
         NullEventFilterCollection m_filters;
@@ -161,7 +157,7 @@ namespace ARIASDK_NS_BEGIN
         NullLogManager() { };
 
         // Inherited via ILogManager
-        virtual bool DispatchEvent(DebugEvent evt) override
+        virtual bool DispatchEvent(DebugEvent /*evt*/) override
         {
             return false;
         }
@@ -237,92 +233,92 @@ namespace ARIASDK_NS_BEGIN
             return nullContext;
         }
 
-        virtual status_t SetContext(std::string const & name, std::string const & value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(std::string const & /*name*/, std::string const & /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, const char * value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, const char * /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, double value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, double /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, int64_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, int64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, int8_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, int8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, int16_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, int16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, int32_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, int32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, uint8_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, uint8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
-        virtual status_t SetContext(const std::string & name, uint16_t value, PiiKind piiKind = PiiKind_None) override
-        {
-            return STATUS_ENOSYS;
-        }
-
-        virtual status_t SetContext(const std::string & name, uint32_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, uint16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, uint64_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, uint32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, bool value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, uint64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, time_ticks_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, bool /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual status_t SetContext(const std::string & name, GUID_t value, PiiKind piiKind = PiiKind_None) override
+        virtual status_t SetContext(const std::string & /*name*/, time_ticks_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
         {
             return STATUS_ENOSYS;
         }
 
-        virtual ILogger * GetLogger(std::string const & tenantToken, std::string const & source = std::string(), std::string const & experimentationProject = std::string()) override
+        virtual status_t SetContext(const std::string & /*name*/, GUID_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override
+        {
+            return STATUS_ENOSYS;
+        }
+
+        virtual ILogger * GetLogger(std::string const & /*tenantToken*/, std::string const & /*source*/ = std::string(), std::string const & /*experimentationProject*/ = std::string()) override
         {
             static NullLogger nullLogger;
             return &nullLogger;
         }
 
-        virtual void AddEventListener(DebugEventType type, DebugEventListener & listener) override {};
+        virtual void AddEventListener(DebugEventType /*type*/, DebugEventListener & /*listener*/) override {};
 
-        virtual void RemoveEventListener(DebugEventType type, DebugEventListener & listener) override {};
+        virtual void RemoveEventListener(DebugEventType /*type*/, DebugEventListener & /*listener*/) override {};
 
-        virtual bool AttachEventSource(DebugEventSource & other) override
+        virtual bool AttachEventSource(DebugEventSource & /*other*/) override
         {
             return false;
         }
 
         ///
-        virtual bool DetachEventSource(DebugEventSource & other) override
+        virtual bool DetachEventSource(DebugEventSource & /*other*/) override
         {
             return false;
         }
@@ -352,9 +348,9 @@ namespace ARIASDK_NS_BEGIN
             return m_filters;
         }
 
-        virtual void SetLevelFilter(uint8_t defaultLevel, uint8_t levelMin, uint8_t levelMax) override {};
+        virtual void SetLevelFilter(uint8_t /*defaultLevel*/, uint8_t /*levelMin*/, uint8_t /*levelMax*/) override {};
 
-        virtual void SetLevelFilter(uint8_t defaultLevel, const std::set<uint8_t>& allowedLevels) override {};
+        virtual void SetLevelFilter(uint8_t /*defaultLevel*/, const std::set<uint8_t>& /*allowedLevels*/) override {};
 
         virtual const IDataViewerCollection& GetDataViewerCollection() const noexcept override
         {
@@ -372,8 +368,5 @@ namespace ARIASDK_NS_BEGIN
     };
 
 } ARIASDK_NS_END
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
 
 #endif

--- a/tests/common/Common.hpp
+++ b/tests/common/Common.hpp
@@ -46,18 +46,12 @@ namespace testing {
         std::string haystack(reinterpret_cast<char const*>(arg.data()), arg.size());
         return Matches(HasSubstr(str))(haystack);
     }
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning(disable: 4100)
-#endif
+
     MATCHER_P2(Near, value, range, "")
     {
         UNREFERENCED_PARAMETER(result_listener);
         return (abs(arg - value) <= range);
     }
-#ifdef _MSC_VER
-#pragma warning( pop ) 
-#endif
 
     MATCHER_P(StrAsIntGt, value, "")
     {


### PR DESCRIPTION
DataPackage isn't used by the BondSplicer, so there's no need to generate an object just to throw it away.

I've also renamed the method to addTenantToken to better reflect what it's actually doing.

Edit: Bonus points, this also removes some heap allocs via std::string which the linker likely didn't optimize away as they perform side effects in the c'tor and d'tor.