### PR TITLE
Improve NetworkDetector perf when thread exits early

### DIFF
--- a/lib/pal/desktop/NetworkDetector.cpp
+++ b/lib/pal/desktop/NetworkDetector.cpp
@@ -597,8 +597,8 @@ namespace MAT_NS_BEGIN
                 }
                 catch (std::system_error &ex)
                 {
-                  UNREFERENCED_PARAMETER(ex);
-                  LOG_WARN("NetworkDetector tid=%p is already stopped.", m_listener_tid);
+                    UNREFERENCED_PARAMETER(ex);
+                    LOG_WARN("NetworkDetector tid=%p is already stopped.", m_listener_tid);
                 }
             }
         };


### PR DESCRIPTION
As part of #747, performance when the NetworkDetector thread exits early (common on down-level windows) may've gotten worse, since isRunning was no longer checked as part of the wait_for predicate. This fixes that issue, and should also improve performance by:
* checking isRunning before waiting
* notifying the conditional variable when the thread exits (no-op if nothing is waiting).

Also fixes an issue where the destructor may've thrown an exception.