### PR TITLE
Fix TPM unit test flakiness due to uninitialized m_timers

### DIFF
--- a/lib/packager/BondSplicer.cpp
+++ b/lib/packager/BondSplicer.cpp
@@ -7,13 +7,6 @@
 
 namespace ARIASDK_NS_BEGIN {
 
-
-BondSplicer::BondSplicer()
-  : m_requestRetryCount(0),
-    m_overheadEstimate(0)
-{
-}
-
 size_t BondSplicer::addTenantToken(std::string const& tenantToken)
 {
     size_t begin = m_buffer.size();
@@ -43,58 +36,16 @@ std::vector<uint8_t> BondSplicer::splice() const
     std::vector<uint8_t> output;
     bond_lite::CompactBinaryProtocolWriter writer(output);
 
-    // ClientToCollectorRequest
-    //writer.WriteStructBegin(nullptr, false);
-
-    // 1: optional vector<DataPackage> DataPackages
-    //writer.WriteFieldOmitted(bond_lite::BT_LIST, 1, nullptr);
-
-    // 2: optional int32 RequestRetryCount
-    //writer.WriteFieldOmitted(bond_lite::BT_INT32, 2, nullptr);
-
-    // 3: optional map<string, vector<DataPackage>> TokenToDataPackagesMap
     if (!m_packages.empty()) {
-        //writer.WriteFieldBegin(bond_lite::BT_MAP, 3, nullptr);
-        //writer.WriteMapContainerBegin(m_packages.size(), bond_lite::BT_STRING, bond_lite::BT_LIST);
-
         for (PackageInfo const& package : m_packages) {
-            // Key (string)
-            //writer.WriteString(package.tenantToken);
-
-            // Value (vector<DataPackage>)
-            //writer.WriteContainerBegin(1, bond_lite::BT_STRUCT);
-            //writer.WriteBlob(m_buffer.data() + package.header.offset, package.header.length - 1);
-
-            // 8: optional vector<Record> Records
             if (!package.records.empty()) {
-                //writer.WriteFieldBegin(bond_lite::BT_LIST, 8, nullptr);
-                //writer.WriteContainerBegin(package.records.size(), bond_lite::BT_STRUCT);
-
                 for (Span const& record : package.records) {
                     writer.WriteBlob(m_buffer.data() + record.offset, record.length);
                 }
-
-                //writer.WriteFieldEnd();
             } 
-            else 
-            {
-                //writer.WriteFieldOmitted(bond_lite::BT_LIST, 8, nullptr);
-            }
-
-            //writer.WriteStructEnd(false);
-
-            //writer.WriteContainerEnd();
         }
-
-        //writer.WriteContainerEnd();
-        //writer.WriteFieldEnd();
     } 
-    else
-    {
-        //writer.WriteFieldOmitted(bond_lite::BT_MAP, 3, nullptr);
-    }
 
-    //writer.WriteStructEnd(false);
     return output;
 }
 
@@ -103,7 +54,6 @@ void BondSplicer::clear()
     // Swap with empty instead of clear() to release memory
     std::vector<uint8_t>().swap(m_buffer);
     std::vector<PackageInfo>().swap(m_packages);
-    m_requestRetryCount = 0;
     m_overheadEstimate = 0;
 }
 

--- a/lib/packager/BondSplicer.hpp
+++ b/lib/packager/BondSplicer.hpp
@@ -27,11 +27,10 @@ class BondSplicer
   protected:
     std::vector<uint8_t>     m_buffer;
     std::vector<PackageInfo> m_packages;
-    int32_t                  m_requestRetryCount;
-    size_t                   m_overheadEstimate;
+    size_t                   m_overheadEstimate {};
 
   public:
-    BondSplicer();
+    BondSplicer() noexcept = default;
     BondSplicer(BondSplicer const&) = delete;
     BondSplicer& operator=(BondSplicer const&) = delete;
 

--- a/lib/packager/Packager.cpp
+++ b/lib/packager/Packager.cpp
@@ -17,10 +17,6 @@ namespace ARIASDK_NS_BEGIN {
         }
     }
 
-    Packager::~Packager()
-    {
-    }
-
     void Packager::handleAddEventToPackage(EventsUploadContextPtr const& ctx, StorageRecord const& record, bool& wantMore)
     {
         try {

--- a/lib/packager/Packager.hpp
+++ b/lib/packager/Packager.hpp
@@ -1,12 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 #pragma once
-#include "IOfflineStorage.hpp"
-#include "LogConfiguration.hpp"
-
 #include "api/IRuntimeConfig.hpp"
 
-#include "DataPackage.hpp"
 #include "system/Route.hpp"
 #include "system/Contexts.hpp"
 
@@ -15,7 +11,6 @@ namespace ARIASDK_NS_BEGIN {
     class Packager {
     public:
         Packager(IRuntimeConfig& runtimeConfig);
-        ~Packager();
 
     protected:
         void handleAddEventToPackage(EventsUploadContextPtr const& ctx, StorageRecord const& record, bool& wantMore);
@@ -23,7 +18,7 @@ namespace ARIASDK_NS_BEGIN {
 
     protected:
         IRuntimeConfig & m_config;
-        std::string           m_forcedTenantToken;
+        std::string      m_forcedTenantToken;
 
     public:
         RouteSink<Packager, EventsUploadContextPtr const&, StorageRecord const&, bool&> addEventToPackage{ this, &Packager::handleAddEventToPackage };

--- a/tests/unittests/BondSplicerTests.cpp
+++ b/tests/unittests/BondSplicerTests.cpp
@@ -12,19 +12,11 @@ using namespace MAT;
 
 class ShadowBondSplicer : protected MAT::BondSplicer
 {
-  protected:
-    std::map<size_t, std::string>            m_packageIdToTenantToken;
-    std::map<std::string, DataPackage>       m_TokenToDataPackagesMap;
-
   public:
     using MAT::BondSplicer::addTenantToken;
 
     void addRecord(size_t dataPackageIndex, ::CsProtocol::Record& record)
     {
-        assert(dataPackageIndex < m_TokenToDataPackagesMap.size());
-
-        m_TokenToDataPackagesMap[m_packageIdToTenantToken[dataPackageIndex]].Records.push_back(record);
-
         std::vector<uint8_t> recordBlob;
         {
             bond_lite::CompactBinaryProtocolWriter writer(recordBlob);
@@ -39,14 +31,6 @@ class ShadowBondSplicer : protected MAT::BondSplicer
         static_cast<std::vector<uint8_t>&>(output) = MAT::BondSplicer::splice();
         return output;
     }
-
-    FullDumpBinaryBlob serialize() const
-    {
-        FullDumpBinaryBlob output;
-        bond_lite::CompactBinaryProtocolWriter writer(output);
-        //bond_lite::Serialize(writer, m_shadow);
-        return output;
-    }
 };
 
 //---
@@ -57,172 +41,102 @@ class BondSplicerTests : public Test
     ShadowBondSplicer bs;
 };
 
-TEST_F(BondSplicerTests, Empty)
+TEST_F(BondSplicerTests, addTenantToken_EmptyString_Returns0)
 {
-    EXPECT_THAT(bs.splice(), FullDumpBinaryEq(bs.serialize()));
+   EXPECT_EQ(bs.addTenantToken(std::string { }), size_t { 0 });
 }
 
-TEST_F(BondSplicerTests, OneEmptyTenantToken)
+TEST_F(BondSplicerTests, addTenantToken_TestString_Returns0)
+{
+   EXPECT_EQ(bs.addTenantToken(std::string { "Test" }), size_t { 0 });
+}
+
+TEST_F(BondSplicerTests, addTenantToken_TwoDifferentStrings_Returns0And1)
+{
+   EXPECT_EQ(bs.addTenantToken(std::string { "Test" }), size_t { 0 });
+   EXPECT_EQ(bs.addTenantToken(std::string { "Test2" }), size_t { 1 });
+}
+
+TEST_F(BondSplicerTests, addTenantToken_TwoSameStrings_Returns0And1)
+{
+   EXPECT_EQ(bs.addTenantToken(std::string { "Test" }), size_t { 0 });
+   EXPECT_EQ(bs.addTenantToken(std::string { "Test" }), size_t { 1 });
+}
+
+TEST_F(BondSplicerTests, splice_Empty_SizeZero)
+{
+    EXPECT_EQ(bs.splice().size(), size_t { 0 });
+}
+
+TEST_F(BondSplicerTests, splice_OneEmptyTenantToken_SizeZero)
 {
     bs.addTenantToken("tenant1");
-    EXPECT_THAT(bs.splice(), FullDumpBinaryEq(bs.serialize()));
+    EXPECT_EQ(bs.splice().size(), size_t { 0 });
 }
 
-TEST_F(BondSplicerTests, OneDataPackageWithOneEmptyRecord)
+TEST_F(BondSplicerTests, splice_OnePackageWithOneEmptyRecord_SizeOne)
 {
-/*    DataPackage dp;
-    dp.Source = "source";
-    dp.Ids["abc"] = "def";
-    dp.DataPackageId = "dpid";
-    dp.Timestamp = 1234567890;
-    dp.SchemaVersion = 31;
-    size_t dpIndex = bs.addDataPackage("tenant1", dp);
-
     ::CsProtocol::Record r; 
-    ::CsProtocol::Data d; 
-    r.data.push_back(d);
-    bs.addRecord(dpIndex, r);
+    bs.addRecord(bs.addTenantToken("tenant1"), r);
 
-    EXPECT_THAT(bs.splice(), FullDumpBinaryEq(bs.serialize()));
-    */
+    EXPECT_THAT(bs.splice().size(), size_t { 1 });
 }
 
-TEST_F(BondSplicerTests, MultipleDataPackagesWithRecords)
+TEST_F(BondSplicerTests, splice_OnePackageWithOneNonEmptyRecord_SizeNine)
 {
- /*   DataPackage dp1;
-    dp1.Source = "source1";
-    dp1.Ids["abc"] = "def";
-    dp1.DataPackageId = "dpid1";
-    dp1.Timestamp = 1234567890;
-    dp1.SchemaVersion = 31;
-    size_t dp1Index = bs.addDataPackage("tenant1", dp1);
+   ::CsProtocol::Record r;
+   r.name = std::string { "Record" };
+   bs.addRecord(bs.addTenantToken("tenant1"), r);
 
-    ::CsProtocol::Record r1a;
-    r1a.name = "r1a";
-    bs.addRecord(dp1Index, r1a);
-
-    DataPackage dp2;
-    dp1.Source = "source2";
-    dp1.Ids["ghi"] = "jkl";
-    dp1.DataPackageId = "dpid2";
-    dp1.Timestamp = 987654321;
-    dp1.SchemaVersion = 32;
-    size_t dp2Index = bs.addDataPackage("tenant2", dp2);
-
-    ::CsProtocol::Record r2a;
-    r2a.name = "r2a";
-    bs.addRecord(dp2Index, r2a);
-
-    ::CsProtocol::Record r1b;
-    r1b.name = "r1b";
-    bs.addRecord(dp1Index, r1b);
-
-    ::CsProtocol::Record r2b;
-    r2b.name = "r2b";
-    bs.addRecord(dp2Index, r2b);
-
-    EXPECT_THAT(bs.splice(), FullDumpBinaryEq(bs.serialize()));
-    */
+   EXPECT_THAT(bs.splice().size(), size_t { 9 });
 }
 
-TEST_F(BondSplicerTests, MultipleEverything)
+TEST_F(BondSplicerTests, splice_OneDataPackageWithTwoEmptyRecords_SizeTwo)
 {
-/*    DataPackage dp1;
-    dp1.Source = "source1";
-    dp1.Ids["abc"] = "def";
-    dp1.DataPackageId = "dpid1";
-    dp1.Timestamp = 1234567890;
-    dp1.SchemaVersion = 31;
-    size_t dp1index = bs.addDataPackage("tenant1", dp1);
+   ::CsProtocol::Record r;
+   ::CsProtocol::Record r2;
+   auto tokenIndex = bs.addTenantToken("tenant1");
+   bs.addRecord(tokenIndex, r);
+   bs.addRecord(tokenIndex, r2);
 
-    {
-        ::CsProtocol::Record r; ::CsProtocol::Data d; r.data.push_back(d);
-        r.name = "r1a";
-        r.time = 111111;
-        ::CsProtocol::Value temp;
-        temp.stringValue = "b";
-        r.data[0].properties["a"] = temp;
+   EXPECT_THAT(bs.splice().size(), size_t { 2 });
+}
 
-        ::CsProtocol::Value temp1;
-        temp1.stringValue = "a@b.c";
+TEST_F(BondSplicerTests, splice_OneDataPackageWithTwoNonEmptyRecords_SizeTwenty)
+{
+   ::CsProtocol::Record r;
+   r.name = std::string { "Record1" };
+   ::CsProtocol::Record r2;
+   r2.name = std::string { "Record2" };
+   auto tokenIndex = bs.addTenantToken("tenant1");
+   bs.addRecord(tokenIndex, r);
+   bs.addRecord(tokenIndex, r2);
 
-        ::CsProtocol::PII pii;
-        pii.Kind = ::CsProtocol::PIIKind::Identity;
-        ::CsProtocol::Attributes att;
-        att.pii.push_back(pii);
+   EXPECT_THAT(bs.splice().size(), size_t { 20 });
+}
 
+TEST_F(BondSplicerTests, splice_TwoDataPackagesWithOneEmptyRecordEach_SizeTwo)
+{
+   ::CsProtocol::Record r;
+   ::CsProtocol::Record r2;
+   auto firstTokenIndex = bs.addTenantToken("tenant1");
+   auto secondTokenIndex = bs.addTenantToken("tenant2");
+   bs.addRecord(firstTokenIndex, r);
+   bs.addRecord(secondTokenIndex, r2);
 
-        temp1.attributes.push_back(att);
-        r.data[0].properties["c"] = temp1;
-        bs.addRecord(dp1index, r);
-    }
+   EXPECT_THAT(bs.splice().size(), size_t { 2 });
+}
 
-    {
-        ::CsProtocol::Record r; ::CsProtocol::Data d; r.data.push_back(d);
-        r.name = "r1b";
-        r.time = 222222;
-        ::CsProtocol::Value temp;
-        temp.stringValue = "d";
-        r.data[0].properties["c"] = temp;
+TEST_F(BondSplicerTests, splice_TwoDataPackagesWithOneNonEmptyRecordEach_SizeTwenty)
+{
+   ::CsProtocol::Record r;
+   r.name = std::string { "Record1" };
+   ::CsProtocol::Record r2;
+   r2.name = std::string { "Record2" };
+   auto firstTokenIndex = bs.addTenantToken("tenant1");
+   auto secondTokenIndex = bs.addTenantToken("tenant2");
+   bs.addRecord(firstTokenIndex, r);
+   bs.addRecord(secondTokenIndex, r2);
 
-        ::CsProtocol::Value temp1;
-        temp1.stringValue = "c@d.e";
-
-        ::CsProtocol::PII pii;
-        pii.Kind = ::CsProtocol::PIIKind::Identity;
-        ::CsProtocol::Attributes att;
-        att.pii.push_back(pii);
-
-        temp1.attributes.push_back(att);
-        r.data[0].properties["e"] = temp1;
-
-        bs.addRecord(dp1index, r);
-    }
-
-    DataPackage dp2;
-    dp1.Source = "source2";
-    dp1.Ids["ghi"] = "jkl";
-    dp1.DataPackageId = "dpid2";
-    dp1.Timestamp = 987654321;
-    dp1.SchemaVersion = 32;
-    size_t dp2index = bs.addDataPackage("tenant2", dp2);
-
-    {
-        ::CsProtocol::Record r; ::CsProtocol::Data d; r.data.push_back(d); 
-
-        r.name = "r2a";
-        r.time = 333333;
-        ::CsProtocol::Value temp2;
-        temp2.stringValue = "h.g.f";
-        r.data[0].properties["f.g.h"] = temp2;
-        bs.addRecord(dp2index, r);
-    }
-
-    {
-        ::CsProtocol::Record r; ::CsProtocol::Data d; r.data.push_back(d);
-        r.name = "r2b";
-        r.time = 444444;
-        ::CsProtocol::Value temp3;
-        temp3.stringValue = "k_j_i";
-        r.data[0].properties["i_j_k"] = temp3;
-        bs.addRecord(dp2index, r);
-    }
-
-    {
-        ::CsProtocol::Record r; ::CsProtocol::Data d; r.data.push_back(d);
-        r.name = "r2c";
-        ::CsProtocol::Value temp5;
-
-        ::CsProtocol::PII pii;
-        pii.Kind = ::CsProtocol::PIIKind::Identity;
-        ::CsProtocol::Attributes att;
-        att.pii.push_back(pii);
-        temp5.stringValue = "z@z.z";
-        temp5.attributes.push_back(att);
-        r.data[0].properties["e"] = temp5;        
-        bs.addRecord(dp2index, r);
-    }
-
-    EXPECT_THAT(bs.splice(), FullDumpBinaryEq(bs.serialize()));
-    */
+   EXPECT_THAT(bs.splice().size(), size_t { 20 });
 }


### PR DESCRIPTION
Updated the TPM to ensure that m_timers is initialized and up-to-date before being used. Test failures appeared to have been due to m_timers being uninitialized in a couple unit tests, which didn't call into handleEventArrived

Also changed isTimerUpdated from an atomic to using the same lock as the rest of the transmit profiles. I'm not aware of active related bugs, but using a separate synchronization primitive from the other functions that update isTimerUpdated risks some interesting race conditions.

Fixes #389 and #503 