### PR TITLE
Wrong timestamp when passing const std::time_t &

### DIFF
--- a/examples/cpp/EventSender/EventSender.cpp
+++ b/examples/cpp/EventSender/EventSender.cpp
@@ -91,6 +91,12 @@ int main(int argc, char *argv[])
     auto& config = LogManager::GetLogConfiguration();
     config = MAT::FromJSON(jsonConfig);
 
+#if 0
+    // Enable this code below to forward events to local collector server
+    // See: tools\tools.sln - server project for local cross-platform .NET Core server implementation
+    config[CFG_STR_COLLECTOR_URL] = "http://localhost:5000/OneCollector/";
+#endif
+
     // LogManager initialization
     ILogger *logger = LogManager::Initialize();
     bool utcActive = (bool)(config[CFG_STR_UTC][CFG_BOOL_UTC_ACTIVE]);
@@ -152,11 +158,13 @@ int main(int argc, char *argv[])
                 { "strKey2",  "hello2" },
                 { "int64Key", int64_t(1L) },
                 { "dblKey",   3.14 },
-                { "boolKey",  false },
+                { "boolKeyFalse",  bool(false) },
+                { "boolKeyTrue",   bool(true) },
                 { "guidKey0", GUID_t("00000000-0000-0000-0000-000000000000") },
                 { "guidKey1", GUID_t("00010203-0405-0607-0809-0A0B0C0D0E0F") },
                 { "guidKey2", GUID_t("00010203-0405-0607-0809-0A0B0C0D0E0F") },
-                { "timeKey1", time_ticks_t((uint64_t)0) },     // time in .NET ticks
+                { "timeKey0", time_ticks_t((uint64_t)0) },    // time in .NET ticks 0 (nullable)
+                { "timeKeyNow", time_ticks_t(std::time(0)) }  // time in .NET ticks right now
             });
 
         if (utcActive)

--- a/lib/include/public/EventProperty.hpp
+++ b/lib/include/public/EventProperty.hpp
@@ -73,6 +73,11 @@ namespace ARIASDK_NS_BEGIN
         time_ticks_t(const std::time_t* time);
 
         /// <summary>
+        /// Constructs a time_ticks_t object from a const reference to std::time_t.
+        /// </summary>
+        time_ticks_t(const std::time_t& time) : time_ticks_t(&time) {};
+
+        /// <summary>
         /// The time_ticks_t copy constructor.
         /// </summary>
         time_ticks_t(const time_ticks_t& t);


### PR DESCRIPTION
There's a constructor for `time_ticks_t` that accepts a **pointer** to `std::time_t` . The issue is if you pass in a `const reference` to that type, the compiler is gonna treat it as `long long` rather than the actual type, and treats this as being *Raw uint64_t time in .NET Ticks* rather than the actual Unix time in millis. That results in a wrong timestamp stamped on event.

I noticed this issue while reviewing event contents using local Test Server and Fiddler Inspector.

The fix is to allow accepting `const std::time_t &` , then forwarding it to existing constructor that accepts a pointer. That way the proper time information is retained.

Added this use-case to sample app. Visually inspected in Fiddler that the timestamp in .NET ticks matches the actual current time.