### PR TITLE
ISplicer interface refactor

### DIFF
--- a/Solutions/Clienttelemetry/Clienttelemetry.vcxitems
+++ b/Solutions/Clienttelemetry/Clienttelemetry.vcxitems
@@ -165,6 +165,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\StorageObserver.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\BondSplicer.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\DataPackage.hpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\ISplicer.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\Packager.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\pal\DebugTrace.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\pal\DeviceInformationImpl.hpp" />

--- a/Solutions/Clienttelemetry/Clienttelemetry.vcxitems.filters
+++ b/Solutions/Clienttelemetry/Clienttelemetry.vcxitems.filters
@@ -151,6 +151,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\StorageObserver.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\BondSplicer.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\DataPackage.hpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\ISplicer.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\packager\Packager.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\pal\DebugTrace.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\pal\DeviceInformationImpl.hpp" />

--- a/lib/packager/BondSplicer.hpp
+++ b/lib/packager/BondSplicer.hpp
@@ -4,6 +4,7 @@
 
 #include "pal/PAL.hpp"
 #include "DataPackage.hpp"
+#include "ISplicer.hpp"
 
 #include <list>
 #include <vector>
@@ -11,19 +12,8 @@
 namespace MAT_NS_BEGIN {
 
 
-class BondSplicer
+class BondSplicer : public ISplicer
 {
-  protected:
-    struct Span {
-        size_t offset, length;
-    };
-
-    struct PackageInfo {
-        std::string     tenantToken;
-        Span            header;
-        std::list<Span> records;
-    };
-
   protected:
     std::vector<uint8_t>     m_buffer;
     std::vector<PackageInfo> m_packages;
@@ -34,13 +24,13 @@ class BondSplicer
     BondSplicer(BondSplicer const&) = delete;
     BondSplicer& operator=(BondSplicer const&) = delete;
 
-    size_t addTenantToken(std::string const& tenantToken);
-    void addRecord(size_t dataPackageIndex, std::vector<uint8_t> const& recordBlob);
+    size_t addTenantToken(std::string const& tenantToken) override;
+    void addRecord(size_t dataPackageIndex, std::vector<uint8_t> const& recordBlob) override;
 
-    size_t getSizeEstimate() const;
-    std::vector<uint8_t> splice() const;
+    size_t getSizeEstimate() const override;
+    std::vector<uint8_t> splice() const override;
 
-    void clear();
+    void clear() override;
 };
 
 

--- a/lib/packager/ISplicer.hpp
+++ b/lib/packager/ISplicer.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+#ifndef ISPLICER_HPP
+#define ISPLICER_HPP
+
+#include "pal/PAL.hpp"
+#include "DataPackage.hpp"
+
+#include <list>
+#include <vector>
+
+namespace MAT_NS_BEGIN {
+
+class ISplicer
+{
+  protected:
+    struct Span {
+        size_t offset, length;
+    };
+
+    struct PackageInfo {
+        std::string     tenantToken;
+        Span            header;
+        std::list<Span> records;
+    };
+
+  public:
+    virtual ~ISplicer() noexcept = default;
+
+    virtual size_t addTenantToken(std::string const& tenantToken) = 0;
+    virtual void addRecord(size_t dataPackageIndex, std::vector<uint8_t> const& recordBlob) = 0;
+
+    virtual size_t getSizeEstimate() const = 0;
+    virtual std::vector<uint8_t> splice() const = 0;
+
+    virtual void clear() = 0;
+};
+
+
+} MAT_NS_END
+#endif

--- a/lib/packager/Packager.cpp
+++ b/lib/packager/Packager.cpp
@@ -23,7 +23,7 @@ namespace MAT_NS_BEGIN {
             if (ctx->maxUploadSize == 0) {
                 ctx->maxUploadSize = m_config.GetMaximumUploadSizeBytes();
             }
-            if (ctx->splicer.getSizeEstimate() + record.blob.size() > ctx->maxUploadSize) {
+            if (ctx->splicer->getSizeEstimate() + record.blob.size() > ctx->maxUploadSize) {
                 wantMore = false;
                 if (!ctx->recordIdsAndTenantIds.empty()) {
                     LOG_TRACE("Maximum upload size %u bytes exceeded, not adding the next event (ID %s, size %u bytes)",
@@ -49,10 +49,10 @@ namespace MAT_NS_BEGIN {
             auto it = ctx->packageIds.lower_bound(tenantToken);
             if (it == ctx->packageIds.end() || it->first != tenantToken)
             {
-                it = ctx->packageIds.insert(it, { tenantToken, ctx->splicer.addTenantToken(tenantToken) });
+                it = ctx->packageIds.insert(it, { tenantToken, ctx->splicer->addTenantToken(tenantToken) });
             }
 
-            ctx->splicer.addRecord(it->second, record.blob);
+            ctx->splicer->addRecord(it->second, record.blob);
 
             ctx->recordIdsAndTenantIds[record.id] = record.tenantToken;
             ctx->recordTimestamps.push_back(record.timestamp);
@@ -71,8 +71,8 @@ namespace MAT_NS_BEGIN {
             return;
         }
 
-        ctx->body = ctx->splicer.splice();
-        ctx->splicer.clear();
+        ctx->body = ctx->splicer->splice();
+        ctx->splicer->clear();
 
         packagedEvents(ctx);
     }

--- a/lib/system/Contexts.hpp
+++ b/lib/system/Contexts.hpp
@@ -3,6 +3,7 @@
 #pragma once
 #include "IHttpClient.hpp"
 #include "IOfflineStorage.hpp"
+#include "packager/ISplicer.hpp"
 #include "packager/BondSplicer.hpp"
 #include "pal/PAL.hpp"
 #include "utils/Utils.hpp"
@@ -80,7 +81,7 @@ namespace MAT_NS_BEGIN {
         unsigned                             requestedMaxCount = 0;
 
         // Packaging
-        BondSplicer                          splicer;
+        std::unique_ptr<ISplicer>            splicer;
         unsigned                             maxUploadSize = 0;
         EventLatency                         latency = EventLatency_Unspecified;
         std::map<std::string, size_t>        packageIds;
@@ -102,7 +103,13 @@ namespace MAT_NS_BEGIN {
         int                                  durationMs = -1;
         bool                                 fromMemory = false;
 
-        EventsUploadContext() noexcept
+        EventsUploadContext() noexcept : 
+            EventsUploadContext(std::unique_ptr<ISplicer>(new BondSplicer()))
+        {
+        }
+
+        EventsUploadContext(std::unique_ptr<ISplicer> &&splicer) : 
+            splicer(std::move(splicer))
         {
 #ifdef CRT_DEBUG_LEAKS
             objCount(1);

--- a/tests/unittests/BondSplicerTests.cpp
+++ b/tests/unittests/BondSplicerTests.cpp
@@ -25,7 +25,7 @@ class ShadowBondSplicer : protected MAT::BondSplicer
         MAT::BondSplicer::addRecord(dataPackageIndex, recordBlob);
     }
 
-    FullDumpBinaryBlob splice() const
+    std::vector<uint8_t> splice() const override
     {
         FullDumpBinaryBlob output;
         static_cast<std::vector<uint8_t>&>(output) = MAT::BondSplicer::splice();


### PR DESCRIPTION
In order to support App Insights flow ( #26 ) need a way to initialize `EventsUploadContext` with a different splicer (Json for example)

The PR extracts `ISplicer` interface from `BondSplicer` and make it injectable