### PR TITLE
Public headers had a dependency on private mat/config.h header

### DIFF
--- a/lib/include/mat/config-MIP.h
+++ b/lib/include/mat/config-MIP.h
@@ -14,3 +14,6 @@
 #if defined(_WIN32) && !defined(_WINRT_DLL)
 #define HAVE_MAT_NETDETECT
 #endif
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-MSIPC.h
+++ b/lib/include/mat/config-MSIPC.h
@@ -17,3 +17,6 @@
 #define HAVE_MAT_NETDETECT
 #endif
 */
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-compact-dll.h
+++ b/lib/include/mat/config-compact-dll.h
@@ -11,3 +11,6 @@
 /* #define HAVE_MAT_NETDETECT  */
 /* #define HAVE_MAT_SHORT_NS   */
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-compact-exp.h
+++ b/lib/include/mat/config-compact-exp.h
@@ -11,3 +11,6 @@
 /* #define HAVE_MAT_NETDETECT  */
 /* #define HAVE_MAT_SHORT_NS   */
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-compact-min.h
+++ b/lib/include/mat/config-compact-min.h
@@ -11,3 +11,6 @@
 /* #define HAVE_MAT_NETDETECT  */
 /* #define HAVE_MAT_SHORT_NS   */
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-compact-noutc.h
+++ b/lib/include/mat/config-compact-noutc.h
@@ -11,3 +11,6 @@
 /* #define HAVE_MAT_NETDETECT   */
 #define HAVE_MAT_SHORT_NS
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-compact.h
+++ b/lib/include/mat/config-compact.h
@@ -11,3 +11,6 @@
 /* #define HAVE_MAT_NETDETECT   */
 #define HAVE_MAT_SHORT_NS
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/mat/config-default-cs4.h
+++ b/lib/include/mat/config-default-cs4.h
@@ -16,5 +16,6 @@
 #if defined(_WIN32) && !defined(_WINRT_DLL)
 #define HAVE_MAT_NETDETECT
 #endif
+//#define HAVE_CS3
 #define HAVE_CS4
 #define HAVE_CS4_FULL

--- a/lib/include/mat/config-default.h
+++ b/lib/include/mat/config-default.h
@@ -21,5 +21,6 @@
 #if defined(_WIN32) && !defined(_WINRT_DLL)
 #define HAVE_MAT_NETDETECT
 #endif
+#define HAVE_CS3
 //#define HAVE_CS4
 //#define HAVE_CS4_FULL

--- a/lib/include/mat/config-net40.h
+++ b/lib/include/mat/config-net40.h
@@ -15,3 +15,6 @@
 #define HAVE_MAT_NETDETECT
 #endif
 */
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL

--- a/lib/include/public/CsProtocol_types.hpp
+++ b/lib/include/public/CsProtocol_types.hpp
@@ -25,7 +25,18 @@
 //------------------------------------------------------------------------------
 
 #pragma once
+
+// In order to enable Common Schema 4.x the products using shared library build MUST
+// #define HAVE_CS4 or add -DHAVE_CS4 to their build flags.
+
+// For statically linked SDK the header below is available and determines whether the
+// build includes Common Schema 3.x or 4.x implementation of the protocol.
+#if defined __has_include
+#if __has_include("mat/config.h")
 #include "mat/config.h"
+#endif
+#endif
+
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -17,8 +17,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.4.254.1"
-#define BUILD_VERSION 3,4,254,1
+#define BUILD_VERSION_STR "3.4.269.1"
+#define BUILD_VERSION 3,4,269,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include <stdint.h>
@@ -44,7 +44,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)4 << 32) |
-    ((uint64_t)254 << 16) |
+    ((uint64_t)269 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END


### PR DESCRIPTION
I was helping somebody with a sample app on Windows today, and just realized that we started using `CsProtocol_types.hpp` with the introduction of Privacy Guard. The issue is that `CsProtocol_types.hpp` **public** SDK header includes `mat/config.h` **private** header to determine whether the protocol structure is CS3.x or CS4.x ... Now that obviously breaks the sample apps. Samples won't compile anymore 😀 

Since we, by default, presently assume and prefer CS3.x, there's a very minor mod needed to avoid including the missing config file. Then any product that is clearly aware that they are on CS4.x (once later on they switch to CS4.x), would have to define a `-DHAVE_CS4` in their build system. That way the right structure will be compiled in. This affects only shared lib builds, and does not affect statically linked bits. Usually the entire SDK source is avail to somebody who's doing static linking.

Now an obvious implication that `CsProtocol` and its classes is NOT ABI safe. Anyone who's gonna be registering a custom decorator at runtime should be clearly aware that their custom decorator is compiled with the matching protocol revision. This is NOT a pain-point currently while we're still on CS3.x, and this will not be a pain-point later on when everything is switched to CS4.x by default and all deps are gonna be recompiled..

Just keep an eye on this. @sid-dahiya 