### PR TITLE
Move MAT* and PAL* namespace macros out of version.hpp

### DIFF
--- a/lib/api/AllowedLevelsCollection.hpp
+++ b/lib/api/AllowedLevelsCollection.hpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <cstdint>
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 
 namespace MAT_NS_BEGIN

--- a/lib/api/AuthTokensController.hpp
+++ b/lib/api/AuthTokensController.hpp
@@ -5,7 +5,7 @@
 #ifndef AUTHTOKENSCONTROLLER_HPP
 #define AUTHTOKENSCONTROLLER_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "Enums.hpp"
 #include "pal/PAL.hpp"
 #include "IAuthTokensController.hpp"

--- a/lib/api/IRuntimeConfig.hpp
+++ b/lib/api/IRuntimeConfig.hpp
@@ -5,7 +5,7 @@
 #ifndef IRUNTIMECONFIG_HPP
 #define IRUNTIMECONFIG_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include "ILogger.hpp"
 #include "ILogConfiguration.hpp"

--- a/lib/compression/HttpDeflateCompression.hpp
+++ b/lib/compression/HttpDeflateCompression.hpp
@@ -4,7 +4,7 @@
 //
 
 #pragma once
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "api/IRuntimeConfig.hpp"
 #include "system/Route.hpp"
 #include "system/Contexts.hpp"

--- a/lib/decorators/BaseDecorator.hpp
+++ b/lib/decorators/BaseDecorator.hpp
@@ -5,7 +5,7 @@
 #ifndef BASEDECORATOR_HPP
 #define BASEDECORATOR_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <algorithm>
 #include <string>

--- a/lib/filter/EventFilterCollection.hpp
+++ b/lib/filter/EventFilterCollection.hpp
@@ -5,7 +5,7 @@
 #ifndef EVENTFILTERCOLLECTION_HPP
 #define EVENTFILTERCOLLECTION_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "IEventFilterCollection.hpp"
 
 #include <memory>

--- a/lib/http/HttpClient_Curl.cpp
+++ b/lib/http/HttpClient_Curl.cpp
@@ -8,7 +8,7 @@
 // e.g. WinInet.dll or Win 10 HTTP client instead
 #if defined(MATSDK_PAL_CPP11) && !defined(_MSC_VER) && defined(HAVE_MAT_DEFAULT_HTTP_CLIENT)
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <memory>
 

--- a/lib/include/mat/IBandwidthController.hpp
+++ b/lib/include/mat/IBandwidthController.hpp
@@ -5,7 +5,7 @@
 #ifndef IBANDWIDTHCONTROLLER_HPP
 #define IBANDWIDTHCONTROLLER_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 namespace MAT_NS_BEGIN
 {

--- a/lib/include/public/AggregatedMetric.hpp
+++ b/lib/include/public/AggregatedMetric.hpp
@@ -5,7 +5,7 @@
 #ifndef AGGREGATEDMETRIC_HPP
 #define AGGREGATEDMETRIC_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include "ILogger.hpp"
 

--- a/lib/include/public/CAPIClient.hpp
+++ b/lib/include/public/CAPIClient.hpp
@@ -8,7 +8,7 @@
 // Header-only implementation of C++03 API on top of stable C ABI
 //
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include "mat.h"
 

--- a/lib/include/public/CompliantByDefaultFilterApi.hpp
+++ b/lib/include/public/CompliantByDefaultFilterApi.hpp
@@ -5,7 +5,6 @@
 #ifndef COMPLIANTBYDEFAULTEVENTFILTERAPI_HPP
 #define COMPLIANTBYDEFAULTEVENTFILTERAPI_HPP
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 
 #include <vector>

--- a/lib/include/public/CorrelationVector.hpp
+++ b/lib/include/public/CorrelationVector.hpp
@@ -5,7 +5,6 @@
 #ifndef CORRELATIONVECTOR_HPP
 #define CORRELATIONVECTOR_HPP
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 
 #include <mutex>

--- a/lib/include/public/DebugEvents.hpp
+++ b/lib/include/public/DebugEvents.hpp
@@ -5,8 +5,6 @@
 #ifndef DEBUGEVENTS_HPP
 #define DEBUGEVENTS_HPP
 
-#include "Version.hpp"
-
 #include "ctmacros.hpp"
 
 #include <cstdint>

--- a/lib/include/public/Enums.hpp
+++ b/lib/include/public/Enums.hpp
@@ -5,7 +5,7 @@
 #ifndef MAT_ENUMS_HPP
 #define MAT_ENUMS_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <string>
 #include <vector>

--- a/lib/include/public/EventProperties.hpp
+++ b/lib/include/public/EventProperties.hpp
@@ -7,8 +7,6 @@
 
 #define MAT_C_API
 
-#include "Version.hpp"
-
 #include "Enums.hpp"
 #include "EventProperty.hpp"
 #include "ctmacros.hpp"

--- a/lib/include/public/EventProperty.hpp
+++ b/lib/include/public/EventProperty.hpp
@@ -5,9 +5,8 @@
 #ifndef MAT_EVENTPROPERTY_HPP
 #define MAT_EVENTPROPERTY_HPP
 
-#include "Version.hpp"
-
 #include "ctmacros.hpp"
+
 #include "Enums.hpp"
 #include "CommonFields.h"
 

--- a/lib/include/public/IAFDClient.hpp
+++ b/lib/include/public/IAFDClient.hpp
@@ -5,8 +5,6 @@
 #ifndef IAFGCLIENT_HPP
 #define IAFGCLIENT_HPP
 
-#include "Version.hpp"
-
 #include "ctmacros.hpp"
 #include "ILogger.hpp"
 

--- a/lib/include/public/IAuthTokensController.hpp
+++ b/lib/include/public/IAuthTokensController.hpp
@@ -5,7 +5,6 @@
 #ifndef MAT_IAUTHTOKENS_HPP
 #define MAT_IAUTHTOKENS_HPP
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 #include "Enums.hpp"
 

--- a/lib/include/public/IBandwidthController.hpp
+++ b/lib/include/public/IBandwidthController.hpp
@@ -5,7 +5,7 @@
 #ifndef IBANDWIDTHCONTROLLER_HPP
 #define IBANDWIDTHCONTROLLER_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 namespace MAT_NS_BEGIN
 {

--- a/lib/include/public/ICdsFactory.hpp
+++ b/lib/include/public/ICdsFactory.hpp
@@ -6,7 +6,6 @@
 #define MAT_ICDSFACTORY_HPP
 
 #include "ctmacros.hpp"
-#include "Version.hpp"
 
 #include <functional>
 #include <map>

--- a/lib/include/public/IDataInspector.hpp
+++ b/lib/include/public/IDataInspector.hpp
@@ -6,9 +6,8 @@
 #define IDATAINSPECTOR_HPP
 
 #include "EventProperty.hpp"
-#include "Version.hpp"
-#include "CsProtocol_types.hpp"
 #include "ctmacros.hpp"
+#include "CsProtocol_types.hpp"
 #include <functional>
 #include <memory>
 #include <string>

--- a/lib/include/public/IDataViewer.hpp
+++ b/lib/include/public/IDataViewer.hpp
@@ -5,7 +5,6 @@
 #ifndef IDATAVIEWER_HPP
 #define IDATAVIEWER_HPP
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 #include "IModule.hpp"
 

--- a/lib/include/public/IDataViewerCollection.hpp
+++ b/lib/include/public/IDataViewerCollection.hpp
@@ -6,7 +6,7 @@
 #define IDATAVIEWERCOLLECTION_HPP
 
 #include "IDataViewer.hpp"
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <memory>
 

--- a/lib/include/public/IECSClient.hpp
+++ b/lib/include/public/IECSClient.hpp
@@ -5,8 +5,6 @@
 #ifndef IECSCLIENT_HPP
 #define IECSCLIENT_HPP
 
-#include "Version.hpp"
-
 #include "ctmacros.hpp"
 #include "ILogger.hpp"
 

--- a/lib/include/public/IEventFilter.hpp
+++ b/lib/include/public/IEventFilter.hpp
@@ -5,7 +5,7 @@
 #ifndef IEVENTFILTER_HPP
 #define IEVENTFILTER_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "EventProperties.hpp"
 
 namespace MAT_NS_BEGIN

--- a/lib/include/public/IEventFilterCollection.hpp
+++ b/lib/include/public/IEventFilterCollection.hpp
@@ -5,7 +5,7 @@
 #ifndef IEVENTFILTERCOLLECTION_HPP
 #define IEVENTFILTERCOLLECTION_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "IEventFilter.hpp"
 
 #include <memory>

--- a/lib/include/public/IHttpClient.hpp
+++ b/lib/include/public/IHttpClient.hpp
@@ -6,7 +6,7 @@
 #define IHTTPCLIENT_HPP
 
 #include "IModule.hpp"
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include "Enums.hpp"
 

--- a/lib/include/public/ILogConfiguration.hpp
+++ b/lib/include/public/ILogConfiguration.hpp
@@ -5,10 +5,9 @@
 #ifndef MAT_ILOGCONFIGURATION_HPP
 #define MAT_ILOGCONFIGURATION_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include "Enums.hpp"
-#include "ctmacros.hpp"
 #include "stdint.h"
 
 #include <memory>

--- a/lib/include/public/ILogManager.hpp
+++ b/lib/include/public/ILogManager.hpp
@@ -5,7 +5,7 @@
 #ifndef ILOGMANAGER_HPP
 #define ILOGMANAGER_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <climits>
 #include <cstdint>

--- a/lib/include/public/ILogger.hpp
+++ b/lib/include/public/ILogger.hpp
@@ -5,8 +5,6 @@
 #ifndef MAT_ILOGGER_HPP
 #define MAT_ILOGGER_HPP
 
-#include "Version.hpp"
-
 #include "ctmacros.hpp"
 #include "Enums.hpp"
 #include "EventProperties.hpp"

--- a/lib/include/public/IModule.hpp
+++ b/lib/include/public/IModule.hpp
@@ -5,7 +5,6 @@
 #ifndef IMODULE_HPP
 #define IMODULE_HPP
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 
 ///@cond INTERNAL_DOCS

--- a/lib/include/public/ISemanticContext.hpp
+++ b/lib/include/public/ISemanticContext.hpp
@@ -5,8 +5,6 @@
 #ifndef ISEMANTICCONTEXT_HPP
 #define ISEMANTICCONTEXT_HPP
 
-#include "Version.hpp"
-
 #include "EventProperty.hpp"
 #include "CommonFields.h"
 #include "ctmacros.hpp"

--- a/lib/include/public/ITaskDispatcher.hpp
+++ b/lib/include/public/ITaskDispatcher.hpp
@@ -6,7 +6,6 @@
 #define ITASKDISPATCHER_HPP
 
 #include "IModule.hpp"
-#include "Version.hpp"
 #include "ctmacros.hpp"
 
 #include <atomic>

--- a/lib/include/public/LogConfiguration.hpp
+++ b/lib/include/public/LogConfiguration.hpp
@@ -5,8 +5,6 @@
 #ifndef MAT_LOGCONFIGURATION_HPP
 #define MAT_LOGCONFIGURATION_HPP
 
-#include "Version.hpp"
-
 #include "ILogConfiguration.hpp"
 
 #include "Enums.hpp"

--- a/lib/include/public/LogManagerProvider.hpp
+++ b/lib/include/public/LogManagerProvider.hpp
@@ -10,6 +10,7 @@
 #include "ILogManager.hpp"
 #include "ITaskDispatcher.hpp"
 #include "NullObjects.hpp"
+#include "Version.hpp"
 
 namespace MAT_NS_BEGIN
 {

--- a/lib/include/public/LogSessionData.hpp
+++ b/lib/include/public/LogSessionData.hpp
@@ -5,7 +5,7 @@
 #ifndef LOGSESSIONDATA_HPP
 #define LOGSESSIONDATA_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <string>
 #include <cstdint>

--- a/lib/include/public/PayloadDecoder.hpp
+++ b/lib/include/public/PayloadDecoder.hpp
@@ -11,7 +11,7 @@
 // payload data or Common Schema protocol struct into JSON format.
 //
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include <vector>
 #include <cinttypes>

--- a/lib/include/public/TransmitProfiles.hpp
+++ b/lib/include/public/TransmitProfiles.hpp
@@ -5,7 +5,7 @@
 #ifndef TRANSMITPROFILES_HPP
 #define TRANSMITPROFILES_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #include "Enums.hpp"
 

--- a/lib/include/public/Variant.hpp
+++ b/lib/include/public/Variant.hpp
@@ -5,7 +5,7 @@
 #ifndef MAT_VARIANT_HPP
 #define MAT_VARIANT_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "Enums.hpp"
 
 #include <algorithm>

--- a/lib/include/public/Version.hpp.template
+++ b/lib/include/public/Version.hpp.template
@@ -10,23 +10,8 @@
 #define BUILD_VERSION @BUILD_VERSION_MAJOR@,@BUILD_VERSION_MINOR@,@BUILD_VERSION_PATCH@,@BUILD_NUMBER@
 
 #ifndef RESOURCE_COMPILER_INVOKED
+#include <ctmacros.hpp>
 #include <stdint.h>
-
-#ifdef HAVE_MAT_SHORT_NS
-#define MAT_NS_BEGIN  MAT
-#define MAT_NS_END
-#define PAL_NS_BEGIN  PAL
-#define PAL_NS_END
-#else
-#define MAT_NS_BEGIN  Microsoft { namespace Applications { namespace Events
-#define MAT_NS_END    }}
-#define MAT           ::Microsoft::Applications::Events
-#define PAL_NS_BEGIN  Microsoft { namespace Applications { namespace Events { namespace PlatformAbstraction
-#define PAL_NS_END    }}}
-#define PAL           ::Microsoft::Applications::Events::PlatformAbstraction
-#endif
-
-#define MAT_v1        ::Microsoft::Applications::Telemetry
 
 namespace MAT_NS_BEGIN {
 

--- a/lib/include/public/ctmacros.hpp
+++ b/lib/include/public/ctmacros.hpp
@@ -5,6 +5,22 @@
 #ifndef CTMACROS_HPP
 #define CTMACROS_HPP
 
+#ifdef  HAVE_MAT_SHORT_NS
+#define MAT_NS_BEGIN  MAT
+#define MAT_NS_END
+#define PAL_NS_BEGIN  PAL
+#define PAL_NS_END
+#else
+#define MAT_NS_BEGIN  Microsoft { namespace Applications { namespace Events
+#define MAT_NS_END    }}
+#define MAT           ::Microsoft::Applications::Events
+#define PAL_NS_BEGIN  Microsoft { namespace Applications { namespace Events { namespace PlatformAbstraction
+#define PAL_NS_END    }}}
+#define PAL           ::Microsoft::Applications::Events::PlatformAbstraction
+#endif
+
+#define MAT_v1        ::Microsoft::Applications::Telemetry
+
 #ifdef _WIN32       // Windows platforms
 
 #ifndef MATSDK_SPEC // we use __cdecl by default

--- a/lib/jni/JniConvertors.hpp
+++ b/lib/jni/JniConvertors.hpp
@@ -5,7 +5,7 @@
 #include <jni.h>
 #include <include/public/EventProperties.hpp>
 #include <include/public/IDataInspector.hpp>
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 #define MAT_USE_WEAK_LOGMANAGER
 

--- a/lib/pal/DebugTrace.hpp
+++ b/lib/pal/DebugTrace.hpp
@@ -7,9 +7,8 @@
 
 #include "mat/config.h"
 
-#include "Version.hpp"
-#include "typename.hpp"
 #include "ctmacros.hpp"
+#include "typename.hpp"
 
 namespace PAL_NS_BEGIN
 {

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -6,6 +6,7 @@
 
 #include "ILogManager.hpp"
 #include "ISemanticContext.hpp"
+#include "Version.hpp"
 #include "utils/StringUtils.hpp"
 
 #include <algorithm>

--- a/lib/pal/PAL.hpp
+++ b/lib/pal/PAL.hpp
@@ -6,7 +6,7 @@
 #define PAL_HPP
 
 #include "mat/config.h"
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "DebugTrace.hpp"
 
 #ifdef HAVE_MAT_EXP

--- a/lib/pal/PseudoRandomGenerator.hpp
+++ b/lib/pal/PseudoRandomGenerator.hpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <random>
-#include <Version.hpp>
+#include <ctmacros.hpp>
 
 namespace PAL_NS_BEGIN
 {

--- a/lib/pal/TaskDispatcher.hpp
+++ b/lib/pal/TaskDispatcher.hpp
@@ -19,7 +19,7 @@
 #include <utility>
 
 #include "ITaskDispatcher.hpp"
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 namespace PAL_NS_BEGIN {
 

--- a/lib/pal/TaskDispatcher_CAPI.hpp
+++ b/lib/pal/TaskDispatcher_CAPI.hpp
@@ -7,7 +7,7 @@
 
 #include "ITaskDispatcher.hpp"
 #include "mat.h"
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 namespace PAL_NS_BEGIN {
     class TaskDispatcher_CAPI : public MAT::ITaskDispatcher

--- a/lib/pal/WorkerThread.hpp
+++ b/lib/pal/WorkerThread.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 
 #include "ITaskDispatcher.hpp"
-#include "Version.hpp"
+#include "ctmacros.hpp"
 
 namespace PAL_NS_BEGIN {
 

--- a/lib/pal/desktop/NetworkDetector.cpp
+++ b/lib/pal/desktop/NetworkDetector.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "mat/config.h"
 #ifdef HAVE_MAT_NETDETECT
 

--- a/lib/shared/EventPropertiesCX.hpp
+++ b/lib/shared/EventPropertiesCX.hpp
@@ -6,7 +6,7 @@
 #pragma warning( push )
 #pragma warning( disable : 4454 )
 
-#include <Version.hpp>
+#include <ctmacros.hpp>
 #include "PlatformHelpers.h"
 #include "SchemaStub.hpp"
 

--- a/lib/shared/PlatformHelpers.h
+++ b/lib/shared/PlatformHelpers.h
@@ -5,7 +5,7 @@
 #ifndef PLATFORMHELPERS_HPP
 #define PLATFORMHELPERS_HPP
 
-#include <Version.hpp>
+#include <ctmacros.hpp>
 
 #include <Windows.h>
 #include <string>

--- a/lib/system/EventPropertiesStorage.hpp
+++ b/lib/system/EventPropertiesStorage.hpp
@@ -8,8 +8,6 @@
 
 #include "Enums.hpp"
 #include "EventProperty.hpp"
-#include "Version.hpp"
-
 #include "ctmacros.hpp"
 
 namespace MAT_NS_BEGIN {

--- a/lib/system/JsonFormatter.hpp
+++ b/lib/system/JsonFormatter.hpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "Contexts.hpp"
 #include "CommonFields.h"
 #include <vector>

--- a/lib/utils/FileUtils.hpp
+++ b/lib/utils/FileUtils.hpp
@@ -6,7 +6,7 @@
 #define LIB_FILEUTILS_HPP
 // Cross-platform C-style file utils that work well with UTF-8 filenames
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "pal/PAL.hpp"
 
 namespace MAT_NS_BEGIN

--- a/lib/utils/StringConversion.hpp
+++ b/lib/utils/StringConversion.hpp
@@ -5,7 +5,6 @@
 #ifndef STRINGCONVERSION_HPP
 #define STRINGCONVERSION_HPP
 
-#include "Version.hpp"
 #include "ctmacros.hpp"
 #include <string>
 

--- a/lib/utils/StringUtils.hpp
+++ b/lib/utils/StringUtils.hpp
@@ -5,7 +5,7 @@
 #ifndef STRINGUTILS_HPP
 #define STRINGUTILS_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include <EventProperty.hpp>
 
 #include <algorithm>

--- a/lib/utils/Utils.hpp
+++ b/lib/utils/Utils.hpp
@@ -9,7 +9,7 @@
 // Certain features, e.g. <mutex> or <thread> - cannot be used while building with /cli
 // For this reason this header cannot include any other headers that rely on <mutex> or <thread>
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include "Enums.hpp"
 #include "StringConversion.hpp"
 

--- a/lib/utils/ZlibUtils.hpp
+++ b/lib/utils/ZlibUtils.hpp
@@ -5,7 +5,7 @@
 #ifndef LIB_ZLIB_UTILS_HPP
 #define LIB_ZLIB_UTILS_HPP
 
-#include "Version.hpp"
+#include "ctmacros.hpp"
 #include <vector>
 
 namespace MAT_NS_BEGIN 

--- a/lib/utils/ZlibUtils.hpp
+++ b/lib/utils/ZlibUtils.hpp
@@ -6,6 +6,7 @@
 #define LIB_ZLIB_UTILS_HPP
 
 #include "ctmacros.hpp"
+#include <cstdint>
 #include <vector>
 
 namespace MAT_NS_BEGIN 


### PR DESCRIPTION
The underlying problem is better explained in this issue: https://github.com/microsoft/cpp_client_telemetry/issues/775

I moved the MAT* and PAL* namespace macros to CTMacros.hpp, as it seemed to be the most reasonable place for their addition, though I wouldn't be opposed to moving them to a separate file (NamespaceMacros.hpp perhaps?).

This ostensibly should improve incremental builds after running `git pull`, after a day change, or anything which updates the Version number, as only files which directly depend on the Version.hpp headers should be invalidated by those operations.