### PR TITLE
Changing AppExperimentationImpressionId to Session.ImpressionId

### DIFF
--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/Constants.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/Constants.java
@@ -15,7 +15,6 @@ public class Constants {
 
     public static final String COMMONFIELDS_APP_EXPERIMENTIDS                       = "AppInfo.ExperimentIds";
     public static final String COMMONFIELDS_APP_EXPERIMENTETAG                      = "AppInfo.ETag";
-    public static final String COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID            = "AppInfo.ImpressionId";
 
     public static final String COMMONFIELDS_DEVICE_ID                               = "DeviceInfo.Id";
     public static final String COMMONFIELDS_DEVICE_MAKE                             = "DeviceInfo.Make";
@@ -58,6 +57,7 @@ public class Constants {
     public static final String SESSION_FIRST_TIME                                   = "Session.FirstLaunchTime";
     public static final String SESSION_STATE                                        = "Session.State";
     public static final String SESSION_ID                                           = "Session.Id";
+    public static final String SESSION_IMPRESSION_ID                                = "Session.ImpressionId";
     public static final String SESSION_DURATION                                     = "Session.Duration";
     public static final String SESSION_DURATION_BUCKET                              = "Session.DurationBucket";
     public static final String SESSION_ID_LEGACY                                    = "act_session_id";

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/SemanticContext.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/SemanticContext.java
@@ -104,7 +104,7 @@ class SemanticContext implements ISemanticContext {
      */
     @Override
     public void setAppExperimentImpressionId(final String appExperimentImpressionId) {
-        setCommonField(Constants.COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID, appExperimentImpressionId);
+        setCommonField(Constants.SESSION_IMPRESSION_ID, appExperimentImpressionId);
     }
 
     private native void nativeSetEventExperimentIds(long nativeISemanticContextPtr, String eventName, String experimentIds);

--- a/lib/api/ContextFieldsProvider.cpp
+++ b/lib/api/ContextFieldsProvider.cpp
@@ -125,13 +125,13 @@ namespace ARIASDK_NS_BEGIN
 
             if (!m_commonContextFields.empty())
             {
-                if (m_commonContextFields.find(COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID) != m_commonContextFields.end())
+                if (m_commonContextFields.find(SESSION_IMPRESSION_ID) != m_commonContextFields.end())
                 {
                     CsProtocol::Value temp;
-                    EventProperty prop = m_commonContextFields[COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID];
+                    EventProperty prop = m_commonContextFields[SESSION_IMPRESSION_ID];
                     temp.stringValue = prop.as_string;
 
-                    ext[COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID] = temp;
+                    ext[SESSION_IMPRESSION_ID] = temp;
                 }
 
                 if (m_commonContextFields.find(COMMONFIELDS_APP_EXPERIMENTETAG) != m_commonContextFields.end())

--- a/lib/include/public/CommonFields.h
+++ b/lib/include/public/CommonFields.h
@@ -14,7 +14,6 @@
 
 #define COMMONFIELDS_APP_EXPERIMENTIDS                       "AppInfo.ExperimentIds"
 #define COMMONFIELDS_APP_EXPERIMENTETAG                      "AppInfo.ETag"
-#define COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID            "AppInfo.ImpressionId"
 
 #define COMMONFIELDS_DEVICE_ID                               "DeviceInfo.Id"
 #define COMMONFIELDS_DEVICE_MAKE                             "DeviceInfo.Make"
@@ -57,6 +56,7 @@
 #define SESSION_FIRST_TIME                                   "Session.FirstLaunchTime"
 #define SESSION_STATE                                        "Session.State"
 #define SESSION_ID                                           "Session.Id"
+#define SESSION_IMPRESSION_ID                                "Session.ImpressionId"
 #define SESSION_DURATION                                     "Session.Duration"
 #define SESSION_DURATION_BUCKET                              "Session.DurationBucket"
 #define SESSION_ID_LEGACY                                    "act_session_id"

--- a/lib/include/public/ISemanticContext.hpp
+++ b/lib/include/public/ISemanticContext.hpp
@@ -71,7 +71,7 @@ namespace ARIASDK_NS_BEGIN
         /// Set the application experimentation impression id information of telemetry event.
         /// </summary>
         /// <param name="appExperimentIds">List of expementation IDs which are app/platform specific</param>
-        DECLARE_COMMONFIELD(AppExperimentImpressionId, COMMONFIELDS_APP_EXPERIMENT_IMPRESSION_ID);
+        DECLARE_COMMONFIELD(AppExperimentImpressionId, SESSION_IMPRESSION_ID);
 
         /// <summary>
         /// Set the experiment IDs information of the specified telemetry event.


### PR DESCRIPTION
Outlook iOS/Android depends on "Session.ImpressionId" to populate from "setAppExperimentationImpressionId", currently, the behavior populates "AppInfo.ImpressionId". Changing this back to how it was in the Aria SDK.

Addresses #564 