### PR TITLE
Add support for 1DSSDK iOS build script to generate binary for iOS arm simulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,19 @@ if(APPLE)
     set(IOS True)
     set(APPLE True)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
+    if((${IOS_PLAT} STREQUAL "iphonesimulator") AND (${IOS_ARCH} STREQUAL "arm64"))
+      # iOS arm64 simulator is supported starting BigSur
+      # Unfortunately, CMAKE produces a device binary (not simulator) when providing -miphoneos-version-min flag when building iOS arm64 simulator
+    else()
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
+    endif()
+
+    if((${IOS_PLAT} STREQUAL "iphoneos") OR (${IOS_PLAT} STREQUAL "iphonesimulator"))
+      set(IOS_PLATFORM "${IOS_PLAT}")
+    else()
+      message(FATAL_ERROR "Unrecognized iOS platform '${IOS_PLAT}'")
+    endif()
 
     if(${IOS_ARCH} STREQUAL "x86_64")
       set(IOS_PLATFORM "iphonesimulator")
@@ -51,12 +62,13 @@ if(APPLE)
       message(FATAL_ERROR "Unrecognized iOS architecture '${IOS_ARCH}'")
     endif()
 
-    execute_process(COMMAND xcodebuild -version -sdk ${IOS_PLATFORM} Path
+    execute_process(COMMAND xcodebuild -version -sdk ${IOS_PLATFORM} ONLY_ACTIVE_ARCH=NO Path
       OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
       ERROR_QUIET
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     message("-- CMAKE_OSX_SYSROOT       ${CMAKE_OSX_SYSROOT}")
-    message("-- IOS_ARCH:               ${IOS_ARCH}")
+    message("-- ARCHITECTURE:           ${CMAKE_SYSTEM_PROCESSOR}")
+    message("-- PLATFORM:               ${IOS_PLATFORM}")
   else()
     if(${MAC_ARCH} STREQUAL "x86_64")
       set(CMAKE_SYSTEM_PROCESSOR x86_64)

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -13,14 +13,20 @@ else
 BUILD_TYPE="Debug"
 fi
 
+# Set Architecture: arm64, arm64e or x86_64
 if [ "$2" == "arm64" ] || [ "$3" == "arm64" ]; then
 IOS_ARCH="arm64"
 elif [ "$2" == "arm64e" ] || [ "$3" == "arm64e" ]; then
 IOS_ARCH="arm64e"
-elif [ "$2" == "x86_64" ] || [ "$2" == "simulator" ] || [ "$3" == "x86_64" ] || [ "$3" == "simulator" ]; then
-IOS_ARCH="x86_64"
 else
 IOS_ARCH="x86_64"
+fi
+
+# Set Platform: device or simulator
+if [ "$2" == "device" ] || [ "$3" == "device" ]; then
+IOS_PLAT="iphoneos"
+else
+IOS_PLAT="iphonesimulator"
 fi
 
 # Set target iOS minver
@@ -48,7 +54,7 @@ cd out
 
 CMAKE_PACKAGE_TYPE=tgz
 
-cmake -DBUILD_IOS=YES -DIOS_ARCH=$IOS_ARCH -DIOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET -DBUILD_UNIT_TESTS=YES -DBUILD_FUNC_TESTS=YES -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
+cmake -DBUILD_IOS=YES -DIOS_ARCH=$IOS_ARCH -DIOS_PLAT=$IOS_PLAT -DIOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET -DBUILD_UNIT_TESTS=YES -DBUILD_FUNC_TESTS=YES -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE ..
 make
 
 make package


### PR DESCRIPTION
Add support for 1DSSDK iOS build script to generate binary for iOS arm simulator.

Context:
As part of Apple Silicon release, latest XCode version allows to debug apps on iOS arm64 simulators (previously only x86_64 simulators were available). This change allows build-ios.sh build script to generate 1DS SDK static library than can be used to link into products targeting iOS arm simulator.