### PR TITLE
Fix Clang -Wformat warning on 64 bit Droid

### DIFF
--- a/tests/functests/EventDecoderListener.cpp
+++ b/tests/functests/EventDecoderListener.cpp
@@ -65,7 +65,7 @@ void EventDecoderListener::OnDebugEvent(DebugEvent &evt)
 {
     auto PrintEvent = [](const char *lbl, const DebugEvent &e)
     {
-        printf("%20s: seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", lbl, e.seq, e.ts, e.type, e.param1, e.param2);
+        printf("%20s: seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", lbl, static_cast<unsigned long long>(e.seq), static_cast<unsigned long long>(e.ts), e.type, e.param1, e.param2);
     };
 
     // lock for the duration of the print, so that we don't mess up the prints


### PR DESCRIPTION
Full warning-as-error text:
```
d:\office\dev\telemetry\ariasdk\next\tests\functests\EventDecoderListener.cpp(64,79) : error: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Werror,-Wformat]
        printf("%20s: seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", lbl, e.seq, e.ts, e.type, e.param1, e.param2);
                          ~~~~                                                ^~~~~
                          %lu
d:\office\dev\telemetry\ariasdk\next\tests\functests\EventDecoderListener.cpp(64,86) : error: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Werror,-Wformat]
        printf("%20s: seq=%llu, ts=%llu, type=0x%08x, p1=%zu, p2=%zu\n", lbl, e.seq, e.ts, e.type, e.param1, e.param2);
                                   ~~~~                                              ^~~~
                                   %lu
2 errors generated.
```
`static_cast` the uint64_t to unsigned long long. This warning doesn't when building for 32bit architectures, so the cast seems to make the most sense.