### PR TITLE
Add Support for Mulitple IDataInspectors within Log Manager

### DIFF
--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -807,7 +807,6 @@ namespace MAT_NS_BEGIN
     void LogManagerImpl::SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector)
     {
         LOCKGUARD(m_dataInspectorGuard);
-        m_dataInspectors.clear();
         if(dataInspector == nullptr)
         {
             LOG_WARN("Attempting to set nullptr as DataInspector");
@@ -816,7 +815,7 @@ namespace MAT_NS_BEGIN
 
         auto itDataInspector = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&dataInspector](const std::shared_ptr<IDataInspector>& currentInspector)
         {
-            return strcmp(typeid(dataInspector).name(),typeid(currentInspector).name()) == 0;
+            return strcmp(typeid(*dataInspector).name(),typeid(*currentInspector).name()) == 0;
         });
 
         if (itDataInspector != m_dataInspectors.end())
@@ -847,11 +846,12 @@ namespace MAT_NS_BEGIN
     {
         for (const auto& dataInspector : m_dataInspectors)
         {
-            if (strcmp(uniqueIdentifier.c_str(), typeid(dataInspector).name()) == 0)
+            if (strcmp(uniqueIdentifier.c_str(), typeid(*dataInspector).name()) == 0)
             {
                 return dataInspector;
             }
         }
+        LOG_WARN("DataInspector requested does not exist");
         return  nullptr;
     }
 

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -402,7 +402,7 @@ namespace MAT_NS_BEGIN
             m_httpClient = nullptr;
             m_taskDispatcher = nullptr;
             m_dataViewer = nullptr;
-            std::vector<std::shared_ptr<IDataInspector>>{}.swap(m_dataInspectors);
+            ClearDataInspectors();
 
             m_filters.UnregisterAllFilters();
 

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -846,7 +846,8 @@ namespace MAT_NS_BEGIN
     {
         for (const auto& dataInspector : m_dataInspectors)
         {
-            if (strcmp(uniqueIdentifier.c_str(), typeid(*dataInspector).name()) == 0)
+            std::string inspectorIdentifier(typeid(*dataInspector).name());
+            if (inspectorIdentifier.find(uniqueIdentifier) != std::string::npos)
             {
                 return dataInspector;
             }

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -816,27 +816,6 @@ namespace MAT_NS_BEGIN
         m_dataInspectors.push_back(dataInspector);
     }
 
-    void LogManagerImpl::AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& dataInspector)
-    {
-        LOCKGUARD(m_dataInspectorGuard);
-        if(dataInspector == nullptr)
-        {
-            LOG_WARN("Attempting to set nullptr as DataInspector");
-            return;
-        }
-
-        auto itDataInspector = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&dataInspector](const auto& inspector){
-            return inspector->UniqueIdentifier().compare(dataInspector->UniqueIdentifier()) == 0;
-        });
-
-        if (itDataInspector != m_dataInspectors.end())
-        {
-            m_dataInspectors.erase(itDataInspector);
-        }
-
-        m_dataInspectors.push_back(dataInspector);
-    }
-
     void LogManagerImpl::ClearDataInspectors()
     {
         LOCKGUARD(m_dataInspectorGuard);
@@ -850,18 +829,6 @@ namespace MAT_NS_BEGIN
             return nullptr;
         }
         return m_dataInspectors.at(0);
-    }
-
-    std::shared_ptr<IDataInspector> LogManagerImpl::GetDataInspector(const std::string& uniqueIdentifier) noexcept
-    {
-        for (const auto& dataInspector : m_dataInspectors)
-        {
-            if (dataInspector->UniqueIdentifier().compare(uniqueIdentifier) == 0)
-            {
-                return dataInspector;
-            }
-        }
-        return nullptr;
     }
 
     status_t LogManagerImpl::DeleteData()

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -813,6 +813,18 @@ namespace MAT_NS_BEGIN
             LOG_WARN("Attempting to set nullptr as DataInspector");
             return;
         }
+
+        auto itDataInspector = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&dataInspector](const std::shared_ptr<IDataInspector>& currentInspector)
+        {
+            return strcmp(typeid(dataInspector).name(),typeid(currentInspector).name()) == 0;
+        });
+
+        if (itDataInspector != m_dataInspectors.end())
+        {
+            LOG_WARN("Replacing specified IDataInspector with passed in inspector");
+            m_dataInspectors.erase(itDataInspector);
+        }
+
         m_dataInspectors.push_back(dataInspector);
     }
 
@@ -829,6 +841,18 @@ namespace MAT_NS_BEGIN
             return nullptr;
         }
         return m_dataInspectors.at(0);
+    }
+
+    std::shared_ptr<IDataInspector> LogManagerImpl::GetDataInspector(const std::string& uniqueIdentifier) noexcept
+    {
+        for (const auto& dataInspector : m_dataInspectors)
+        {
+            if (strcmp(uniqueIdentifier.c_str(), typeid(dataInspector).name()) == 0)
+            {
+                return dataInspector;
+            }
+        }
+        return  nullptr;
     }
 
     status_t LogManagerImpl::DeleteData()

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -402,7 +402,7 @@ namespace MAT_NS_BEGIN
             m_httpClient = nullptr;
             m_taskDispatcher = nullptr;
             m_dataViewer = nullptr;
-            m_dataInspectors.clear();
+            std::vector<std::shared_ptr<IDataInspector>>{}.swap(m_dataInspectors);
 
             m_filters.UnregisterAllFilters();
 
@@ -815,7 +815,7 @@ namespace MAT_NS_BEGIN
 
         auto itDataInspector = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&dataInspector](const std::shared_ptr<IDataInspector>& currentInspector)
         {
-            return strcmp(typeid(*dataInspector).name(),typeid(*currentInspector).name()) == 0;
+            return strcmp(dataInspector->GetName(), currentInspector->GetName()) == 0;
         });
 
         if (itDataInspector != m_dataInspectors.end())
@@ -830,19 +830,19 @@ namespace MAT_NS_BEGIN
     void LogManagerImpl::ClearDataInspectors()
     {
         LOCKGUARD(m_dataInspectorGuard);
-        std::vector<std::shared_ptr<IDataInspector>>().swap(m_dataInspectors);
+        std::vector<std::shared_ptr<IDataInspector>>{}.swap(m_dataInspectors);
     }
 
     void LogManagerImpl::RemoveDataInspector(const std::string& name)
     {
         LOCKGUARD(m_dataInspectorGuard);
-        auto it = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&name](const std::shared_ptr<IDataInspector>& inspector){
+        auto itDataInspector = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&name](const std::shared_ptr<IDataInspector>& inspector){
             return strcmp(inspector->GetName(), name.c_str()) == 0;
         });
 
-        if (it != m_dataInspectors.end())
+        if (itDataInspector != m_dataInspectors.end())
         {
-            m_dataInspectors.erase(it);
+            m_dataInspectors.erase(itDataInspector);
         }
     }
 

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -402,7 +402,7 @@ namespace MAT_NS_BEGIN
             m_httpClient = nullptr;
             m_taskDispatcher = nullptr;
             m_dataViewer = nullptr;
-            m_dataInspector = nullptr;
+            m_dataInspectors.clear();
 
             m_filters.UnregisterAllFilters();
 
@@ -525,9 +525,9 @@ namespace MAT_NS_BEGIN
         m_context.SetCustomField(name, prop);
         {
             LOCKGUARD(m_dataInspectorGuard);
-            if (m_dataInspector)
+            for(const auto& dataInspector : m_dataInspectors)
             {
-                m_dataInspector->InspectSemanticContext(name, value, /*isGlobalContext: */ true, std::string{});
+                dataInspector->InspectSemanticContext(name, value, /*isGlobalContext: */ true, std::string{});
             }
         }
         return STATUS_SUCCESS;
@@ -603,9 +603,9 @@ namespace MAT_NS_BEGIN
         m_context.SetCustomField(name, prop);
         {
             LOCKGUARD(m_dataInspectorGuard);
-            if (m_dataInspector)
+            for(const auto& dataInspector : m_dataInspectors)
             {
-                m_dataInspector->InspectSemanticContext(name, value, /*isGlobalContext: */ true, std::string{});
+                dataInspector->InspectSemanticContext(name, value, /*isGlobalContext: */ true, std::string{});
             }
         }
         return STATUS_SUCCESS;
@@ -710,9 +710,9 @@ namespace MAT_NS_BEGIN
             {
                 LOCKGUARD(m_dataInspectorGuard);
 
-                if (m_dataInspector)
+                for (const auto& dataInspector : m_dataInspectors)
                 {
-                    m_dataInspector->InspectRecord(*(event->source));
+                    dataInspector->InspectRecord(*(event->source));
                 }
             }
             GetSystem()->sendEvent(event);
@@ -807,12 +807,61 @@ namespace MAT_NS_BEGIN
     void LogManagerImpl::SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector)
     {
         LOCKGUARD(m_dataInspectorGuard);
-        m_dataInspector = dataInspector;
+        m_dataInspectors.clear();
+        if(dataInspector == nullptr)
+        {
+            LOG_WARN("Attempting to set nullptr as DataInspector");
+            return;
+        }
+        m_dataInspectors.push_back(dataInspector);
+    }
+
+    void LogManagerImpl::AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& dataInspector)
+    {
+        LOCKGUARD(m_dataInspectorGuard);
+        if(dataInspector == nullptr)
+        {
+            LOG_WARN("Attempting to set nullptr as DataInspector");
+            return;
+        }
+
+        auto itDataInspector = std::find_if(m_dataInspectors.begin(), m_dataInspectors.end(), [&dataInspector](const auto& inspector){
+            return inspector->UniqueIdentifier().compare(dataInspector->UniqueIdentifier()) == 0;
+        });
+
+        if (itDataInspector != m_dataInspectors.end())
+        {
+            m_dataInspectors.erase(itDataInspector);
+        }
+
+        m_dataInspectors.push_back(dataInspector);
+    }
+
+    void LogManagerImpl::ClearDataInspectors()
+    {
+        LOCKGUARD(m_dataInspectorGuard);
+        m_dataInspectors.clear();
     }
 
     std::shared_ptr<IDataInspector> LogManagerImpl::GetDataInspector() noexcept
     {
-        return m_dataInspector;
+        if(m_dataInspectors.empty())
+        {
+            return nullptr;
+        }
+        return m_dataInspectors.at(0);
+    }
+
+    std::shared_ptr<IDataInspector> LogManagerImpl::GetDataInspector(const std::string& uniqueIdentifier) noexcept
+    {
+        for (const auto& dataInspector : m_dataInspectors)
+        {
+            if (dataInspector->UniqueIdentifier().compare(uniqueIdentifier) == 0)
+            {
+                return dataInspector;
+            }
+        }
+        return nullptr;
     }
 
     status_t LogManagerImpl::DeleteData()

--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -297,10 +297,8 @@ namespace MAT_NS_BEGIN
         static size_t GetDeadLoggerCount();
 
         virtual void SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) override;
-        virtual void AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) override;
         virtual void ClearDataInspectors() override;
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept override;
-        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept override;
 
        protected:
         std::unique_ptr<ITelemetrySystem>& GetSystem();

--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -299,6 +299,7 @@ namespace MAT_NS_BEGIN
         virtual void SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) override;
         virtual void ClearDataInspectors() override;
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept override;
+        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept override;
 
        protected:
         std::unique_ptr<ITelemetrySystem>& GetSystem();

--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -298,8 +298,8 @@ namespace MAT_NS_BEGIN
 
         virtual void SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) override;
         virtual void ClearDataInspectors() override;
-        virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept override;
-        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept override;
+        virtual void RemoveDataInspector(const std::string& name) override;
+        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& name) noexcept override;
 
        protected:
         std::unique_ptr<ITelemetrySystem>& GetSystem();

--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -297,8 +297,10 @@ namespace MAT_NS_BEGIN
         static size_t GetDeadLoggerCount();
 
         virtual void SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) override;
-
+        virtual void AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) override;
+        virtual void ClearDataInspectors() override;
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept override;
+        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept override;
 
        protected:
         std::unique_ptr<ITelemetrySystem>& GetSystem();
@@ -337,7 +339,7 @@ namespace MAT_NS_BEGIN
         EventFilterCollection m_filters;
         std::vector<std::unique_ptr<IModule>> m_modules;
         DataViewerCollection m_dataViewerCollection;
-        std::shared_ptr<IDataInspector> m_dataInspector;
+        std::vector<std::shared_ptr<IDataInspector>> m_dataInspectors;
         std::recursive_mutex m_dataInspectorGuard;
     };
 

--- a/lib/include/public/IDataInspector.hpp
+++ b/lib/include/public/IDataInspector.hpp
@@ -118,6 +118,12 @@ namespace MAT_NS_BEGIN
         /// <param name="isGlobalContext">Whether this is a global/logmanager Context or local ILogger context</param>
         /// <param name="associatedTenant">(Optional) Tenant associated with the Context</param>
         virtual void InspectSemanticContext(const std::string& contextName, GUID_t contextValue, bool isGlobalContext, const std::string& associatedTenant) noexcept = 0;
+
+        /// <summary>
+        /// Get the descriptive name for inspector.
+        /// </summary>
+        /// <returns>String descriptor for instance of IDataInspector.</returns>
+        virtual const std::string& UniqueIdentifier() const = 0;
     };
 
 }

--- a/lib/include/public/IDataInspector.hpp
+++ b/lib/include/public/IDataInspector.hpp
@@ -118,6 +118,12 @@ namespace MAT_NS_BEGIN
         /// <param name="isGlobalContext">Whether this is a global/logmanager Context or local ILogger context</param>
         /// <param name="associatedTenant">(Optional) Tenant associated with the Context</param>
         virtual void InspectSemanticContext(const std::string& contextName, GUID_t contextValue, bool isGlobalContext, const std::string& associatedTenant) noexcept = 0;
+
+        /// <summary>
+        /// Returns unique name for current Data Inspector
+        /// </summary>
+        /// <returns>Name of Data Inspector</returns>
+        virtual const char* GetName() const noexcept { return ""; }
     };
 
 }

--- a/lib/include/public/IDataInspector.hpp
+++ b/lib/include/public/IDataInspector.hpp
@@ -118,12 +118,6 @@ namespace MAT_NS_BEGIN
         /// <param name="isGlobalContext">Whether this is a global/logmanager Context or local ILogger context</param>
         /// <param name="associatedTenant">(Optional) Tenant associated with the Context</param>
         virtual void InspectSemanticContext(const std::string& contextName, GUID_t contextValue, bool isGlobalContext, const std::string& associatedTenant) noexcept = 0;
-
-        /// <summary>
-        /// Get the descriptive name for inspector.
-        /// </summary>
-        /// <returns>String descriptor for instance of IDataInspector.</returns>
-        virtual const std::string& UniqueIdentifier() const = 0;
     };
 
 }

--- a/lib/include/public/ILogManager.hpp
+++ b/lib/include/public/ILogManager.hpp
@@ -380,10 +380,28 @@ namespace MAT_NS_BEGIN
         virtual void SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) = 0;
 
         /// <summary>
+        /// Adds new IDataInspector to LogManager, or updates that instance with new IDataInspector
+        /// </summary>
+        /// <param name="dataInspector">Shared Ptr to and instance of IDataInspector</param>
+        virtual void AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) = 0;
+
+        /// <summary>
+        /// Clears all IDataInspectors
+        /// </summary>
+        virtual void ClearDataInspectors() = 0;
+
+        /// <summary>
         /// Get the current instance of IDataInspector
         /// </summary>
         /// <returns>Current instance of IDataInspector if set, nullptr otherwise.</returns>
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept = 0;
+
+        /// <summary>
+        /// Gets the specified instance of IDataInspector
+        /// </summary>
+        /// <param name="uniqueIdentifier">String that identifies the IDataInspector</param>
+        /// <returns>Specified instance of IDataInspector if present, nullptr otherwise.</returns>
+        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept = 0;
     };
 
 }

--- a/lib/include/public/ILogManager.hpp
+++ b/lib/include/public/ILogManager.hpp
@@ -385,17 +385,23 @@ namespace MAT_NS_BEGIN
         virtual void ClearDataInspectors() = 0;
 
         /// <summary>
-        /// Get the first instance of IDataInspector
+        /// Removes specified IDataInspector
         /// </summary>
-        /// <returns>Current instance of IDataInspector if set, nullptr otherwise.</returns>
-        virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept = 0;
+        /// <param name="name">String name that identifies IDataInspector</param>
+        virtual void RemoveDataInspector(const std::string& name) = 0;
 
         /// <summary>
-        /// Get the current instance of IDataInspector specified by the UniqueIdentifier
+        /// Get the current instance of IDataInspector specified by the name
         /// </summary>
-        /// <param name="uniqueIdentifier">String name that identifies IDataInspector</param>
-        /// <returns>Current instance of IDataInspector if set, nullptr otherwise.</returns>
-        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept = 0;
+        /// <param name="name">String name that identifies IDataInspector</param>
+        /// <returns>Selected instance of IDataInspector if available, nullptr otherwise.</returns>
+        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& name) noexcept = 0;
+
+        /// <summary>
+        /// Get the current instance of IDataInspector specified by an empty string
+        /// </summary>
+        /// <returns>Selected instance of IDataInspector if available, nullptr otherwise.</returns>
+        virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept { return GetDataInspector(std::string{}); }
     };
 
 }

--- a/lib/include/public/ILogManager.hpp
+++ b/lib/include/public/ILogManager.hpp
@@ -385,10 +385,17 @@ namespace MAT_NS_BEGIN
         virtual void ClearDataInspectors() = 0;
 
         /// <summary>
-        /// Get the current instance of IDataInspector
+        /// Get the first instance of IDataInspector
         /// </summary>
         /// <returns>Current instance of IDataInspector if set, nullptr otherwise.</returns>
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept = 0;
+
+        /// <summary>
+        /// Get the current instance of IDataInspector specified by the UniqueIdentifier
+        /// </summary>
+        /// <param name="uniqueIdentifier">String name that identifies IDataInspector</param>
+        /// <returns>Current instance of IDataInspector if set, nullptr otherwise.</returns>
+        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept = 0;
     };
 
 }

--- a/lib/include/public/ILogManager.hpp
+++ b/lib/include/public/ILogManager.hpp
@@ -380,12 +380,6 @@ namespace MAT_NS_BEGIN
         virtual void SetDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) = 0;
 
         /// <summary>
-        /// Adds new IDataInspector to LogManager, or updates that instance with new IDataInspector
-        /// </summary>
-        /// <param name="dataInspector">Shared Ptr to and instance of IDataInspector</param>
-        virtual void AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& dataInspector) = 0;
-
-        /// <summary>
         /// Clears all IDataInspectors
         /// </summary>
         virtual void ClearDataInspectors() = 0;
@@ -395,13 +389,6 @@ namespace MAT_NS_BEGIN
         /// </summary>
         /// <returns>Current instance of IDataInspector if set, nullptr otherwise.</returns>
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept = 0;
-
-        /// <summary>
-        /// Gets the specified instance of IDataInspector
-        /// </summary>
-        /// <param name="uniqueIdentifier">String that identifies the IDataInspector</param>
-        /// <returns>Specified instance of IDataInspector if present, nullptr otherwise.</returns>
-        virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& uniqueIdentifier) noexcept = 0;
     };
 
 }

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -377,6 +377,11 @@ namespace MAT_NS_BEGIN
             return nullptr;
         }
 
+        std::shared_ptr<IDataInspector> GetDataInspector(const std::string& /*uniqueIdentifier*/) noexcept override
+        {
+            return nullptr;
+        }
+
         virtual status_t DeleteData() noexcept override 
         { 
             return STATUS_ENOSYS;

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -370,16 +370,9 @@ namespace MAT_NS_BEGIN
 
         void SetDataInspector(const std::shared_ptr<IDataInspector>& /*dataInspector*/) override {}
 
-        void AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& /*dataInspector*/) override {}
-
         void ClearDataInspectors() override {}
 
         std::shared_ptr<IDataInspector> GetDataInspector() noexcept override
-        {
-            return nullptr;
-        }
-
-        std::shared_ptr<IDataInspector> GetDataInspector(const std::string& /*uniqueIdentifier*/) noexcept override
         {
             return nullptr;
         }

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -370,14 +370,11 @@ namespace MAT_NS_BEGIN
 
         void SetDataInspector(const std::shared_ptr<IDataInspector>& /*dataInspector*/) override {}
 
+        void RemoveDataInspector(const std::string& /*name*/) override {}
+
         void ClearDataInspectors() override {}
 
-        std::shared_ptr<IDataInspector> GetDataInspector() noexcept override
-        {
-            return nullptr;
-        }
-
-        std::shared_ptr<IDataInspector> GetDataInspector(const std::string& /*uniqueIdentifier*/) noexcept override
+        std::shared_ptr<IDataInspector> GetDataInspector(const std::string& /*name*/) noexcept override
         {
             return nullptr;
         }

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -370,7 +370,16 @@ namespace MAT_NS_BEGIN
 
         void SetDataInspector(const std::shared_ptr<IDataInspector>& /*dataInspector*/) override {}
 
+        void AddOrUpdateDataInspector(const std::shared_ptr<IDataInspector>& /*dataInspector*/) override {}
+
+        void ClearDataInspectors() override {}
+
         std::shared_ptr<IDataInspector> GetDataInspector() noexcept override
+        {
+            return nullptr;
+        }
+
+        std::shared_ptr<IDataInspector> GetDataInspector(const std::string& /*uniqueIdentifier*/) noexcept override
         {
             return nullptr;
         }


### PR DESCRIPTION
the follow up changes will need to be to either the `IDataInspector` to have a public function that identifies the type of DataInspector is it (such as `UniqueIdentifier()` which will always describe the type of identifier) or we could change the ILogManager interface to include identifiers when adding new IDataInspectors (such as change `SetDataInspector(std::shared_ptr<IDataInspector>)` to `AddDataInspector(std::string, std::shared_ptr<IDataInspector>)`) or we could use a call to `typeid(currentInspector).name()` and compare that to the currently present `IDataInspector`'s however I'm not confident that using `typeid` wouldn't cause any issues down the road. This last solution I believe would reduce the number public interface changes