### PR TITLE
Re-remove the namespace macros from Version.hpp.template

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,34 +6,19 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.5.57.1"
-#define BUILD_VERSION 3,5,57,1
+#define BUILD_VERSION_STR "3.5.60.1"
+#define BUILD_VERSION 3,5,60,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
+#include <ctmacros.hpp>
 #include <stdint.h>
-
-#ifdef HAVE_MAT_SHORT_NS
-#define MAT_NS_BEGIN  MAT
-#define MAT_NS_END
-#define PAL_NS_BEGIN  PAL
-#define PAL_NS_END
-#else
-#define MAT_NS_BEGIN  Microsoft { namespace Applications { namespace Events
-#define MAT_NS_END    }}
-#define MAT           ::Microsoft::Applications::Events
-#define PAL_NS_BEGIN  Microsoft { namespace Applications { namespace Events { namespace PlatformAbstraction
-#define PAL_NS_END    }}}
-#define PAL           ::Microsoft::Applications::Events::PlatformAbstraction
-#endif
-
-#define MAT_v1        ::Microsoft::Applications::Telemetry
 
 namespace MAT_NS_BEGIN {
 
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)5 << 32) |
-    ((uint64_t)57 << 16) |
+    ((uint64_t)60 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END
@@ -42,4 +27,5 @@ namespace PAL_NS_BEGIN { } PAL_NS_END
 
 #endif // RESOURCE_COMPILER_INVOKED
 #endif
+
 

--- a/lib/include/public/Version.hpp.template
+++ b/lib/include/public/Version.hpp.template
@@ -10,23 +10,8 @@
 #define BUILD_VERSION @BUILD_VERSION_MAJOR@,@BUILD_VERSION_MINOR@,@BUILD_VERSION_PATCH@,@BUILD_NUMBER@
 
 #ifndef RESOURCE_COMPILER_INVOKED
+#include <ctmacros.hpp>
 #include <stdint.h>
-
-#ifdef HAVE_MAT_SHORT_NS
-#define MAT_NS_BEGIN  MAT
-#define MAT_NS_END
-#define PAL_NS_BEGIN  PAL
-#define PAL_NS_END
-#else
-#define MAT_NS_BEGIN  Microsoft { namespace Applications { namespace Events
-#define MAT_NS_END    }}
-#define MAT           ::Microsoft::Applications::Events
-#define PAL_NS_BEGIN  Microsoft { namespace Applications { namespace Events { namespace PlatformAbstraction
-#define PAL_NS_END    }}}
-#define PAL           ::Microsoft::Applications::Events::PlatformAbstraction
-#endif
-
-#define MAT_v1        ::Microsoft::Applications::Telemetry
 
 namespace MAT_NS_BEGIN {
 
@@ -42,4 +27,3 @@ namespace PAL_NS_BEGIN { } PAL_NS_END
 
 #endif // RESOURCE_COMPILER_INVOKED
 #endif
-


### PR DESCRIPTION
Also update the generated file, since in my previous PR I presumed that was done automatically overnight. Mistake on my end, yuck.