### PR TITLE
Fix essential OACR warning: "result" is dereferenced, but may still be NULL

### DIFF
--- a/lib/system/EventProperties.cpp
+++ b/lib/system/EventProperties.cpp
@@ -450,6 +450,11 @@ namespace MAT_NS_BEGIN {
     {
         size_t size = m_storage->properties.size() + m_storage->propertiesPartB.size() + 1;
         evt_prop * result = static_cast<evt_prop *>(calloc(sizeof(evt_prop), size));
+        if (result==nullptr)
+        {
+            LOG_ERROR("Unable to allocate memory to pack EventProperties");
+            return result;
+        };
         size_t i = 0;
         for(auto &props : { m_storage->properties, m_storage->propertiesPartB })
             for (auto &kv : props)
@@ -483,6 +488,11 @@ namespace MAT_NS_BEGIN {
     bool EventProperties::unpack(evt_prop *packed, size_t size)
     {
         evt_prop *curr = packed;
+        if (packed==nullptr)
+        {
+            // Invalid input (nullptr) from C API results in an empty property bag
+            return false;
+        };
 
         // Verify size using size_t size parameter passed down by evt_log_s API call
         if (size == 0)


### PR DESCRIPTION
This appears to be the only `<IMPORTANCE>Essential</IMPORTANCE>` warning in the list of warnings.

Both scenarios being fixed are highly unlikely in real-world. Both are related to C API and do not impact pure C++ customers:

- 1st fix: scenario `pack` - device is dramatically out-of-memory. The system should've crashed elsewhere already. Now we silently ignore `packing` EventProperties into C-style struct. We do not employ this code anywhere in a pure C++ API use-case.

- 2nd fix: scenario `unpack` - user passes in an invalid (nullptr) input from C API. Previously we were crashing, punishing the user. Now we'll treat `nullptr` input as empty properties list, that'll result in an empty event, that will be ignored and reported as invalid to C++ Debug Event listener in the rest of the flow (if Event listener is registered). Also `unpack` API call now returns `false` if called with invalid pointer.