### PR TITLE
Prepare for release 3.5.57

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.5.25.1"
-#define BUILD_VERSION 3,5,25,1
+#define BUILD_VERSION_STR "3.5.57.1"
+#define BUILD_VERSION 3,5,57,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include <stdint.h>
@@ -33,7 +33,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)5 << 32) |
-    ((uint64_t)25 << 16) |
+    ((uint64_t)57 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END

--- a/lib/include/public/Version.hpp.template
+++ b/lib/include/public/Version.hpp.template
@@ -10,8 +10,23 @@
 #define BUILD_VERSION @BUILD_VERSION_MAJOR@,@BUILD_VERSION_MINOR@,@BUILD_VERSION_PATCH@,@BUILD_NUMBER@
 
 #ifndef RESOURCE_COMPILER_INVOKED
-#include <ctmacros.hpp>
 #include <stdint.h>
+
+#ifdef HAVE_MAT_SHORT_NS
+#define MAT_NS_BEGIN  MAT
+#define MAT_NS_END
+#define PAL_NS_BEGIN  PAL
+#define PAL_NS_END
+#else
+#define MAT_NS_BEGIN  Microsoft { namespace Applications { namespace Events
+#define MAT_NS_END    }}
+#define MAT           ::Microsoft::Applications::Events
+#define PAL_NS_BEGIN  Microsoft { namespace Applications { namespace Events { namespace PlatformAbstraction
+#define PAL_NS_END    }}}
+#define PAL           ::Microsoft::Applications::Events::PlatformAbstraction
+#endif
+
+#define MAT_v1        ::Microsoft::Applications::Telemetry
 
 namespace MAT_NS_BEGIN {
 
@@ -27,3 +42,4 @@ namespace PAL_NS_BEGIN { } PAL_NS_END
 
 #endif // RESOURCE_COMPILER_INVOKED
 #endif
+


### PR DESCRIPTION
Two changes:
- `Version.hpp` has been refactored recently, but the `Version.hpp.template` file that re-generates the `Version.hpp` has not been adjusted accordingly. I'm fixing it now.
- updated `Version.hpp` with today's build date to create a release tag off that
