### PR TITLE
Adding return value statements  in flush and flushAndTearDown methods of ODWLogManager.mm

### DIFF
--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -187,6 +187,7 @@ static BOOL _initialized = false;
             [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
+        return ODWEfail;
     }
 }
 
@@ -194,7 +195,7 @@ static BOOL _initialized = false;
 {
     try
     {
-        ODWStatus status = ((ODWStatus)LogManager::FlushAndTeardown());
+        return ((ODWStatus)LogManager::FlushAndTeardown());
     }
     catch (const std::exception &e)
     {
@@ -203,6 +204,7 @@ static BOOL _initialized = false;
             [ODWLogger raiseException: e.what()];
         }
         [ODWLogger traceException: e.what()];
+        return ODWEfail;
     }
 }
 


### PR DESCRIPTION
Description:

While updating the pod spec with version 3.5.19, the local build verification failed with below error:

`- ERROR | [iOS] xcodebuild:  OneDsCppSdk.iOS/wrappers/obj-c/ODWLogManager.mm:207:1: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]`

When I looked at recent changes I found [a recent change](https://github.com/microsoft/cpp_client_telemetry/pull/750/files#diff-e120c7a402598bfdf01df679f15c6d3d87dc63c9a59354d7fd0a2ec188040b94R197) in which we do not return an instance of ODWStatus in these two methods in `ODWLogManager.mm`
```
+(ODWStatus)flush
+(ODWStatus)flushAndTeardown 
```

Solution: 

1. Return ODWEfail when exception occurs in these two methods.
2. Return ODWStatus in value returned from `LogManager::FlushAndTeardown()` in `flushAndTeardown` 



