### PR TITLE
Final Steps of Moving String methods to StringUtils.hpp

### DIFF
--- a/lib/http/HttpClient_Apple.mm
+++ b/lib/http/HttpClient_Apple.mm
@@ -12,6 +12,7 @@
 #import <CFNetwork/CFNetwork.h>
 
 #include "HttpClient_Apple.hpp"
+#include "utils/StringUtils.hpp"
 #include "utils/Utils.hpp"
 
 namespace MAT_NS_BEGIN {

--- a/lib/http/HttpClient_WinRt.cpp
+++ b/lib/http/HttpClient_WinRt.cpp
@@ -9,7 +9,7 @@
 #include "pal/PAL.hpp"
 
 #include "http/HttpClient_WinRt.hpp"
-#include "utils/Utils.hpp"
+#include "utils/StringUtils.hpp"
 
 #include <algorithm>
 #include <memory>

--- a/lib/jni/Utils_jni.cpp
+++ b/lib/jni/Utils_jni.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#include <utils/StringUtils.hpp>
 #include <utils/Utils.hpp>
 #include "JniConvertors.hpp"
 

--- a/lib/utils/Utils.hpp
+++ b/lib/utils/Utils.hpp
@@ -23,8 +23,6 @@
 /* Lean implementation of SLDC "Annex K" for non-Windows OS */
 #include "annex_k.hpp"
 
-#include "utils/StringUtils.hpp"
-
 #if (__cplusplus < 201402L) && !defined(_MSC_VER)
 /* Workaround for lack of std::make_unique in C++11 (gcc-5). N3936 for C++14 support mentions 201402L */
 #include <memory>

--- a/tests/unittests/PackagerTests.cpp
+++ b/tests/unittests/PackagerTests.cpp
@@ -2,7 +2,7 @@
 
 #include "common/Common.hpp"
 #include "common/MockIRuntimeConfig.hpp"
-#include "utils/Utils.hpp"
+#include "utils/StringUtils.hpp"
 #include "packager/Packager.hpp"
 #include "bond/All.hpp"
 #include "CsProtocol_types.hpp"

--- a/tests/unittests/StringUtilsTests.cpp
+++ b/tests/unittests/StringUtilsTests.cpp
@@ -104,3 +104,34 @@ TEST(StringUtilsTests, AreAllCharactersWhitelisted)
 	EXPECT_TRUE(StringUtils::AreAllCharactersWhitelisted("abc123", "abcdef123456"));
 	EXPECT_FALSE(StringUtils::AreAllCharactersWhitelisted("abc123", "abcdef23456"));
 }
+
+TEST(StringUtilsTests, ToString)
+{
+    EXPECT_THAT(toString(true), Eq("true"));
+    EXPECT_THAT(toString(false), Eq("false"));
+
+    EXPECT_THAT(toString('A'), Eq("65"));
+    EXPECT_THAT(toString(static_cast<char>(-128)), Eq("-128"));
+    EXPECT_THAT(toString(static_cast<char>(127)), Eq("127"));
+
+    EXPECT_THAT(toString(-12345), Eq("-12345"));
+    EXPECT_THAT(toString(12345), Eq("12345"));
+
+    EXPECT_THAT(toString(-1234567l), Eq("-1234567"));
+    EXPECT_THAT(toString(1234567l), Eq("1234567"));
+
+    EXPECT_THAT(toString(-12345678901ll), Eq("-12345678901"));
+    EXPECT_THAT(toString(12345678901ll), Eq("12345678901"));
+
+    EXPECT_THAT(toString(static_cast<unsigned char>(255)), Eq("255"));
+
+    EXPECT_THAT(toString(12345u), Eq("12345"));
+
+    EXPECT_THAT(toString(1234567ul), Eq("1234567"));
+
+    EXPECT_THAT(toString(12345678901ull), Eq("12345678901"));
+
+    EXPECT_THAT(toString(1234.5f), Eq("1234.500000"));
+    EXPECT_THAT(toString(1234.567), Eq("1234.567000"));
+    EXPECT_THAT(toString(1234.567891l), Eq("1234.567891"));
+}

--- a/tests/unittests/UtilsTests.cpp
+++ b/tests/unittests/UtilsTests.cpp
@@ -12,37 +12,6 @@ using namespace MAT;
 
 using std::string;
 
-TEST(UtilsTests, ToString)
-{
-    EXPECT_THAT(toString(true),                                  Eq("true"));
-    EXPECT_THAT(toString(false),                                Eq("false"));
-
-    EXPECT_THAT(toString('A'),                                     Eq("65"));
-    EXPECT_THAT(toString(static_cast<char>(-128)),               Eq("-128"));
-    EXPECT_THAT(toString(static_cast<char>(127)),                 Eq("127"));
-
-    EXPECT_THAT(toString(-12345),                              Eq("-12345"));
-    EXPECT_THAT(toString(12345),                                Eq("12345"));
-
-    EXPECT_THAT(toString(-1234567l),                         Eq("-1234567"));
-    EXPECT_THAT(toString(1234567l),                           Eq("1234567"));
-
-    EXPECT_THAT(toString(-12345678901ll),                Eq("-12345678901"));
-    EXPECT_THAT(toString(12345678901ll),                  Eq("12345678901"));
-
-    EXPECT_THAT(toString(static_cast<unsigned char>(255)),        Eq("255"));
-
-    EXPECT_THAT(toString(12345u),                               Eq("12345"));
-
-    EXPECT_THAT(toString(1234567ul),                          Eq("1234567"));
-
-    EXPECT_THAT(toString(12345678901ull),                 Eq("12345678901"));
-
-    EXPECT_THAT(toString(1234.5f),                        Eq("1234.500000"));
-    EXPECT_THAT(toString(1234.567),                       Eq("1234.567000"));
-    EXPECT_THAT(toString(1234.567891l),                   Eq("1234.567891"));
-}
-
 TEST(UtilsTests, TestValidatePropertyName)
 {
 	// Valid property name could be described by the following Regex


### PR DESCRIPTION
- Fixed a couple remaining build breaks that I missed in https://github.com/microsoft/cpp_client_telemetry/pull/772.
- Moved the applicable Unit Test to StringUtilsTests.cpp
- Updated the Modules rev.