### PR TITLE
[Objc] Add experimentation functions

### DIFF
--- a/wrappers/obj-c/ODWSemanticContext.h
+++ b/wrappers/obj-c/ODWSemanticContext.h
@@ -26,11 +26,32 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)setUserAdvertisingId:(nonnull NSString *)userAdvertisingId;
 
 /*!
+ @brief Sets the experimentation IDs for determining the deployment configuration.
+ @param experimentIds A string that contains the experimentation IDs.
+ */
+-(void)setAppExperimentIds:(nonnull NSString*)experimentIds;
+
+/*!
+ @brief Sets the experimentation IDs for the specified telemetry event.
+ @param experimentIds A string that contains the experimentation IDs.
+ @param eventName A string that contains the name of the event.
+ */
+-(void)setAppExperimentIds:(nonnull NSString*)experimentIds
+                  forEvent:(nonnull NSString*)eventName;
+
+/*!
  @brief Sets the experiment tag (experiment configuration) context information for telemetry events.
  <b>Note:</b> This method removes any previously stored experiment IDs that were set using setAppExperimentETag.
  @param eTag A string that contains the ETag which is a hash of the set of experiments.
  */
 -(void)setAppExperimentETag:(nonnull NSString *)eTag;
+
+/*!
+ @brief Sets the impression ID (an identifier of the currently running flights) for an experiment.
+ @details Calling this method removes the previously stored experimentation IDs and flight IDs.
+ @param impressionId A string that contains the impression ID for the currently active configuration.
+ */
+-(void)setAppExperimentImpressionId:(nonnull NSString*)impressionId;
 
 @end
 

--- a/wrappers/obj-c/ODWSemanticContext.mm
+++ b/wrappers/obj-c/ODWSemanticContext.mm
@@ -37,10 +37,30 @@ using namespace MAT;
     _wrappedSemanticContext->SetUserAdvertisingId(strUserAdvertisingId);
 }
 
+-(void)setAppExperimentIds:(nonnull NSString*)experimentIds
+{
+    std::string strAppExperimentIds = std::string([experimentIds UTF8String]);
+    _wrappedSemanticContext->SetAppExperimentIds(strAppExperimentIds);
+}
+
+-(void)setAppExperimentIds:(nonnull NSString*)experimentIds
+                  forEvent:(nonnull NSString*)eventName
+{
+    std::string strAppExperimentIds = std::string([experimentIds UTF8String]);
+    std::string stEventName = std::string([eventName UTF8String]);
+    _wrappedSemanticContext->SetEventExperimentIds(stEventName, strAppExperimentIds);
+}
+
 -(void)setAppExperimentETag:(nonnull NSString *)eTag
 {
     std::string strETag = std::string([eTag UTF8String]);
     _wrappedSemanticContext->SetAppExperimentETag(strETag);
+}
+
+-(void)setAppExperimentImpressionId:(nonnull NSString*)impressionId
+{
+    std::string strImpressionId = std::string([impressionId UTF8String]);
+    _wrappedSemanticContext->SetAppExperimentImpressionId(strImpressionId);
 }
 
 @end


### PR DESCRIPTION
Add the following experimentation functions to the `ODWSemanticContext` wrapper -

- `setAppExperimentIds:`
- `setAppExperimentIds:forEvent:`
- `setAppExperimentImpressionId:`

The names and docs were copied from the legacy Aria SDK