### PR TITLE
Expose LogConfiguration.getLogConfigurationCopy() and LogManager.loggerWithTenant() with custom config on iOS

### DIFF
--- a/lib/jni/LogManager_jni.cpp
+++ b/lib/jni/LogManager_jni.cpp
@@ -704,7 +704,7 @@ namespace
             }
             return result;
         }
- 
+
         jobject mapTranslate(VariantMap& variantMap)
         {
             auto map = env->NewObject(configClass, configInit);

--- a/lib/jni/LogManager_jni.cpp
+++ b/lib/jni/LogManager_jni.cpp
@@ -704,7 +704,7 @@ namespace
             }
             return result;
         }
-
+ 
         jobject mapTranslate(VariantMap& variantMap)
         {
             auto map = env->NewObject(configClass, configInit);

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -312,114 +312,114 @@ extern NSString * _Nonnull const ODWCFG_BOOL_SESSION_RESET_ENABLED;
 @interface ODWLogConfiguration : NSObject
 
 /*!
- @brief Return a copy of the default configuration
+@brief Return a copy of the default configuration
 */
 +(nullable ODWLogConfiguration *)getLogConfigurationCopy;
 
 /*!
- @brief Sets the URI of the event collector.
- @param eventCollectorUri A string for event collector uri.
+@brief Sets the URI of the event collector.
+@param eventCollectorUri A string for event collector uri.
 */
 +(void)setEventCollectorUri:(nonnull NSString *)eventCollectorUri;
 
 /*!
- @brief Returns the URI of the event collector.
+@brief Returns the URI of the event collector.
 */
 +(nullable NSString *)eventCollectorUri;
 
 /*!
- @brief Sets the RAM queue size limit in bytes.
- @param cacheMemorySizeLimitInBytes  A long value for memory size limit in bytes.
+@brief Sets the RAM queue size limit in bytes.
+@param cacheMemorySizeLimitInBytes  A long value for memory size limit in bytes.
 */
 +(void)setCacheMemorySizeLimitInBytes:(uint64_t)cacheMemorySizeLimitInBytes;
 
 /*!
- @brief return the RAM queue size limit in bytes.
+@brief return the RAM queue size limit in bytes.
 */
 +(uint64_t)cacheMemorySizeLimitInBytes;
 
 /*!
- @brief Sets the size limit of the disk file used to cache events on the client side.
- @param cacheFileSizeLimitInBytes  A long value for cache file size limit.
+@brief Sets the size limit of the disk file used to cache events on the client side.
+@param cacheFileSizeLimitInBytes  A long value for cache file size limit.
 */
 +(void)setCacheFileSizeLimitInBytes:(uint64_t)cacheFileSizeLimitInBytes;
 
 /*!
- @brief Returns the size limit of the disk file used to cache events on the client side.
+@brief Returns the size limit of the disk file used to cache events on the client side.
 */
 +(uint64_t)cacheFileSizeLimitInBytes;
 
 /*!
- @brief Sets max teardown upload time in seconds.
- @param maxTeardownUploadTimeInSec An integer that time in seconds.
+@brief Sets max teardown upload time in seconds.
+@param maxTeardownUploadTimeInSec An integer that time in seconds.
 */
 +(void)setMaxTeardownUploadTimeInSec:(int)maxTeardownUploadTimeInSec;
 
 /*!
- @brief Sets if trace logging to file is enabled.
- @param enableTrace True if tracing is enabled.
+@brief Sets if trace logging to file is enabled.
+@param enableTrace True if tracing is enabled.
 */
 +(void)setEnableTrace:(bool)enableTrace;
 
 /*!
- @brief Sets if console logging from the iOS wrapper is enabled.
- @param enableConsoleLogging True if logging is enabled.
+@brief Sets if console logging from the iOS wrapper is enabled.
+@param enableConsoleLogging True if logging is enabled.
 */
 +(void)setEnableConsoleLogging:(bool)enableConsoleLogging;
 
 /*!
- @brief Sets the internal SDK debugging trace level.
- @param TraceLevel one of the ACTTraceLevel values.
+@brief Sets the internal SDK debugging trace level.
+@param TraceLevel one of the ACTTraceLevel values.
 */
 +(void)setTraceLevel:(int)TraceLevel;
 
 /*!
- @brief Returns true if tracing is enabled.
+@brief Returns true if tracing is enabled.
 */
 +(bool)enableTrace;
 
 /*!
- @brief Returns true if console logging is enabled.
+@brief Returns true if console logging is enabled.
 */
 +(bool)enableConsoleLogging;
 
 /*!
- @brief Sets if inner C++ exceptions should be surfaced to Wrapper consumers.
- @param surfaceCppExceptions True if C++ exceptions should be surfaced.
+@brief Sets if inner C++ exceptions should be surfaced to Wrapper consumers.
+@param surfaceCppExceptions True if C++ exceptions should be surfaced.
 */
 +(void)setSurfaceCppExceptions:(bool)surfaceCppExceptions;
 
 /*!
- @brief Returns true if inner C++ exceptions are surfaced to Wrapper consumers.
+@brief Returns true if inner C++ exceptions are surfaced to Wrapper consumers.
 */
 +(bool)surfaceCppExceptions;
 
 /*!
- @brief Sets if session timestamp should be reset after a session ends
- @param enableSessionReset True if session should be reset on session end.
+@brief Sets if session timestamp should be reset after a session ends
+@param enableSessionReset True if session should be reset on session end.
 */
 +(void)setEnableSessionReset:(bool)enableSessionReset;
 
 /*!
- @brief Returns true if session will be reset on session end.
+@brief Returns true if session will be reset on session end.
 */
 +(bool)enableSessionReset;
 
 /*!
- @brief Sets the cache file path.
- @param cacheFilePath A string for the cache path.
+@brief Sets the cache file path.
+@param cacheFilePath A string for the cache path.
 */
 +(void)setCacheFilePath:(nonnull NSString *)cacheFilePath;
 
 /*!
- @brief Returns the cache file path.
+@brief Returns the cache file path.
 */
 +(nullable NSString *)cacheFilePath;
 
 /*!
- @brief Sets a config key to a string value
- @param key A key.
- @param value A value.
+@brief Sets a config key to a string value for the copied config
+@param key A key.
+@param value A value.
 */
 -(void)set:(nonnull NSString *)key withValue:(nonnull NSString *)value;
 

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -10,6 +10,11 @@
 @interface ODWLogConfiguration : NSObject
 
 /*!
+@brief Return a copy of the default configuration
+*/
++(nullable ODWLogConfiguration *)getLogConfigurationCopy;
+
+/*!
 @brief Sets the URI of the event collector.
 @param eventCollectorUri A string for event collector uri.
 */

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -45,21 +45,6 @@ extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_WAL_JOURNAL;
 extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_NET_DETECT;
 
 /*!
- Parameter that allows to check if the SDK is running on UTC mode
-*/
-extern NSString * _Nonnull const ODWCFG_BOOL_UTC_ENABLED;
-
-/*!
- Parameter that allows to check if the SDK is running on UTC mode
-*/
-extern NSString * _Nonnull const ODWCFG_BOOL_UTC_ACTIVE;
-
-/*!
- Parameter that allows to check if the Windows 10 version SDK is using supports large payloads on UTC
-*/
-extern NSString * _Nonnull const ODWCFG_BOOL_UTC_LARGE_PAYLOADS;
-
-/*!
  The event collection URI.
 */
 extern NSString * _Nonnull const ODWCFG_STR_COLLECTOR_URL;
@@ -108,11 +93,6 @@ extern NSString * _Nonnull const ODWCFG_STR_TRACE_FOLDER_PATH;
  The SDK mode.
 */
 extern NSString * _Nonnull const ODWCFG_INT_SDK_MODE;
-
-/*!
- UTC lives at the root of all UTC-specific configuration.
-*/
-extern NSString * _Nonnull const ODWCFG_STR_UTC;
 
 /*!
  Set the provider group directly with a string (which will be converted to a GUID).
@@ -200,16 +180,6 @@ extern NSString * _Nonnull const ODWCFG_MODULE_PRIVACY_GUARD;
  IDecorator override module
 */
 extern NSString * _Nonnull const ODWCFG_MODULE_OFFLINE_STORAGE;
-
-/*!
- Pointer to the Android app's JavaVM
-*/
-extern NSString * _Nonnull const ODWCFG_PTR_ANDROID_JVM;
-
-/*!
- JObject of the Android app's main activity
-*/
-extern NSString * _Nonnull const ODWCFG_JOBJECT_ANDROID_ACTIVITY;
 
 /*!
  LogManagerFactory's name parameter

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -5,6 +5,308 @@
 #include "objc_begin.h"
 
 /*!
+ Enable analytics.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_ANALYTICS;
+
+/*!
+ Enable multitenant.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_MULTITENANT;
+
+/*!
+ Enable CRC-32 check.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_CRC32;
+
+/*!
+ Enable HMAC authentication.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_HMAC;
+
+/*!
+ Enable dropping events if DB file size exceeds its limit.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_DB_DROP_IF_FULL;
+
+/*!
+ Enable database compression.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_DB_COMPRESS;
+
+/*!
+ Enable WAL journal.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_WAL_JOURNAL;
+
+/*!
+ Enable network detector.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_NET_DETECT;
+
+/*!
+ Parameter that allows to check if the SDK is running on UTC mode
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_UTC_ENABLED;
+
+/*!
+ Parameter that allows to check if the SDK is running on UTC mode
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_UTC_ACTIVE;
+
+/*!
+ Parameter that allows to check if the Windows 10 version SDK is using supports large payloads on UTC
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_UTC_LARGE_PAYLOADS;
+
+/*!
+ The event collection URI.
+*/
+extern NSString * _Nonnull const ODWCFG_STR_COLLECTOR_URL;
+
+/*!
+ The cache file-path.
+*/
+extern NSString * _Nonnull const ODWCFG_STR_CACHE_FILE_PATH;
+
+/*!
+ the cache file size limit in bytes.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_CACHE_FILE_SIZE;
+
+/*!
+ The RAM queue size limit in bytes.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_RAM_QUEUE_SIZE;
+
+/*!
+ The size of the RAM queue buffers, in bytes.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_RAM_QUEUE_BUFFERS;
+
+/*!
+ The trace level mask.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_TRACE_LEVEL_MASK;
+
+/*!
+ The minimum trace level.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_TRACE_LEVEL_MIN;
+
+/*!
+ Enable trace logs.
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_ENABLE_TRACE;
+
+/*!
+ The trace filepath.
+*/
+extern NSString * _Nonnull const ODWCFG_STR_TRACE_FOLDER_PATH;
+
+/*!
+ The SDK mode.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_SDK_MODE;
+
+/*!
+ UTC lives at the root of all UTC-specific configuration.
+*/
+extern NSString * _Nonnull const ODWCFG_STR_UTC;
+
+/*!
+ Set the provider group directly with a string (which will be converted to a GUID).
+*/
+extern NSString * _Nonnull const ODWCFG_STR_PROVIDER_GROUP_ID;
+
+/*!
+ The maximum teardown time.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_MAX_TEARDOWN_TIME;
+
+/*!
+ The maximum number of pending HTTP requests.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_MAX_PENDING_REQ;
+
+/*!
+ The maximum package drop on full.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_MAX_PKG_DROP_ON_FULL;
+
+/*!
+ The cache file percentage full notification.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_STORAGE_FULL_PCT;
+
+/*!
+ The minimum time (ms) between storage full notifications.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_STORAGE_FULL_CHECK_TIME;
+
+/*!
+ The cache memory percentage full notification.
+*/
+extern NSString * _Nonnull const ODWCFG_INT_RAMCACHE_FULL_PCT;
+
+/*!
+ PRAGMA journal mode.
+*/
+extern NSString * _Nonnull const ODWCFG_STR_PRAGMA_JOURNAL_MODE;
+
+/*!
+ PRAGMA synchronous.
+*/
+extern NSString * _Nonnull const ODWCFG_STR_PRAGMA_SYNCHRONOUS;
+
+extern NSString * _Nonnull const ODWCFG_STR_PRIMARY_TOKEN;
+
+/*!
+ Parameter that allows to apply custom transmit profile on SDK start
+*/
+extern NSString * _Nonnull const ODWCFG_STR_START_PROFILE_NAME;
+
+/*!
+ Parameter that allows to load a set of custom transmit profile on SDK start
+*/
+extern NSString * _Nonnull const ODWCFG_STR_TRANSMIT_PROFILES;
+
+/*!
+ IHttpClient override module
+*/
+extern NSString * _Nonnull const ODWCFG_MODULE_HTTP_CLIENT;
+
+/*!
+ ITaskDispatcher override module
+*/
+extern NSString * _Nonnull const ODWCFG_MODULE_TASK_DISPATCHER;
+
+/*!
+ IDataViewer override module
+*/
+extern NSString * _Nonnull const ODWCFG_MODULE_DATA_VIEWER;
+
+/*!
+ IDecorator override module
+*/
+extern NSString * _Nonnull const ODWCFG_MODULE_DECORATOR;
+
+/*!
+ IDecorator override module
+*/
+extern NSString * _Nonnull const ODWCFG_MODULE_PRIVACY_GUARD;
+
+/*!
+ IDecorator override module
+*/
+extern NSString * _Nonnull const ODWCFG_MODULE_OFFLINE_STORAGE;
+
+/*!
+ Pointer to the Android app's JavaVM
+*/
+extern NSString * _Nonnull const ODWCFG_PTR_ANDROID_JVM;
+
+/*!
+ JObject of the Android app's main activity
+*/
+extern NSString * _Nonnull const ODWCFG_JOBJECT_ANDROID_ACTIVITY;
+
+/*!
+ LogManagerFactory's name parameter
+*/
+extern NSString * _Nonnull const ODWCFG_STR_FACTORY_NAME;
+
+/*!
+ LogManagerFactory (and friends) config map
+*/
+extern NSString * _Nonnull const ODWCFG_MAP_FACTORY_CONFIG;
+
+/*!
+ sub-component in CFG_MAP_FACTORY_CONFIG: LogManagerFactory host parameter
+*/
+extern NSString * _Nonnull const ODWCFG_STR_FACTORY_HOST;
+
+/*!
+ sub-component in CFG_MAP_FACTORY_CONFIG: capi's scope parameter
+*/
+extern NSString * _Nonnull const ODWCFG_STR_CONTEXT_SCOPE;
+
+/*!
+ MetaStats configuration
+*/
+extern NSString * _Nonnull const ODWCFG_MAP_METASTATS_CONFIG;
+
+/*!
+ MetaStats configuration: time interval
+*/
+extern NSString * _Nonnull const ODWCFG_INT_METASTATS_INTERVAL;
+
+/*!
+ MetaStats configuration: time interval
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_METASTATS_SPLIT;
+
+/*!
+ Compatibility configuration
+*/
+extern NSString * _Nonnull const ODWCFG_MAP_COMPAT;
+
+/*!
+ Compatibility configuration: dot mode
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_COMPAT_DOTS;
+
+/*!
+ LogManagerFactory: is this log manager instance in host mode?
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_HOST_MODE;
+
+/*!
+ HTTP configuration map
+*/
+extern NSString * _Nonnull const ODWCFG_MAP_HTTP;
+
+/*!
+ HTTP configuration map: MS root check
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_HTTP_MS_ROOT_CHECK;
+
+/*!
+ HTTP configuration: compression
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_HTTP_COMPRESSION;
+
+/*!
+ TPM configuration map
+*/
+extern NSString * _Nonnull const ODWCFG_MAP_TPM;
+
+/*!
+ TPM configuration: max retry
+*/
+extern NSString * _Nonnull const ODWCFG_INT_TPM_MAX_RETRY;
+
+/*!
+ TPM configuration map
+*/
+extern NSString * _Nonnull const ODWCFG_STR_TPM_BACKOFF;
+
+/*!
+ TPM configuration map
+*/
+extern NSString * _Nonnull const ODWCFG_INT_TPM_MAX_BLOB_BYTES;
+
+/*!
+ TPM configuration map
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_TPM_CLOCK_SKEW_ENABLED;
+
+/*!
+ When enabled, the session timer is reset after session is completed, allowing for several session events in the duration of the SDK lifecycle
+*/
+extern NSString * _Nonnull const ODWCFG_BOOL_SESSION_RESET_ENABLED;
+
+/*!
  The <b>ODWLogConfiguration</b> static class represents general logging properties.
 */
 @interface ODWLogConfiguration : NSObject

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -312,109 +312,116 @@ extern NSString * _Nonnull const ODWCFG_BOOL_SESSION_RESET_ENABLED;
 @interface ODWLogConfiguration : NSObject
 
 /*!
-@brief Return a copy of the default configuration
+ @brief Return a copy of the default configuration
 */
 +(nullable ODWLogConfiguration *)getLogConfigurationCopy;
 
 /*!
-@brief Sets the URI of the event collector.
-@param eventCollectorUri A string for event collector uri.
+ @brief Sets the URI of the event collector.
+ @param eventCollectorUri A string for event collector uri.
 */
 +(void)setEventCollectorUri:(nonnull NSString *)eventCollectorUri;
 
 /*!
-@brief Returns the URI of the event collector.
+ @brief Returns the URI of the event collector.
 */
 +(nullable NSString *)eventCollectorUri;
 
 /*!
-@brief Sets the RAM queue size limit in bytes.
-@param cacheMemorySizeLimitInBytes  A long value for memory size limit in bytes.
+ @brief Sets the RAM queue size limit in bytes.
+ @param cacheMemorySizeLimitInBytes  A long value for memory size limit in bytes.
 */
 +(void)setCacheMemorySizeLimitInBytes:(uint64_t)cacheMemorySizeLimitInBytes;
 
 /*!
-@brief return the RAM queue size limit in bytes.
+ @brief return the RAM queue size limit in bytes.
 */
 +(uint64_t)cacheMemorySizeLimitInBytes;
 
 /*!
-@brief Sets the size limit of the disk file used to cache events on the client side.
-@param cacheFileSizeLimitInBytes  A long value for cache file size limit.
+ @brief Sets the size limit of the disk file used to cache events on the client side.
+ @param cacheFileSizeLimitInBytes  A long value for cache file size limit.
 */
 +(void)setCacheFileSizeLimitInBytes:(uint64_t)cacheFileSizeLimitInBytes;
 
 /*!
-@brief Returns the size limit of the disk file used to cache events on the client side.
+ @brief Returns the size limit of the disk file used to cache events on the client side.
 */
 +(uint64_t)cacheFileSizeLimitInBytes;
 
 /*!
-@brief Sets max teardown upload time in seconds.
-@param maxTeardownUploadTimeInSec An integer that time in seconds.
+ @brief Sets max teardown upload time in seconds.
+ @param maxTeardownUploadTimeInSec An integer that time in seconds.
 */
 +(void)setMaxTeardownUploadTimeInSec:(int)maxTeardownUploadTimeInSec;
 
 /*!
-@brief Sets if trace logging to file is enabled.
-@param enableTrace True if tracing is enabled.
+ @brief Sets if trace logging to file is enabled.
+ @param enableTrace True if tracing is enabled.
 */
 +(void)setEnableTrace:(bool)enableTrace;
 
 /*!
-@brief Sets if console logging from the iOS wrapper is enabled.
-@param enableConsoleLogging True if logging is enabled.
+ @brief Sets if console logging from the iOS wrapper is enabled.
+ @param enableConsoleLogging True if logging is enabled.
 */
 +(void)setEnableConsoleLogging:(bool)enableConsoleLogging;
 
 /*!
-@brief Sets the internal SDK debugging trace level.
-@param TraceLevel one of the ACTTraceLevel values.
+ @brief Sets the internal SDK debugging trace level.
+ @param TraceLevel one of the ACTTraceLevel values.
 */
 +(void)setTraceLevel:(int)TraceLevel;
 
 /*!
-@brief Returns true if tracing is enabled.
+ @brief Returns true if tracing is enabled.
 */
 +(bool)enableTrace;
 
 /*!
-@brief Returns true if console logging is enabled.
+ @brief Returns true if console logging is enabled.
 */
 +(bool)enableConsoleLogging;
 
 /*!
-@brief Sets if inner C++ exceptions should be surfaced to Wrapper consumers.
-@param surfaceCppExceptions True if C++ exceptions should be surfaced.
+ @brief Sets if inner C++ exceptions should be surfaced to Wrapper consumers.
+ @param surfaceCppExceptions True if C++ exceptions should be surfaced.
 */
 +(void)setSurfaceCppExceptions:(bool)surfaceCppExceptions;
 
 /*!
-@brief Returns true if inner C++ exceptions are surfaced to Wrapper consumers.
+ @brief Returns true if inner C++ exceptions are surfaced to Wrapper consumers.
 */
 +(bool)surfaceCppExceptions;
 
 /*!
-@brief Sets if session timestamp should be reset after a session ends
-@param enableSessionReset True if session should be reset on session end.
+ @brief Sets if session timestamp should be reset after a session ends
+ @param enableSessionReset True if session should be reset on session end.
 */
 +(void)setEnableSessionReset:(bool)enableSessionReset;
 
 /*!
-@brief Returns true if session will be reset on session end.
+ @brief Returns true if session will be reset on session end.
 */
 +(bool)enableSessionReset;
 
 /*!
-@brief Sets the cache file path.
-@param cacheFilePath A string for the cache path.
+ @brief Sets the cache file path.
+ @param cacheFilePath A string for the cache path.
 */
 +(void)setCacheFilePath:(nonnull NSString *)cacheFilePath;
 
 /*!
-@brief Returns the cache file path.
+ @brief Returns the cache file path.
 */
 +(nullable NSString *)cacheFilePath;
+
+/*!
+ @brief Sets a config key to a string value
+ @param key A key.
+ @param value A value.
+*/
+-(void)set:(nonnull NSString *)key withValue:(nonnull NSString *)value;
 
 @end
 

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -456,4 +456,10 @@ NSString *const ODWCFG_BOOL_SESSION_RESET_ENABLED = @"sessionResetEnabled";
     return [NSString stringWithCString:strCacheFilePath.c_str() encoding:NSUTF8StringEncoding];
 }
 
+-(void)set:(nonnull NSString *)key withValue:(nonnull NSString *)value
+{
+    ILogConfiguration wrappedConfig = *_wrappedConfiguration;
+    wrappedConfig[[key UTF8String]] = [value UTF8String];
+}
+
 @end

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -51,21 +51,6 @@ NSString *const ODWCFG_BOOL_ENABLE_WAL_JOURNAL = @"enableWALJournal";
 NSString *const ODWCFG_BOOL_ENABLE_NET_DETECT = @"enableNetworkDetector";
 
 /*!
- Parameter that allows to check if the SDK is running on UTC mode
-*/
-NSString *const ODWCFG_BOOL_UTC_ENABLED = @"enabled";
-
-/*!
- Parameter that allows to check if the SDK is running on UTC mode
-*/
-NSString *const ODWCFG_BOOL_UTC_ACTIVE = @"active";
-
-/*!
- Parameter that allows to check if the Windows 10 version SDK is using supports large payloads on UTC
-*/
-NSString *const ODWCFG_BOOL_UTC_LARGE_PAYLOADS = @"largePayloadsEnabled";
-
-/*!
  The event collection URI.
 */
 NSString *const ODWCFG_STR_COLLECTOR_URL = @"eventCollectorUri";
@@ -114,11 +99,6 @@ NSString *const ODWCFG_STR_TRACE_FOLDER_PATH = @"traceFolderPath";
  The SDK mode.
 */
 NSString *const ODWCFG_INT_SDK_MODE = @"sdkmode";
-
-/*!
- UTC lives at the root of all UTC-specific configuration.
-*/
-NSString *const ODWCFG_STR_UTC = @"utc";
 
 /*!
  Set the provider group directly with a string (which will be converted to a GUID).
@@ -206,16 +186,6 @@ NSString *const ODWCFG_MODULE_PRIVACY_GUARD = @"privacy_guard";
  IDecorator override module
 */
 NSString *const ODWCFG_MODULE_OFFLINE_STORAGE = @"offlineStorage";
-
-/*!
- Pointer to the Android app's JavaVM
-*/
-NSString *const ODWCFG_PTR_ANDROID_JVM = @"android_jvm";
-
-/*!
- JObject of the Android app's main activity
-*/
-NSString *const ODWCFG_JOBJECT_ANDROID_ACTIVITY = @"android_activity";
 
 /*!
  LogManagerFactory's name parameter

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -14,6 +14,22 @@ using namespace Microsoft::Applications::Events;
     static bool _enableConsoleLogging;
     static bool _enableSessionReset;
     static bool _surfaceCppExceptions;
+    ILogConfiguration* _wrappedConfiguration;
+
+-(instancetype)initWithILogConfiguration:(ILogConfiguration*)config
+{
+    self = [super init];
+    if(self) {
+        _wrappedConfiguration = config;
+    }
+    return self;
+}
+
++(nullable ODWLogConfiguration *)getLogConfigurationCopy
+{
+    auto& config = LogManager::GetLogConfiguration();
+    return [[ODWLogConfiguration alloc] initWithILogConfiguration: *config];
+}
 
 +(void)setEventCollectorUri:(nonnull NSString *)eventCollectorUri
 {

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -4,6 +4,7 @@
 //
 #import <Foundation/Foundation.h>
 #import "ODWLogConfiguration.h"
+#import "ODWLogConfiguration_private.h"
 #import "ODWLogger_private.h"
 #import "LogManager.hpp"
 
@@ -23,6 +24,11 @@ using namespace Microsoft::Applications::Events;
         _wrappedConfiguration = config;
     }
     return self;
+}
+
+-(nullable ILogConfiguration*)getWrappedConfiguration
+{
+    return _wrappedConfiguration;
 }
 
 +(nullable ODWLogConfiguration *)getLogConfigurationCopy

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -10,6 +10,308 @@
 
 using namespace Microsoft::Applications::Events;
 
+/*!
+  Enable analytics.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_ANALYTICS = @"enableLifecycleSession";
+
+/*!
+ Enable multitenant.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_MULTITENANT = @"multiTenantEnabled";
+
+/*!
+ Enable CRC-32 check.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_CRC32 = @"enableCRC32";
+
+/*!
+ Enable HMAC authentication.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_HMAC = @"enableHMAC";
+
+/*!
+ Enable dropping events if DB file size exceeds its limit.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_DB_DROP_IF_FULL = @"enableDbDropIfFull";
+
+/*!
+ Enable database compression.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_DB_COMPRESS = @"enableDBCompression";
+
+/*!
+ Enable WAL journal.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_WAL_JOURNAL = @"enableWALJournal";
+
+/*!
+ Enable network detector.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_NET_DETECT = @"enableNetworkDetector";
+
+/*!
+ Parameter that allows to check if the SDK is running on UTC mode
+*/
+NSString *const ODWCFG_BOOL_UTC_ENABLED = @"enabled";
+
+/*!
+ Parameter that allows to check if the SDK is running on UTC mode
+*/
+NSString *const ODWCFG_BOOL_UTC_ACTIVE = @"active";
+
+/*!
+ Parameter that allows to check if the Windows 10 version SDK is using supports large payloads on UTC
+*/
+NSString *const ODWCFG_BOOL_UTC_LARGE_PAYLOADS = @"largePayloadsEnabled";
+
+/*!
+ The event collection URI.
+*/
+NSString *const ODWCFG_STR_COLLECTOR_URL = @"eventCollectorUri";
+
+/*!
+ The cache file-path.
+*/
+NSString *const ODWCFG_STR_CACHE_FILE_PATH = @"cacheFilePath";
+
+/*!
+ the cache file size limit in bytes.
+*/
+NSString *const ODWCFG_INT_CACHE_FILE_SIZE = @"cacheFileSizeLimitInBytes";
+
+/*!
+ The RAM queue size limit in bytes.
+*/
+NSString *const ODWCFG_INT_RAM_QUEUE_SIZE = @"cacheMemorySizeLimitInBytes";
+
+/*!
+ The size of the RAM queue buffers, in bytes.
+*/
+NSString *const ODWCFG_INT_RAM_QUEUE_BUFFERS = @"maxDBFlushQueues";
+
+/*!
+ The trace level mask.
+*/
+NSString *const ODWCFG_INT_TRACE_LEVEL_MASK = @"traceLevelMask";
+
+/*!
+ The minimum trace level.
+*/
+NSString *const ODWCFG_INT_TRACE_LEVEL_MIN = @"minimumTraceLevel";
+
+/*!
+ Enable trace logs.
+*/
+NSString *const ODWCFG_BOOL_ENABLE_TRACE = @"enableTrace";
+
+/*!
+ The trace filepath.
+*/
+NSString *const ODWCFG_STR_TRACE_FOLDER_PATH = @"traceFolderPath";
+
+/*!
+ The SDK mode.
+*/
+NSString *const ODWCFG_INT_SDK_MODE = @"sdkmode";
+
+/*!
+ UTC lives at the root of all UTC-specific configuration.
+*/
+NSString *const ODWCFG_STR_UTC = @"utc";
+
+/*!
+ Set the provider group directly with a string (which will be converted to a GUID).
+*/
+NSString *const ODWCFG_STR_PROVIDER_GROUP_ID = @"providerGroupId";
+
+/*!
+ The maximum teardown time.
+*/
+NSString *const ODWCFG_INT_MAX_TEARDOWN_TIME = @"maxTeardownUploadTimeInSec";
+
+/*!
+ The maximum number of pending HTTP requests.
+*/
+NSString *const ODWCFG_INT_MAX_PENDING_REQ = @"maxPendingHTTPRequests";
+
+/*!
+ The maximum package drop on full.
+*/
+NSString *const ODWCFG_INT_MAX_PKG_DROP_ON_FULL = @"maxPkgDropOnFull";
+
+/*!
+ The cache file percentage full notification.
+*/
+NSString *const ODWCFG_INT_STORAGE_FULL_PCT = @"cacheFileFullNotificationPercentage";
+
+/*!
+ The minimum time (ms) between storage full notifications.
+*/
+NSString *const ODWCFG_INT_STORAGE_FULL_CHECK_TIME = @"cacheFullNotificationIntervalTime";
+
+/*!
+ The cache memory percentage full notification.
+*/
+NSString *const ODWCFG_INT_RAMCACHE_FULL_PCT = @"cacheMemoryFullNotificationPercentage";
+
+/*!
+ PRAGMA journal mode.
+*/
+NSString *const ODWCFG_STR_PRAGMA_JOURNAL_MODE = @"PRAGMA_journal_mode";
+
+/*!
+ PRAGMA synchronous.
+*/
+NSString *const ODWCFG_STR_PRAGMA_SYNCHRONOUS = @"PRAGMA_synchronous";
+
+NSString *const ODWCFG_STR_PRIMARY_TOKEN = @"primaryToken";
+
+/*!
+ Parameter that allows to apply custom transmit profile on SDK start
+*/
+NSString *const ODWCFG_STR_START_PROFILE_NAME = @"startProfileName";
+
+/*!
+ Parameter that allows to load a set of custom transmit profile on SDK start
+*/
+NSString *const ODWCFG_STR_TRANSMIT_PROFILES = @"transmitProfiles";
+
+/*!
+ IHttpClient override module
+*/
+NSString *const ODWCFG_MODULE_HTTP_CLIENT = @"httpClient";
+
+/*!
+ ITaskDispatcher override module
+*/
+NSString *const ODWCFG_MODULE_TASK_DISPATCHER = @"taskDispatcher";
+
+/*!
+ IDataViewer override module
+*/
+NSString *const ODWCFG_MODULE_DATA_VIEWER = @"dataViewer";
+
+/*!
+ IDecorator override module
+*/
+NSString *const ODWCFG_MODULE_DECORATOR = @"decorator";
+
+/*!
+ IDecorator override module
+*/
+NSString *const ODWCFG_MODULE_PRIVACY_GUARD = @"privacy_guard";
+
+/*!
+ IDecorator override module
+*/
+NSString *const ODWCFG_MODULE_OFFLINE_STORAGE = @"offlineStorage";
+
+/*!
+ Pointer to the Android app's JavaVM
+*/
+NSString *const ODWCFG_PTR_ANDROID_JVM = @"android_jvm";
+
+/*!
+ JObject of the Android app's main activity
+*/
+NSString *const ODWCFG_JOBJECT_ANDROID_ACTIVITY = @"android_activity";
+
+/*!
+ LogManagerFactory's name parameter
+*/
+NSString *const ODWCFG_STR_FACTORY_NAME = @"name";
+
+/*!
+ LogManagerFactory (and friends) config map
+*/
+NSString *const ODWCFG_MAP_FACTORY_CONFIG = @"config";
+
+/*!
+ sub-component in CFG_MAP_FACTORY_CONFIG: LogManagerFactory host parameter
+*/
+NSString *const ODWCFG_STR_FACTORY_HOST = @"host";
+
+/*!
+ sub-component in CFG_MAP_FACTORY_CONFIG: capi's scope parameter
+*/
+NSString *const ODWCFG_STR_CONTEXT_SCOPE = @"scope";
+
+/*!
+ MetaStats configuration
+*/
+NSString *const ODWCFG_MAP_METASTATS_CONFIG = @"stats";
+
+/*!
+ MetaStats configuration: time interval
+*/
+NSString *const ODWCFG_INT_METASTATS_INTERVAL = @"interval";
+
+/*!
+ MetaStats configuration: time interval
+*/
+NSString *const ODWCFG_BOOL_METASTATS_SPLIT = @"split";
+
+/*!
+ Compatibility configuration
+*/
+NSString *const ODWCFG_MAP_COMPAT = @"compat";
+
+/*!
+ Compatibility configuration: dot mode
+*/
+NSString *const ODWCFG_BOOL_COMPAT_DOTS = @"dotType";
+
+/*!
+ LogManagerFactory: is this log manager instance in host mode?
+*/
+NSString *const ODWCFG_BOOL_HOST_MODE = @"hostMode";
+
+/*!
+ HTTP configuration map
+*/
+NSString *const ODWCFG_MAP_HTTP = @"http";
+
+/*!
+ HTTP configuration map: MS root check
+*/
+NSString *const ODWCFG_BOOL_HTTP_MS_ROOT_CHECK = @"msRootCheck";
+
+/*!
+ HTTP configuration: compression
+*/
+NSString *const ODWCFG_BOOL_HTTP_COMPRESSION = @"compress";
+
+/*!
+ TPM configuration map
+*/
+NSString *const ODWCFG_MAP_TPM = @"tpm";
+
+/*!
+ TPM configuration: max retry
+*/
+NSString *const ODWCFG_INT_TPM_MAX_RETRY = @"maxRetryCount";
+
+/*!
+ TPM configuration map
+*/
+NSString *const ODWCFG_STR_TPM_BACKOFF = @"backoffConfig";
+
+/*!
+ TPM configuration map
+*/
+NSString *const ODWCFG_INT_TPM_MAX_BLOB_BYTES = @"maxBlobSize";
+
+/*!
+ TPM configuration map
+*/
+NSString *const ODWCFG_BOOL_TPM_CLOCK_SKEW_ENABLED = @"clockSkewEnabled";
+
+/*!
+ When enabled, the session timer is reset after session is completed, allowing for several session events in the duration of the SDK lifecycle
+*/
+NSString *const ODWCFG_BOOL_SESSION_RESET_ENABLED = @"sessionResetEnabled";
+
 @implementation ODWLogConfiguration
     static bool _enableTrace;
     static bool _enableConsoleLogging;

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -28,7 +28,8 @@ using namespace Microsoft::Applications::Events;
 +(nullable ODWLogConfiguration *)getLogConfigurationCopy
 {
     auto& config = LogManager::GetLogConfiguration();
-    return [[ODWLogConfiguration alloc] initWithILogConfiguration: *config];
+    ILogConfiguration configCopy(config);
+    return [[ODWLogConfiguration alloc] initWithILogConfiguration: &configCopy];
 }
 
 +(void)setEventCollectorUri:(nonnull NSString *)eventCollectorUri

--- a/wrappers/obj-c/ODWLogConfiguration_private.h
+++ b/wrappers/obj-c/ODWLogConfiguration_private.h
@@ -10,8 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 using namespace MAT;
 
-#define EXCEPTION_TRACE_FORMAT @"C++ Exception: %s"
-
 /*!
  The <b>ODWLogConfiguration</b> static class represents general logging properties.
 */

--- a/wrappers/obj-c/ODWLogConfiguration_private.h
+++ b/wrappers/obj-c/ODWLogConfiguration_private.h
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "objc_begin.h"
+#include "LogManager.hpp"
+#import "ODWLogConfiguration.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+using namespace MAT;
+
+#define EXCEPTION_TRACE_FORMAT @"C++ Exception: %s"
+
+/*!
+ The <b>ODWLogConfiguration</b> static class represents general logging properties.
+*/
+@interface ODWLogConfiguration (Private)
+
+/*!
+ @brief Constructs an ODWLogConfiguration object, taking internal API config pointer. This method might be only used internally by wrapper.
+ */
+-(instancetype)initWithILogConfiguration:(ILogConfiguration*)config;
+
+/*!
+ @brief Return the wrapped config. This method might be only used internally by wrapper.
+ */
+-(nullable ILogConfiguration*)getWrappedConfiguration;
+
+@end
+
+NS_ASSUME_NONNULL_END
+#include "objc_end.h"

--- a/wrappers/obj-c/ODWLogManager.h
+++ b/wrappers/obj-c/ODWLogManager.h
@@ -50,10 +50,10 @@ typedef NS_ENUM(NSInteger, ODWStatus)
 +(nullable ODWLogger *)initForTenant:(nonnull NSString *)tenantToken;
 
 /*!
-@brief Initializes the telemetry logging system with the specified tenant token and custom cofiguration.
-@param tenantToken A string that contains the tenant token.
-@param config A Dictionary that contains a custom configuration.
-@return An ODWLogger instance
+ @brief Initializes the telemetry logging system with the specified tenant token and custom cofiguration.
+ @param tenantToken A string that contains the tenant token.
+ @param config A Dictionary that contains a custom configuration.
+ @return An ODWLogger instance
 */
 +(nullable ODWLogger *)initForTenant:(nonnull NSString *)tenantToken withConfig:(nullable NSDictionary *)config;
 
@@ -72,6 +72,17 @@ typedef NS_ENUM(NSInteger, ODWStatus)
  */
 +(nullable ODWLogger *)loggerWithTenant:(NSString *)tenantToken
                   source:(NSString *)source;
+
+/*!
+ @brief Retrieves a new instance of ODWLogger for logging telemetry events. Initializes the telemetry logging system, if not already initialized, with the default configuration using the specified tenant token and source.
+ @param tenantToken A string that contains the tenant token.
+ @param source A string that contains the name of the source of events.
+ @param config A Dictionary that contains a custom configuration.
+ @return An ODWLogger pointer that points to the logger for the specified tenantToken and source.
+ */
++(nullable ODWLogger *)loggerWithTenant:(NSString *)tenantToken
+                  source:(NSString *)source
+                  withConfig:(nullable NSDictionary *)config;
 
 /*!
  @brief Retrieves a new instance of ODWLogger for logging telemetry events. It requires to previously call "loggerWithTenant" method

--- a/wrappers/obj-c/ODWLogManager.h
+++ b/wrappers/obj-c/ODWLogManager.h
@@ -50,10 +50,10 @@ typedef NS_ENUM(NSInteger, ODWStatus)
 +(nullable ODWLogger *)initForTenant:(nonnull NSString *)tenantToken;
 
 /*!
- @brief Initializes the telemetry logging system with the specified tenant token and custom cofiguration.
- @param tenantToken A string that contains the tenant token.
- @param config A Dictionary that contains a custom configuration.
- @return An ODWLogger instance
+@brief Initializes the telemetry logging system with the specified tenant token and custom cofiguration.
+@param tenantToken A string that contains the tenant token.
+@param config A Dictionary that contains a custom configuration.
+@return An ODWLogger instance
 */
 +(nullable ODWLogger *)initForTenant:(nonnull NSString *)tenantToken withConfig:(nullable NSDictionary *)config;
 

--- a/wrappers/obj-c/ODWLogManager.h
+++ b/wrappers/obj-c/ODWLogManager.h
@@ -82,7 +82,7 @@ typedef NS_ENUM(NSInteger, ODWStatus)
  */
 +(nullable ODWLogger *)loggerWithTenant:(NSString *)tenantToken
                   source:(NSString *)source
-                  withConfig:(nullable NSDictionary *)config;
+                  withConfig:(nonnull ODWLogConfiguration *)config;
 
 /*!
  @brief Retrieves a new instance of ODWLogger for logging telemetry events. It requires to previously call "loggerWithTenant" method

--- a/wrappers/obj-c/ODWLogManager.h
+++ b/wrappers/obj-c/ODWLogManager.h
@@ -74,7 +74,7 @@ typedef NS_ENUM(NSInteger, ODWStatus)
                   source:(NSString *)source;
 
 /*!
- @brief Retrieves a new instance of ODWLogger for logging telemetry events. Initializes the telemetry logging system, if not already initialized, with the default configuration using the specified tenant token and source.
+ @brief Retrieves a new instance of ODWLogger for logging telemetry events. This function expects that the telemetry logging system has already been initialized.
  @param tenantToken A string that contains the tenant token.
  @param source A string that contains the name of the source of events.
  @param config A Dictionary that contains a custom configuration.

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -8,6 +8,7 @@
 #import "ODWLogger_private.h"
 #include <stdexcept>
 #include "LogManager.hpp"
+#include "LogManagerProvider.hpp"
 
 using namespace MAT;
 using namespace Microsoft::Applications::Events;
@@ -31,6 +32,13 @@ static BOOL _initialized = false;
     {
         return nil;
     }
+
+    status_t status = status_t::STATUS_SUCCESS;
+    ODWLogConfiguration* config = [ODWLogConfiguration getLogConfigurationCopy];
+    ILogManager* manager = LogManagerProvider::CreateLogManager(
+        config._wrappedConfiguration,
+        status);
+
     std::string strToken = std::string([tenantToken UTF8String]);
     std::string strSource = std::string([source UTF8String]);
     ILogger* logger = nullptr;

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -57,42 +57,17 @@ static BOOL _initialized = false;
 
 +(nullable ODWLogger *)loggerWithTenant:(nonnull NSString *)tenantToken
                   source:(nonnull NSString *)source
-                  withConfig:(nullable NSDictionary *)config
+                  withConfig:(nonnull ODWLogConfiguration *)config
 {
-    if (config == nil || config.count == 0)
-    {
-        return [ODWLogManager loggerWithTenant:tenantToken source:source];
-    }
-
     status_t status = status_t::STATUS_SUCCESS;
-    ODWLogConfiguration* odwConfig = [ODWLogConfiguration getLogConfigurationCopy];
-    if (odwConfig == nil)
+    ILogConfiguration* wrappedConfig = [config getWrappedConfiguration];
+    if (wrappedConfig == nil)
     {
         return nil;
-    }
-
-    ILogConfiguration* wrappedConfigPtr = [odwConfig getWrappedConfiguration];
-    if (wrappedConfigPtr == nil)
-    {
-        return nil;
-    }
-    ILogConfiguration wrappedConfig = *wrappedConfigPtr;
-    NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:config
-                                                        options:0
-                                                            error:&error];
-    if (jsonData)
-    {
-        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-        ILogConfiguration inputConfig = MAT::FromJSON([jsonString UTF8String]);
-        for (const auto& kv : *inputConfig)
-        {
-            wrappedConfig[kv.first.c_str()] = kv.second;
-        }
     }
 
     ILogManager* manager = LogManagerProvider::CreateLogManager(
-        wrappedConfig,
+        *wrappedConfig,
         status);
 
     if (status == status_t::STATUS_SUCCESS && manager != nil)

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -59,6 +59,13 @@ static BOOL _initialized = false;
                   source:(nonnull NSString *)source
                   withConfig:(nonnull ODWLogConfiguration *)config
 {
+    // We expect that the static LogManager has already been initialized before this function is called
+    // If not, return nil
+    if (!_initialized)
+    {
+        return nil;
+    }
+
     status_t status = status_t::STATUS_SUCCESS;
     ILogConfiguration* wrappedConfig = [config getWrappedConfiguration];
     if (wrappedConfig == nil)
@@ -286,7 +293,7 @@ static BOOL _initialized = false;
     PerformActionWithCppExceptionsCatch(^(void) {
         std::string strKey = std::string([name UTF8String]);
         std::string strValue = std::string([value UTF8String]);
-        
+
         LogManager::SetContext(strKey, strValue);
     });
 }

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -4,6 +4,7 @@
 //
 #import <Foundation/Foundation.h>
 #import "ODWLogConfiguration.h"
+#import "ODWLogConfiguration_private.h"
 #import "ODWLogManager.h"
 #import "ODWLogger_private.h"
 #include <stdexcept>
@@ -35,9 +36,10 @@ static BOOL _initialized = false;
 
     status_t status = status_t::STATUS_SUCCESS;
     ODWLogConfiguration* config = [ODWLogConfiguration getLogConfigurationCopy];
-    ILogManager* manager = LogManagerProvider::CreateLogManager(
+    ILogConfiguration* wrappedConfig = [config getWrappedConfiguration];
+    /*ILogManager* manager = LogManagerProvider::CreateLogManager(
         config._wrappedConfiguration,
-        status);
+        status);*/
 
     std::string strToken = std::string([tenantToken UTF8String]);
     std::string strSource = std::string([source UTF8String]);

--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -66,9 +66,33 @@ static BOOL _initialized = false;
 
     status_t status = status_t::STATUS_SUCCESS;
     ODWLogConfiguration* odwConfig = [ODWLogConfiguration getLogConfigurationCopy];
-    ILogConfiguration* wrappedConfig = [odwConfig getWrappedConfiguration];
+    if (odwConfig == nil)
+    {
+        return nil;
+    }
+
+    ILogConfiguration* wrappedConfigPtr = [odwConfig getWrappedConfiguration];
+    if (wrappedConfigPtr == nil)
+    {
+        return nil;
+    }
+    ILogConfiguration wrappedConfig = *wrappedConfigPtr;
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:config
+                                                        options:0
+                                                            error:&error];
+    if (jsonData)
+    {
+        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        ILogConfiguration inputConfig = MAT::FromJSON([jsonString UTF8String]);
+        for (const auto& kv : *inputConfig)
+        {
+            wrappedConfig[kv.first.c_str()] = kv.second;
+        }
+    }
+
     ILogManager* manager = LogManagerProvider::CreateLogManager(
-        *wrappedConfig,
+        wrappedConfig,
         status);
 
     if (status == status_t::STATUS_SUCCESS && manager != nil)


### PR DESCRIPTION
Currently iOS only uses default config, which makes side-by-side loggers with different configuration not possible. close #784 