### PR TITLE
Update OfflineStorage_SQLite.cpp

### DIFF
--- a/lib/offline/OfflineStorage_SQLite.cpp
+++ b/lib/offline/OfflineStorage_SQLite.cpp
@@ -864,7 +864,7 @@ namespace MAT_NS_BEGIN {
         }
         pageCountStmt.getRow(pageCount);
         pageCountStmt.reset();
-        return pageCount * m_pageSize;
+        return size_t(pageCount) * size_t(m_pageSize);
     }
 
     size_t OfflineStorage_SQLite::GetRecordCountUnsafe(EventLatency latency) const


### PR DESCRIPTION
Fix security warnings by converting both arguments to size_t using function cast

Fixes #687 