### PR TITLE
Update build-gtest.sh

### DIFF
--- a/build-gtest.sh
+++ b/build-gtest.sh
@@ -35,8 +35,8 @@ mkdir -p build || true
 cd build
 cmake -Dgtest_build_samples=OFF \
       -Dgmock_build_samples=OFF \
-      -Dgtest_build_tests=$BUILD_TESTS \
-      -Dgmock_build_tests=$BUILD_TESTS \
+      -Dgtest_build_tests=OFF \
+      -Dgmock_build_tests=OFF \
       -DCMAKE_CXX_FLAGS="-fPIC $CXX_FLAGS" \
       -DBUILD_IOS=$IOS_BUILD \
       ..


### PR DESCRIPTION
There's some recent update on Mac OS X that now fails the gtest build. I am temporarily turning off the tests of GTest build (where the failure is happening). Most likely we need to stop building our legacy GTest included in the repo - switching to what Linux is doing (building GTest from their GitHub master).