### PR TITLE
Remove main usage of codecvt_utf8_utf16

### DIFF
--- a/lib/utils/StringConversion.cpp
+++ b/lib/utils/StringConversion.cpp
@@ -7,7 +7,9 @@
 #include <codecvt>
 #include <locale>
 
+#ifdef _WIN32
 #include "windows.h"
+#endif  // _WIN32
 
 namespace MAT_NS_BEGIN
 {

--- a/lib/utils/StringConversion.cpp
+++ b/lib/utils/StringConversion.cpp
@@ -7,23 +7,37 @@
 #include <codecvt>
 #include <locale>
 
+#include "windows.h"
+
 namespace MAT_NS_BEGIN
 {
+
+// codecvt_utf8_utf16 has been deprecated in c++17, and it has behaved
+// inconsistently on different standard libraries, like libc++.
+// Since this is only used on Windows, we rely on windows.h.
+#ifdef _WIN32
     /** \brief Convert UTF-8 to UTF-16
     */
     std::wstring to_utf16_string(const std::string& in)
     {
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-        return converter.from_bytes(in);
+        int in_length = static_cast<int>(in.size());
+        int out_length = MultiByteToWideChar(CP_UTF8, 0, &in[0], in_length, NULL, 0);
+        std::wstring result(out_length, '\0');
+        MultiByteToWideChar(CP_UTF8, 0, &in[0], in_length, &result[0], out_length);
+        return result;
     }
 
     /** \brief Convert UTF-16 to UTF-8
     */
     std::string to_utf8_string(const std::wstring& in)
     {
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
-        return converter.to_bytes(in);
+        int in_length = static_cast<int>(in.size());
+        int out_length = WideCharToMultiByte(CP_UTF8, 0, &in[0], in_length, NULL, 0, NULL, NULL);
+        std::string result(out_length, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, &in[0], in_length, &result[0], out_length, NULL, NULL);
+        return result;
     }
+#endif  // _WIN32
 }
 MAT_NS_END
 

--- a/lib/utils/StringConversion.hpp
+++ b/lib/utils/StringConversion.hpp
@@ -10,9 +10,11 @@
 
 namespace MAT_NS_BEGIN {
 
+#ifdef _WIN32
 std::wstring to_utf16_string(const std::string& in);
 
 std::string to_utf8_string(const std::wstring& in);
+#endif  // _WIN32
 
 } MAT_NS_END
 

--- a/tests/unittests/StringUtilsTests.cpp
+++ b/tests/unittests/StringUtilsTests.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "common/Common.hpp"
+#include "utils/StringConversion.hpp"
 #include "utils/StringUtils.hpp"
 
 using namespace testing;
@@ -134,4 +135,26 @@ TEST(StringUtilsTests, ToString)
     EXPECT_THAT(toString(1234.5f), Eq("1234.500000"));
     EXPECT_THAT(toString(1234.567), Eq("1234.567000"));
     EXPECT_THAT(toString(1234.567891l), Eq("1234.567891"));
+}
+
+TEST(StringUtilsTests, Utf8Utf16Conversion)
+{
+    std::vector<std::string> test_strings = {
+        "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg",
+        "The quick brown fox jumps over the lazy dog",
+        "El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío,"
+        "añoraba a su querido cachorro.",
+        "Le cœur déçu mais l'âme plutôt naïve, Louÿs rêva de crapaüter en canoë"
+        "au delà des îles, près du mälström où brûlent les novæ.",
+        "Árvíztűrő tükörfúrógép",
+        "いろはにほへとちりぬるを",
+        "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム",
+        "В чащах юга жил бы цитрус? Да, но фальшивый экземпляр!",
+        "我能吞下玻璃而不伤身体。",
+        "!@#$%^&*()-=_+[]\\{}|;':\",./<>?",
+    };
+
+    for (std::string str : test_strings) {
+      EXPECT_EQ(str, to_utf8_string(to_utf16_string(str)));
+    }
 }

--- a/tests/unittests/StringUtilsTests.cpp
+++ b/tests/unittests/StringUtilsTests.cpp
@@ -137,6 +137,7 @@ TEST(StringUtilsTests, ToString)
     EXPECT_THAT(toString(1234.567891l), Eq("1234.567891"));
 }
 
+#ifdef _WIN32
 TEST(StringUtilsTests, Utf8Utf16Conversion)
 {
     std::vector<std::string> test_strings = {
@@ -158,3 +159,4 @@ TEST(StringUtilsTests, Utf8Utf16Conversion)
       EXPECT_EQ(str, to_utf8_string(to_utf16_string(str)));
     }
 }
+#endif  // _WIN32


### PR DESCRIPTION
codecvt_utf8_utf16 has been deprecated in c++17, and it has behaved inconsistently on different standard libraries, like libc++. Since these conversions are only used on Windows, this switches to the windows.h utility.

Related to #191 and #262 