### PR TITLE
Azure Monitor: Add GZIP header option to HttpDeflateCompression

### DIFF
--- a/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
+++ b/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
@@ -84,7 +84,7 @@ set(SRCS
 
 # Support for Azure Monitor / Application Insights
 if (BUILD_AZMON)
-    include(${SDK_ROOT}/lib/modules/azmon/CMakeLists.txt)
+    include(${SDK_ROOT}/lib/modules/azmon/CMakeLists.txt OPTIONAL)
 endif()
 
 if(EXISTS ${SDK_ROOT}/lib/modules/dataviewer/)

--- a/lib/api/IRuntimeConfig.hpp
+++ b/lib/api/IRuntimeConfig.hpp
@@ -130,6 +130,12 @@ namespace MAT_NS_BEGIN
         virtual bool IsHttpRequestCompressionEnabled() = 0;
 
         /// <summary>
+        /// Returns content encoding method for http request
+        /// </summary>
+        /// <returns>A string value (<i>deflate</i>) or (<i>gzip</i>).</returns>
+        virtual const std::string& GetHttpRequestContentEncoding() const = 0;
+
+        /// <summary>
         /// Gets the minimum bandwidth necessary to start an upload.
         /// </summary>
         /// <remarks>

--- a/lib/compression/HttpDeflateCompression.cpp
+++ b/lib/compression/HttpDeflateCompression.cpp
@@ -10,10 +10,13 @@
 
 namespace MAT_NS_BEGIN {
 
-
     HttpDeflateCompression::HttpDeflateCompression(IRuntimeConfig& runtimeConfig)
         : m_config(runtimeConfig)
     {
+        // Plain "deflate": negative -MAX_WBITS argument which makes zlib use "raw deflate"
+        // without zlib header, as required by IIS.
+        // "gzip": Add 16 to windowBits to write a simple gzip header
+        m_windowBits = m_config.GetHttpRequestContentEncoding() == "gzip" ? (MAX_WBITS | 16) : -MAX_WBITS;
     }
 
     HttpDeflateCompression::~HttpDeflateCompression()
@@ -34,10 +37,7 @@ namespace MAT_NS_BEGIN {
         z_stream stream;
         memset(&stream, 0, sizeof(stream));
 
-        // All values are defaults as would be used by a plain deflate(), except
-        // for the negative -MAX_WBITS argument which makes zlib use "raw deflate"
-        // without zlib header, as required by IIS.
-        int result = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -MAX_WBITS, 8 /*DEF_MEM_LEVEL*/, Z_DEFAULT_STRATEGY);
+        int result = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, m_windowBits, 8 /*DEF_MEM_LEVEL*/, Z_DEFAULT_STRATEGY);
         if (result != Z_OK) {
             LOG_WARN("HTTP request compressing failed, error=%u/%u (%s)", 1, result, stream.msg);
             compressionFailed(ctx);

--- a/lib/compression/HttpDeflateCompression.hpp
+++ b/lib/compression/HttpDeflateCompression.hpp
@@ -19,6 +19,7 @@ namespace MAT_NS_BEGIN {
 
     protected:
         IRuntimeConfig& m_config;
+        int m_windowBits;
 
     public:
         RouteSource<EventsUploadContextPtr const&>                              compressionFailed;

--- a/lib/config/RuntimeConfig_Default.hpp
+++ b/lib/config/RuntimeConfig_Default.hpp
@@ -49,6 +49,7 @@ namespace MAT_NS_BEGIN
              {CFG_BOOL_HTTP_COMPRESSION, false}
 #endif
              ,
+             {"contentEncoding", "deflate"},
              /* Optional parameter to require Microsoft Root CA */
              {CFG_BOOL_HTTP_MS_ROOT_CHECK, false}}},
         {CFG_MAP_TPM,
@@ -143,6 +144,11 @@ namespace MAT_NS_BEGIN
         virtual bool IsHttpRequestCompressionEnabled() override
         {
             return config[CFG_MAP_HTTP][CFG_BOOL_HTTP_COMPRESSION];
+        }
+
+        virtual const std::string& GetHttpRequestContentEncoding() const override
+        {
+            return config[CFG_MAP_HTTP]["contentEncoding"];
         }
 
         virtual unsigned GetMinimumUploadBandwidthBps() override

--- a/tests/common/Common.hpp
+++ b/tests/common/Common.hpp
@@ -63,4 +63,6 @@ namespace testing {
 
     bool Expand(const char* source, size_t sourceLen, char** dest, size_t& destLen, bool sizeAtZeroIndex);
 
+    void InflateVector(std::vector<uint8_t> &in, std::vector<uint8_t> &out, bool isGzip = false);
+
 } // namespace testing


### PR DESCRIPTION
AppInsights supports `gzip` compression for content encoding:
Add an option to configure `HttpDeflateCompression` to add `gzip` header
~~Adding it as and constructoe parameter since it's not really configurable~~ Added a private "contentEncoding" runtime configuration, when compression is enabled the events must be sent with gzip header


Private module integration PR:
https://github.com/microsoft/cpp_client_telemetry_modules/pull/40

Issue #26 
