### PR TITLE
Fix potential hang in NetworkDetector for short-lived LogManagers

### DIFF
--- a/lib/pal/desktop/NetworkDetector.cpp
+++ b/lib/pal/desktop/NetworkDetector.cpp
@@ -380,10 +380,8 @@ namespace MAT_NS_BEGIN
             }
 
             MSG msg;
-            m_listener_tid = GetCurrentThreadId();
             PostThreadMessage(m_listener_tid, NETDETECTOR_START, 0, 0);
             {
-                std::unique_lock<std::mutex> lock(m_lock);
                 cv.notify_all();
             }
 
@@ -437,8 +435,6 @@ namespace MAT_NS_BEGIN
                 pNlm->Release();
                 pNlm = nullptr;
             };
-
-            m_listener_tid = 0;
         }
 
         /// <summary>
@@ -531,10 +527,15 @@ namespace MAT_NS_BEGIN
             // Start a new thread. Notify waiters on exit.
             netDetectThread = std::thread([this]()
             {
+                {
+                  std::lock_guard<std::mutex> lk(m_lock);
+                  m_listener_tid = GetCurrentThreadId();
+                }
                 run();
                 LOG_TRACE("NetworkDetector tid=%p is shutting down..", m_listener_tid);
                 {
                     std::lock_guard<std::mutex> lk(m_lock);
+                    m_listener_tid = 0;
                     isRunning = false;
                 }
             });
@@ -549,8 +550,8 @@ namespace MAT_NS_BEGIN
                     // - COM object can't be started (pre-Win 8 scenario)
                     int retry = 1;
                     constexpr int max_retries = 2;
-                    while (!cv.wait_for(lock, std::chrono::milliseconds(NETDETECTOR_COM_SETTLE_MS),
-                        [this] {return (m_listener_tid != 0); }) && (isRunning) && (retry < max_retries))
+                    while (cv.wait_for(lock, std::chrono::milliseconds(NETDETECTOR_COM_SETTLE_MS))
+                           == std::cv_status::timeout && (retry < max_retries))
                     {
                         LOG_TRACE("NetworkDetector starting up... [%u]", retry);
                         retry++;
@@ -573,18 +574,26 @@ namespace MAT_NS_BEGIN
         /// </summary>
         void NetworkDetector::Stop()
         {
-            if ((isRunning) || (netDetectThread.joinable()))
+            if (netDetectThread.joinable())
             {
-                PostThreadMessage(m_listener_tid, NETDETECTOR_STOP, 0, NULL);
-                try {
-                    if (netDetectThread.joinable())
-                        netDetectThread.join();
-                    LOG_TRACE("NetworkDetector tid=%p has stopped.", m_listener_tid);
-                }
-                catch (std::system_error &ex)
+                std::unique_lock<std::mutex> lk(m_lock);
+                if (!isRunning || m_listener_tid == 0 ||
+                    !PostThreadMessage(m_listener_tid, NETDETECTOR_STOP, 0, NULL))
                 {
-                    UNREFERENCED_PARAMETER(ex);
-                    LOG_WARN("NetworkDetector tid=%p is already stopped.", m_listener_tid);
+                    LOG_ERROR("NetworkDetector thread unable to be shut down.");
+                }
+                else
+                {
+                    try {
+                        lk.unlock();
+                        netDetectThread.join();
+                        LOG_TRACE("NetworkDetector tid=%p has stopped.", m_listener_tid);
+                    }
+                    catch (std::system_error &ex)
+                    {
+                        UNREFERENCED_PARAMETER(ex);
+                        LOG_WARN("NetworkDetector tid=%p is already stopped.", m_listener_tid);
+                    }
                 }
             }
         };

--- a/lib/pal/desktop/NetworkDetector.hpp
+++ b/lib/pal/desktop/NetworkDetector.hpp
@@ -127,8 +127,8 @@ namespace MAT_NS_BEGIN
 
                     std::mutex                          m_lock;
                     std::condition_variable             cv;
-                    bool                                isRunning;
-                    bool                                isCoInitialized;
+                    bool                                isRunning = false;
+                    bool                                isCoInitialized = false;
                     std::thread                         netDetectThread;
 
                     /// <summary>
@@ -145,7 +145,7 @@ namespace MAT_NS_BEGIN
                     DWORD                               m_dwCookie_INetworkEvents;
                     DWORD                               m_dwCookie_INetworkConnectionEvents;
                     DWORD                               m_dwCookie_INetworkListManagerEvents;
-                    DWORD                               m_listener_tid;
+                    DWORD                               m_listener_tid = 0;
 
                     NLM_CONNECTIVITY                    m_connectivity;
 


### PR DESCRIPTION
Due to when the thread id is set, and the performance of COM operations on slow machines, it's possible for PostThreadMessage to not have a valid thread id for sending NETDETECTOR_STOP. This change sets the thread id much earlier and adds logic to verify that PostThreadMessage has sent NETDETECTOR_STOP before joining the thread. On low-performance machines with a short-lived log manager, this was very consistently causing hangs for users.

I still think there's opportunities to improve this code:
* Not creating a thread separately from the worker thread
* Not needing to wait on a join, but we'd need to clean the thread logic up to use weak pointers