### PR TITLE
Expose file cache size limit and db drop property in C# projection

### DIFF
--- a/lib/shared/LogConfigurationCX.cpp
+++ b/lib/shared/LogConfigurationCX.cpp
@@ -17,13 +17,15 @@ namespace MATW_NS_BEGIN {
     {
         MAT::ILogConfiguration& configurationCore = MAT::LogManager::GetLogConfiguration();
         configurationCore[MAT::CFG_INT_SDK_MODE] = (int)this->SdkMode;
-        configurationCore[MAT::CFG_STR_CACHE_FILE_PATH]    = FromPlatformString(this->OfflineStorage);
-        configurationCore[MAT::CFG_STR_COLLECTOR_URL]      = FromPlatformString(this->CollectorURL);
-        configurationCore[MAT::CFG_INT_TRACE_LEVEL_MASK]   = this->TraceLevelMask;
-        configurationCore[MAT::CFG_INT_TRACE_LEVEL_MIN]    = (int)(this->MinTraceLevel);
-        configurationCore[MAT::CFG_INT_MAX_TEARDOWN_TIME]  = this->MaxTeardownUploadTimeInSec;
-        configurationCore[MAT::CFG_INT_MAX_PENDING_REQ]    = this->MaxPendingHTTPRequests;
-        configurationCore[MAT::CFG_INT_RAM_QUEUE_BUFFERS]  = this->MaxDBFlushQueues;
+        configurationCore[MAT::CFG_STR_CACHE_FILE_PATH]         = FromPlatformString(this->OfflineStorage);
+        configurationCore[MAT::CFG_INT_CACHE_FILE_SIZE]         = this->CacheFileSizeLimitInBytes;
+        configurationCore[MAT::CFG_BOOL_ENABLE_DB_DROP_IF_FULL] = this->EnableDBDropIfFull;
+        configurationCore[MAT::CFG_STR_COLLECTOR_URL]           = FromPlatformString(this->CollectorURL);
+        configurationCore[MAT::CFG_INT_TRACE_LEVEL_MASK]        = this->TraceLevelMask;
+        configurationCore[MAT::CFG_INT_TRACE_LEVEL_MIN]         = (int)(this->MinTraceLevel);
+        configurationCore[MAT::CFG_INT_MAX_TEARDOWN_TIME]       = this->MaxTeardownUploadTimeInSec;
+        configurationCore[MAT::CFG_INT_MAX_PENDING_REQ]         = this->MaxPendingHTTPRequests;
+        configurationCore[MAT::CFG_INT_RAM_QUEUE_BUFFERS]       = this->MaxDBFlushQueues;
 
         // Populate these two fields at C++ core only if not empty at C# projection
         if (!this->StartProfileName->Equals(""))

--- a/lib/shared/LogConfigurationCX.hpp
+++ b/lib/shared/LogConfigurationCX.hpp
@@ -70,6 +70,8 @@ namespace Microsoft {
                         CollectorURL = CollectorUrlDefault;
                         StartProfileName = "";
                         TransmitProfiles = "";
+                        CacheFileSizeLimitInBytes = 3 * 1024 * 1024;
+                        EnableDBDropIfFull = false;
                     }
 
                     property String^ CollectorURL;
@@ -77,6 +79,8 @@ namespace Microsoft {
                     property bool AutoLogAppResume;
                     property bool AutoLogUnhandledException;
                     property String^ OfflineStorage;
+                    property unsigned int CacheFileSizeLimitInBytes;
+                    property bool EnableDBDropIfFull;
                     property SdkModeTypes SdkMode;
                     property unsigned int TraceLevelMask;
                     property ACTTraceLevel MinTraceLevel;


### PR DESCRIPTION
**Issue:** Cache file size limit is not customizable in the C# projection
**Fix:** Expose public properties that would let users customize the cache file size limit. Also expose a bool that would allow users to enable flush the cache file once limit is reached.