### PR TITLE
Reinstate custom decorator and add new usage example to it

### DIFF
--- a/docs/cpp-compiler-support.md
+++ b/docs/cpp-compiler-support.md
@@ -1,0 +1,39 @@
+# Modern C++ language and compiler support, and upgrade roadmap
+
+Current modern C++ version used for development is driven from C++ style guidelines across different projects/teams which predominantly use 1DS C++ SDK:
+
+1. [Chromium C++ guidlines](https://chromium-cpp.appspot.com/) : Chromium has default support available for C++11 ( with few exceptions ) and C++14 ( with few exceptions ), and NOT yet support C++17. As per the timelines mentioned in their website, C++17 support won't happen anytime before Mid-2021.
+
+2. [Azure SDK C++ Compiler Support](https://azure.github.io/azure-sdk/cpp_implementation.html#linux) : Azure SDK requires all client applications to compile successfully using GCC-4.8 compiler in order to run on RHEL 7+, Oracle 7+, Oracle Linux 7+, SLES12 SP2+. GCC 4.8.1 supports all major features of C++11 standard with exception of [N2670](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2670.htm) - _Minimal support for GC_. This requirement is driven from end of life cycle for these products. RHEL 7 has maintenance support till 30 June 2024, and SLES12 SP2 till 31st March 2021. The SDK guidelines are in draft, so this may change in future.
+
+3. [Office C++ Guidelines](https://github.com/microsoft/OfficeCppGuidelines/blob/master/CppCoreGuidelines.md) : Office C++ Guidelines cover C++17.
+
+Based on above guidelines, below are the C++ version support guidelines and future roadmap:
+
+1. 1DS C++ SDK code should compile successfully using below compiler versions (with C++11 support):
+    - Visual Studio 2017 or later.
+    - GNU Compiler Colletion (GCC) version 4.8 or later.
+    - Clang 3.4 or later
+    - Apple Clang 9.1 or later
+
+        There are places in code still using features `<codecvt>` header which is deprecated in C++17, this would be fixed.
+
+2. **C++11 features usability** : The 1DS SDK is written using C++11 features, and developers are encouraged to use these features as and when needed.
+
+3. **C++14 features usability** : One of the omissisions from C++11 standards, and made available in C++14 standard is support for `std::make_unique`. This is already [backported](https://github.com/microsoft/cpp_client_telemetry/blob/780205d2ea0298e41e82d54a3d203366f051cdf4/lib/utils/Utils.hpp#L28) in 1DS SDK, and hence compiles successfully with C++11 compilers.
+If there are any other features which needs to be used, contributions through PRs to backport them for C++11 compiler in 1DS SDK can be done. One of the benefit of supporing C++14 would be to enable use of Guidelines Support Library(GSL) library. We would re-visited this once Azure SDK lifts the requirement for supporting GCC 4.8 compiler. As of now, we can use C++14 features for Windows platform-specific code ( eg Winlnet or WinHTTP client, or other platform bindings), because we are alredy building with either Visual Studio 2017+ or modern clang (Chromium).
+
+4. **C++17 features usability** : C++17 features are not yet supported as per Chromium C++ guideline (see above), and hence 1DS SDK doesn't support using these features. This would be revisited around Mid-2021 once Chromium removes this restrictions. There are plans to backport some of the needed features like [std::variant](https://en.cppreference.com/w/cpp/utility/variant), [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view), and [std::visit](https://en.cppreference.com/w/cpp/utility/variant/visit) during this year(2020). For any other feature requirements, contributions through PRs to backport them for C++11 compiler in 1DS SDK can be done. Guidelines for backporting are been discussed in (Issue#557)[https://github.com/microsoft/cpp_client_telemetry/issues/557] and would be finalized soon.
+
+5. **C++20 features usability** : As of now, there are no timelines for support of C++20 features. There are plans to backport (std::span)[https://en.cppreference.com/w/cpp/container/span] during this year (2020). This can be optionally lifted from Microsoft GSL span (once we start supporting C++17), as it internally uses C++14 features.
+
+6. **End of Support** : As we start supporting builds using C++17 compiler, C++11 build support would be removed, and the backported features from C++14 and C++17 would be cleaned-up.
+
+Summarising roadmap in tabular format:
+
+| C++ Compilers | Currently Support | Start of Support | End of Support |
+| --- | --- | -- | -- |
+| C++11 | Yes | - | Mid-2021 |
+| C++14 | Yes ( Soft support for Windows specific components) | - | Mid-2021 |
+| C++17 | No | Mid-2021 | No Plans |
+| C++20 | No | No Plans | No Plans |

--- a/examples/cpp/EventSender/EventSender.cpp
+++ b/examples/cpp/EventSender/EventSender.cpp
@@ -11,9 +11,6 @@ using namespace MAT;
 // Define it once per .exe or .dll in any compilation module
 LOGMANAGER_INSTANCE
 
-// Replace line below by your API key
-#define TOKEN "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-xxxx"
-
 // Read configuration and event file contents
 std::string readall(const std::string& path)
 {
@@ -24,7 +21,8 @@ std::string readall(const std::string& path)
 
 #define JSON_CONFIG(...)    ( #__VA_ARGS__ )
 
-// Default configuration
+// Default configuration in JSON format. Telemetry by default is sent to "1DSCppSdkTest" tenant.
+// Please change "primaryToken" parameter below to send telemetry to your subscription.
 const char* defaultConfig = static_cast<const char *> JSON_CONFIG
 (
     {
@@ -48,7 +46,7 @@ const char* defaultConfig = static_cast<const char *> JSON_CONFIG
         "maxTeardownUploadTimeInSec" : 1,
         "minimumTraceLevel" : 4,
         "multiTenantEnabled" : true,
-        "primaryToken" : "6d084bbf6a9644ef83f40a77c9e34580-c2d379e0-4408-4325-9b4d-2a7d78131e14-7322",
+        "primaryToken" : "7c8b1796cbc44bd5a03803c01c2b9d61-b6e370dd-28d9-4a52-9556-762543cf7aa7-6991",
         "sample" : {
             "rate": 0
         },

--- a/examples/cpp/SampleCpp/main.cpp
+++ b/examples/cpp/SampleCpp/main.cpp
@@ -308,10 +308,13 @@ int main()
     printf("Teardown time: %d\n", int(config[CFG_INT_MAX_TEARDOWN_TIME]) );
     config[CFG_INT_SDK_MODE] = SdkModeTypes::SdkModeTypes_CS;
 
+#ifdef _WIN32
     // Code snippet showing how to perform MS Root certificate check for v10 end-point.
     // Most other end-points are Baltimore CA-rooted. But v10 is MS CA-rooted.
     config["http"]["msRootCheck"] = true;
     config[CFG_STR_COLLECTOR_URL] = "https://v10.events.data.microsoft.com/OneCollector/1.0/";
+#endif
+
     logger = LogManager::Initialize(API_KEY);
 
     logPiiMark();   // Direct upload

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -342,10 +342,16 @@ namespace PAL_NS_BEGIN {
         // number of days from beginning to 1601 multiplied by ticks per day
         return ticks + 0x701ce1722770000ULL;
 #else
-        // FIXME: [MG] - add millis remainder to ticks
-        std::time_t now = time(0);
-        MAT::time_ticks_t ticks(&now);
-        return ticks.ticks;
+        // On Un*x systems system_clock de-facto contains UTC time. Ref:
+        // https://en.cppreference.com/w/cpp/chrono/system_clock
+        // This UTC epoch contract has been signed in blood since C++20
+        std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
+        auto duration = now.time_since_epoch();
+        auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        uint64_t ticks = millis;
+        ticks *= 10000; // convert millis to ticks (1 tick = 100ns)
+        ticks += 0x89F7FF5F7B58000ULL; // UTC time 0 in .NET ticks
+        return ticks;
 #endif
     }
 


### PR DESCRIPTION
Closing #524  -- custom decorator feature got accidentally removed during merge conflict resolution. I'm adding the feature bindings back alongside with a small example that illustrates how to use the feature to inspect Part C props in a customer-supplied callback, which may come in handy for the OTEL PrivacyGuard feature.

I'd like to merge this first, then we can discuss possible subsequent improvements that I do not want to cover in this PR:
- chaining of decorators (this could already be done in customer code with existing solution, no SDK change)
- multiple decorators (do we ever need this if customers can chain decorators on their end?)
- currently a decorator may inspect and alter the data -- this was done by design, to allow populating any Common Schema attribute not exposed on API surface.
- example also shows how to change the `orgId` field using decorator - @kindbe, we discussed it in #566 , but I think it also makes sense to eventually provide a semantic API for that, i.e. not needing the decorator approach to populate `orgId`.


Decorator functional test simply prints out the values as follows:
```
Note: Google Test filter = *Custom_Decorator*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from APITest
[ RUN      ] APITest.Custom_Decorator
Event Name: foobar
Event Name: MyEvent.With.Props
- keyGuid=76CE7649-3A58-4861-8202-7D7FDFAED483
- keyString=Hello World!
[       OK ] APITest.Custom_Decorator (1219 ms)
[----------] 1 test from APITest (1221 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1223 ms total)
[  PASSED  ] 1 test.
```