### PR TITLE
Build is broken if compiling without modules

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: 'true'
+      continue-on-error: true
     - name: Chocolatey
       run: |
         $Env:ANDROID_SDK_ROOT = "C:\Android\android-sdk"

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-        token:  ${{ secrets.GIT_PULL_TOKEN }}
     - name: Chocolatey
       run: |
         $Env:ANDROID_SDK_ROOT = "C:\Android\android-sdk"

--- a/.github/workflows/build-ios-latest.yml
+++ b/.github/workflows/build-ios-latest.yml
@@ -23,9 +23,5 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
-        token:  ${{ secrets.GIT_PULL_TOKEN }}
     - name: build
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
       run: ./build-tests-ios.sh ${{ matrix.config }} ${{ matrix.simulator }}

--- a/.github/workflows/build-ios-latest.yml
+++ b/.github/workflows/build-ios-latest.yml
@@ -23,5 +23,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      continue-on-error: true
     - name: build
       run: ./build-tests-ios.sh ${{ matrix.config }} ${{ matrix.simulator }}

--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -24,7 +24,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Test ${{ matrix.os }} ${{ matrix.config }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
       run: ./build-tests.sh ${{ matrix.config }}

--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -22,6 +22,8 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
+      continue-on-error: true
     - name: Test ${{ matrix.os }} ${{ matrix.config }}
       run: ./build-tests.sh ${{ matrix.config }}

--- a/.github/workflows/build-windows-clang.yaml
+++ b/.github/workflows/build-windows-clang.yaml
@@ -28,8 +28,6 @@ jobs:
 
     - name: Build
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
         VSTOOLS_VERSION: vs2019
       shell: cmd
       run: build-cmake-clang-vs2019.cmd

--- a/.github/workflows/build-windows-clang.yaml
+++ b/.github/workflows/build-windows-clang.yaml
@@ -18,6 +18,7 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
+      continue-on-error: true
 
     - name: Setup Tools
       env:

--- a/.github/workflows/build-windows-vs2017.yaml
+++ b/.github/workflows/build-windows-vs2017.yaml
@@ -25,8 +25,6 @@ jobs:
 
     - name: Build
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
         SKIP_ARM_BUILD: 1
         SKIP_ARM64_BUILD: 1
         SKIP_DEBUG_BUILD: 1

--- a/.github/workflows/build-windows-vs2017.yaml
+++ b/.github/workflows/build-windows-vs2017.yaml
@@ -18,6 +18,7 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
+      continue-on-error: true
 
     - name: Setup Tools
       shell: cmd

--- a/.github/workflows/build-windows-vs2019.yaml
+++ b/.github/workflows/build-windows-vs2019.yaml
@@ -25,8 +25,6 @@ jobs:
 
     - name: Build
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
         SKIP_ARM_BUILD: 1
         SKIP_ARM64_BUILD: 1
         PlatformToolset: v142

--- a/.github/workflows/build-windows-vs2019.yaml
+++ b/.github/workflows/build-windows-vs2019.yaml
@@ -18,6 +18,7 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v2
+      continue-on-error: true
 
     - name: Setup Tools
       shell: cmd

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,8 +29,9 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
-    - name: Checkout repository
+    - name: Checkout
       uses: actions/checkout@v2
+      continue-on-error: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: check out code
+
+    - name: Checkout
       uses: actions/checkout@v2
+      continue-on-error: true
 
     - name: install misspell
       run: |

--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -21,7 +21,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-        token:  ${{ secrets.GIT_PULL_TOKEN }}
     - name: Build and Test
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -17,10 +17,13 @@ jobs:
     runs-on: macos-latest
     name: Android Unit Tests (Mac)
     steps:
+
     - name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
+      continue-on-error: true
+
     - name: Build and Test
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -25,8 +25,5 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Test ${{ matrix.arch }} ${{ matrix.config }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GIT_PULL_TOKEN: ${{ secrets.GIT_PULL_TOKEN }}
       shell: cmd
       run: build-tests.cmd ${{ matrix.arch }} ${{ matrix.config }}

--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -23,7 +23,11 @@ jobs:
         os: [windows-2016]
     
     steps:
-    - uses: actions/checkout@v1
+
+    - name: Checkout
+      uses: actions/checkout@v1
+      continue-on-error: true
+
     - name: Test ${{ matrix.arch }} ${{ matrix.config }}
       shell: cmd
       run: build-tests.cmd ${{ matrix.arch }} ${{ matrix.config }}

--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 By contributing to 1DS C++ SDK repository, you agree that your contributions
 will be licensed under [Apache License 2.0](LICENSE).
+

--- a/lib/android_build/app/src/androidTest/java/com/microsoft/applications/events/maesdktest/LogManagerDDVUnitTest.java
+++ b/lib/android_build/app/src/androidTest/java/com/microsoft/applications/events/maesdktest/LogManagerDDVUnitTest.java
@@ -237,14 +237,14 @@ public class LogManagerDDVUnitTest extends MaeUnitLogger {
         copyConfig.getLogConfiguration(LogConfigurationKey.CFG_MAP_TPM), is(not(nullValue())));
     final ILogger secondaryLogger = secondaryManager.getLogger(contosoToken, "contoso", "");
 
-    assertThat(
-        secondaryManager.initializeDiagnosticDataViewer("contoso", "http://10.0.0.2"), is(true));
-    assertThat(secondaryManager.isViewerEnabled(), is(true));
-    secondaryLogger.logEvent("some.event");
+    if (secondaryManager.initializeDiagnosticDataViewer("contoso", "http://10.0.0.2")) {
+      assertThat(secondaryManager.isViewerEnabled(), is(true));
+      secondaryLogger.logEvent("some.event");
 
-    secondaryManager.flush();
-    secondaryManager.pauseTransmission();
-    secondaryManager.disableViewer();
+      secondaryManager.flush();
+      secondaryManager.pauseTransmission();
+      secondaryManager.disableViewer();
+    }
     LogManager.flushAndTeardown();
   }
 

--- a/lib/include/mat/config-default.h
+++ b/lib/include/mat/config-default.h
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #define EVTSDK_VERSION_PREFIX "EVT"
-#if defined(_WIN32) /* && defined(HAVE_PRIVATE_MODULES) */
-#define HAVE_MAT_UTC
-#define HAVE_MAT_AI
+#if defined(_WIN32)
+#if defined __has_include
+#  if __has_include ("modules/azmon/AITelemetrySystem.hpp")
+#    define HAVE_MAT_AI
+#  endif
+#  if __has_include ("modules/utc/UtcTelemetrySystem.hpp")
+#    define HAVE_MAT_UTC
+#  endif
+#endif
 #endif
 #if defined(HAVE_PRIVATE_MODULES)
 #define HAVE_MAT_EXP

--- a/lib/offline/OfflineStorageFactory.cpp
+++ b/lib/offline/OfflineStorageFactory.cpp
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include "mat/config.h"
+
+#pragma once
+#include "pal/PAL.hpp"
+
 #include "OfflineStorageFactory.hpp"
 
 #ifdef USE_ROOM
@@ -10,6 +14,8 @@
 #else
 #include "offline/OfflineStorage_SQLite.hpp"
 #endif
+
+#include <memory>
 
 namespace MAT_NS_BEGIN
 {
@@ -29,6 +35,8 @@ namespace MAT_NS_BEGIN
         return std::make_shared<OfflineStorage_SQLite>(logManager, runtimeConfig);
 #endif //USE_ROOM
 #else
+        UNREFERENCED_PARAMETER(logManager);
+        UNREFERENCED_PARAMETER(runtimeConfig);
         LOG_TRACE("MAT storage disabled");
         return nullptr;
 #endif //HAVE_MAT_STORAGE

--- a/lib/offline/OfflineStorageFactory.hpp
+++ b/lib/offline/OfflineStorageFactory.hpp
@@ -5,7 +5,6 @@
 #ifndef OFFLINESTORAGEFACTORY_HPP
 #define OFFLINESTORAGEFACTORY_HPP
 
-#ifdef HAVE_MAT_STORAGE
 #include "IOfflineStorage.hpp"
 #include "api/IRuntimeConfig.hpp"
 
@@ -18,8 +17,6 @@ namespace MAT_NS_BEGIN
     };
 }
 MAT_NS_END
-
-#endif // HAVE_MAT_STORAGE
 
 #endif  // HTTPCLIENTFACTORY_HPP
 


### PR DESCRIPTION
Motivation for this PR:

- make sure that the entire set of tests for all platforms is functional and passing even if compiling without private modules.

- remove private submodules cloning from GitHub Actions. Azure DevOps / VSO workflow may still be able to clone all if build account is explicitly authorized (for local runs in your own Docker). But we are not longer using PAT token for the clone action here.

While testing these changes I also did a full build in Visual Studio to cover additional extra projects that are not presently covered by CI, e.g. `ClientTelemetry3s.lib` - super-slim static build. It turned out that this slim build got broken some time ago due to Offline Storage factory refactor in `OfflineStorageFactory.cpp`. I fixed it too. We need to add slim build to CI later on, but right now I verified that it works with an ad-hoc test.