### PR TITLE
Suppress Clang inconsistent-missing-override warnings around GMock Macros

### DIFF
--- a/tests/common/MockIEcsClient.hpp
+++ b/tests/common/MockIEcsClient.hpp
@@ -8,6 +8,10 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
 
 #ifdef _MSC_VER
 // Avoid noise caused by ECS using const modifier on value-type arguments like int, bool and double.
@@ -63,6 +67,9 @@ class MockIEcsClient : public ecsclient::IEcsClient {
     MOCK_METHOD0(ResumeSendingRequests, void());
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockIHttpClient.hpp
+++ b/tests/common/MockIHttpClient.hpp
@@ -9,6 +9,10 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
 
 class MockIHttpClient : public MAT::IHttpClient {
   public:
@@ -20,6 +24,9 @@ class MockIHttpClient : public MAT::IHttpClient {
     MOCK_METHOD1(CancelRequestAsync, void(std::string const & id));
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockILogManagerInternal.hpp
+++ b/tests/common/MockILogManagerInternal.hpp
@@ -13,6 +13,11 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
+
     class MockILogManagerInternal : public MAT::ILogManagerInternal
     {
     public:
@@ -48,6 +53,10 @@ namespace testing {
         MOCK_METHOD4(GetLogger, MAT::ILogger * (std::string const &, MAT::ContextFieldsProvider*, std::string const &, std::string const &));
         MOCK_METHOD1(sendEvent, void(MAT::IncomingEventContextPtr const &));
     };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockIOfflineStorage.hpp
+++ b/tests/common/MockIOfflineStorage.hpp
@@ -9,6 +9,10 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
 
 class MockIOfflineStorage : public MAT::IOfflineStorage {
   public:
@@ -34,9 +38,12 @@ class MockIOfflineStorage : public MAT::IOfflineStorage {
     MOCK_METHOD0(DeleteAllRecords, void());
     MOCK_CONST_METHOD1(GetRecordCount, size_t(MAT::EventLatency));
     MOCK_METHOD3(GetRecords, std::vector<MAT::StorageRecord>(bool, MAT::EventLatency, unsigned));
-	MOCK_METHOD0(ResizeDb, bool());
+    MOCK_METHOD0(ResizeDb, bool());
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockIOfflineStorageObserver.hpp
+++ b/tests/common/MockIOfflineStorageObserver.hpp
@@ -8,6 +8,10 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
 
 class MockIOfflineStorageObserver : public MAT::IOfflineStorageObserver {
   public:
@@ -23,6 +27,9 @@ class MockIOfflineStorageObserver : public MAT::IOfflineStorageObserver {
     MOCK_METHOD1(OnStorageRecordsSaved, void(size_t numRecords));
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockIRuntimeConfig.hpp
+++ b/tests/common/MockIRuntimeConfig.hpp
@@ -10,6 +10,11 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
+
     class MockIRuntimeConfig : public MAT::RuntimeConfig_Default /* MAT::IRuntimeConfig */ {
 
     protected:
@@ -49,6 +54,9 @@ namespace testing {
 
     };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockISemanticContext.hpp
+++ b/tests/common/MockISemanticContext.hpp
@@ -8,6 +8,10 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
 
 class MockISemanticContext : public MAT::ContextFieldsProvider {
   public:
@@ -31,6 +35,9 @@ class MockISemanticContext : public MAT::ContextFieldsProvider {
     MOCK_METHOD2(SetEventExperimentIds, void(std::string const& eventName, std::string const& experimentIds));
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace testing
 

--- a/tests/common/MockISqlite3Proxy.hpp
+++ b/tests/common/MockISqlite3Proxy.hpp
@@ -12,6 +12,10 @@
 
 namespace testing {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use override.
+#endif
 
 class MockISqlite3Proxy : public MAT::ISqlite3Proxy {
   public:
@@ -53,6 +57,9 @@ class MockISqlite3Proxy : public MAT::ISqlite3Proxy {
     MOCK_METHOD1(sqlite3_vfs_find, sqlite3_vfs * (char const* zVfsName));
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 }  // namespace testing
 

--- a/tests/common/MockITelemetrySystem.hpp
+++ b/tests/common/MockITelemetrySystem.hpp
@@ -12,6 +12,11 @@ using namespace MAT;
 
 namespace testing {
 
+#if defined( __clang__ )
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override" // GMock MOCK_METHOD* macros don't use override.
+#endif
+
     class MockITelemetrySystem : public ITelemetrySystem {
     public:
         MockITelemetrySystem() {};
@@ -56,6 +61,10 @@ namespace testing {
         MOCK_METHOD1(handleIncomingEventPrepared, void(IncomingEventContextPtr const& event));
         MOCK_METHOD1(preparedIncomingEventAsync, void(IncomingEventContextPtr const& event));
     };
+
+#if defined( __clang__ )
+#pragma clang diagnostic pop
+#endif
 
 }  // namespace MAT_NS_BEGIN
 

--- a/tests/common/MockITenantDataSerializer.hpp
+++ b/tests/common/MockITenantDataSerializer.hpp
@@ -15,6 +15,12 @@ namespace testing
 {
 #pragma warning(push)
 #pragma warning(disable:4373)
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"  // GMock MOCK_METHOD* macros don't use the override keyword.
+#endif
+
     class MockITenantDataSerializer : public ITenantDataSerializer
     {
     public:
@@ -23,6 +29,10 @@ namespace testing
         MOCK_CONST_METHOD1(SerializeTenantData, std::string(TenantDataPtr tenantData));
         MOCK_CONST_METHOD1(DeserializeTenantData, TenantDataPtr(const std::string& string));
     };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 #pragma warning(pop)
 } // namespace testing
-

--- a/tests/unittests/UnitTests.vcxproj
+++ b/tests/unittests/UnitTests.vcxproj
@@ -471,7 +471,6 @@
     <ClInclude Include="$(ProjectDir)..\common\MockIBandwidthController.hpp" />
     <ClInclude Include="$(ProjectDir)..\common\MockIEcsClient.hpp" />
     <ClInclude Include="$(ProjectDir)..\common\MockIHttpClient.hpp" />
-    <ClInclude Include="$(ProjectDir)..\common\MockILocalStorageReader.hpp" />
     <ClInclude Include="$(ProjectDir)..\common\MockILogManagerInternal.hpp" />
     <ClInclude Include="$(ProjectDir)..\common\MockIOfflineStorage.hpp" />
     <ClInclude Include="$(ProjectDir)..\common\MockIOfflineStorageObserver.hpp" />
@@ -483,18 +482,18 @@
     <ClInclude Include="$(ProjectDir)..\common\SocketTools.hpp" />
     <ClInclude Include="CheckForExceptionOrAbort.hpp" />
   </ItemGroup>
-  <ItemGroup Condition = "exists('$(ProjectDir)..\..\lib\modules\exp')">
+  <ItemGroup Condition="exists('$(ProjectDir)..\..\lib\modules\exp')">
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSConfigCacheTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientUtilsTests.cpp" />
   </ItemGroup>
-  <ItemGroup Condition = "exists('$(ProjectDir)..\..\lib\modules\privacyguard')">
+  <ItemGroup Condition="exists('$(ProjectDir)..\..\lib\modules\privacyguard')">
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyGuardTests.cpp" />
   </ItemGroup>
-  <ItemGroup Condition = "exists('$(ProjectDir)..\..\lib\modules\dataviewer')">
+  <ItemGroup Condition="exists('$(ProjectDir)..\..\lib\modules\dataviewer')">
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\dataviewer\tests\unittests\DefaultDataViewerTests.cpp" />
     <ClCompile Include="$(ProjectDir)\DataViewerCollectionTests.cpp" />
-  </ItemGroup>   
+  </ItemGroup>
   <Import Project="$(SolutionDir)\build.props" Condition="Exists('$(SolutionDir)\build.props')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/tests/unittests/UnitTests.vcxproj.filters
+++ b/tests/unittests/UnitTests.vcxproj.filters
@@ -9,7 +9,6 @@
     <ClCompile Include="$(ProjectDir)\CorrelationVectorTests.cpp" />
     <ClCompile Include="$(ProjectDir)\DataViewerCollectionTests.cpp" />
     <ClCompile Include="$(ProjectDir)\DebugEventSourceTests.cpp" />
-    <ClCompile Include="$(ProjectDir)\DefaultDataViewerTests.cpp" />
     <ClCompile Include="$(ProjectDir)\DiskLocalStorageTests.cpp" />
     <ClCompile Include="$(ProjectDir)\EventPropertiesStorageTests.cpp" />
     <ClCompile Include="$(ProjectDir)\EventPropertiesTests.cpp" />
@@ -31,7 +30,6 @@
     <ClCompile Include="$(ProjectDir)\OfflineStorageTests_SQLite.cpp" />
     <ClCompile Include="$(ProjectDir)\PackagerTests.cpp" />
     <ClCompile Include="$(ProjectDir)\PalTests.cpp" />
-    <ClCompile Include="$(ProjectDir)\PrivacyGuardTests.cpp" />
     <ClCompile Include="$(ProjectDir)\RouteTests.cpp" />
     <ClCompile Include="$(ProjectDir)\StringUtilsTests.cpp" />
     <ClCompile Include="$(ProjectDir)\TaskDispatcherCAPITests.cpp" />
@@ -53,17 +51,16 @@
     <ClCompile Include="$(ProjectDir)\LoggerTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\common\Reactor.cpp" />
     <ClCompile Include="$(ProjectDir)\DeviceStateHandlerTests.cpp" />
-    <ClCompile Include="$(ProjectDir)\ECSClientTests.cpp" />
-    <ClCompile Include="$(ProjectDir)\ECSClientUtilsTests.cpp" />
-    <ClCompile Include="$(ProjectDir)\ECSConfigCacheTests.cpp" />
     <ClCompile Include="$(ProjectDir)\AIJsonSerializerTests.cpp" />
     <ClCompile Include="$(ProjectDir)\AITelemetrySystemTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSConfigCacheTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientUtilsTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyGuardTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\dataviewer\tests\unittests\DefaultDataViewerTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(ProjectDir)..\common\MockIHttpClient.hpp">
-      <Filter>mocks</Filter>
-    </ClInclude>
-    <ClInclude Include="$(ProjectDir)..\common\MockILocalStorageReader.hpp">
       <Filter>mocks</Filter>
     </ClInclude>
     <ClInclude Include="$(ProjectDir)..\common\MockILogManagerInternal.hpp">


### PR DESCRIPTION
`MOCK_METHOD` macros and their ilk appear to not append the `override` keyword to their generated method declarations. As such I'm disabling Clang's[ inconsistent-missing-override](https://clang.llvm.org/docs/DiagnosticsReference.html#winconsistent-missing-override) warning around only those types.

I also cleaned up the vcproj, let me know if I missed anything and I'm happy to undo that.