### PR TITLE
Fixed documentation warnings in  ObjC layer which cause XCode build to fail

### DIFF
--- a/wrappers/obj-c/ODWDiagnosticDataViewer.h
+++ b/wrappers/obj-c/ODWDiagnosticDataViewer.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @brief Enables Data Viewer.
  @param endpoint A string that contains endpoint to route events.
- @param completionWithResult Code to execute when enable is completed. <b>Note:</b> This value can be null.
+ @param completion Code to execute when enable is completed. <b>Note:</b> This value can be null.
  */
 +(void)enableRemoteViewer:(NSString *)endpoint
 	 completionWithResult:(void(^)(bool result))completion;

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -62,7 +62,7 @@
 
 /*!
 @brief Sets the internal SDK debugging trace level.
-@param one of the ACTTraceLevel values.
+@param TraceLevel one of the ACTTraceLevel values.
 */
 +(void)setTraceLevel:(int)TraceLevel;
 


### PR DESCRIPTION
Fixed documentation warnings in  ObjC layer which cause XCode build to fail when "Documentation Comments" build setting is "YES" for a build target.