### PR TITLE
Add a getter for pointer to the LogManager singleton instance

### DIFF
--- a/lib/include/public/LogManagerBase.hpp
+++ b/lib/include/public/LogManagerBase.hpp
@@ -678,10 +678,12 @@ namespace ARIASDK_NS_BEGIN
         }
 
         /// <summary>
-        /// Obtain a raw pointer to the ILogManager singleton instance
+        /// Obtain a raw pointer to the ILogManager singleton instance.
+        /// NOTE: this API should not be used concurrently with Initialize or FlushAndTeardown API calls.
         /// </summary>
-        static ILogManager* GetLogManagerInstance() noexcept
+        static ILogManager* GetInstance() noexcept
         {
+            LM_LOCKGUARD(stateLock());
             return instance;
         }
     };

--- a/tests/functests/BasicFuncTests.cpp
+++ b/tests/functests/BasicFuncTests.cpp
@@ -1445,14 +1445,14 @@ TEST_F(BasicFuncTests, raceBetweenUploadAndShutdownMultipleLogManagers)
 
 TEST_F(BasicFuncTests, logManager_getLogManagerInstance_uninitializedReturnsNull)
 {
-    auto lm = LogManager::GetLogManagerInstance();
+    auto lm = LogManager::GetInstance();
     EXPECT_EQ(lm,nullptr);
 }
 
 TEST_F(BasicFuncTests, logManager_getLogManagerInstance_initializedReturnsNonnull)
 {
     LogManager::Initialize();
-    auto lm = LogManager::GetLogManagerInstance();
+    auto lm = LogManager::GetInstance();
     EXPECT_NE(lm,nullptr);
     LogManager::FlushAndTeardown();
 }


### PR DESCRIPTION
The motivation behind this is to give us a way to use the same calling paradigm--operating on instance pointers--for both the LogManager singleton and additional LogManagers made via CreateLogManager().