### PR TITLE
Capturing ConnectivityManager exceptions in Android

### DIFF
--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/HttpClient.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/HttpClient.java
@@ -220,12 +220,20 @@ public class HttpClient {
                 m_connectivityManager.registerDefaultNetworkCallback(m_callback);
               }
             }
-            catch (Exception e) {
+            catch (SecurityException e) {
               // Fetching CONNECTIVITY_SERVICE can throw a SecurityException, especially in Android Work Profile cases
               // "package does not belong to xxxx"
-              // can also throw runtimeException: 
+              Log.e("MAE", "SecurityException in HttpClient initialization", e);
+            }
+            catch (RuntimeException e) {
+              // can throw runtimeException: 
               // https://developer.android.com/reference/android/net/ConnectivityManager#registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback)
-              // in either case, we don't have access to ConnectivityInfo, so can't truly populate callback/isMetered, or react to network changes
+              Log.e("MAE", "RuntimeException in HttpClient initialization", e);
+            }
+            catch (Exception e) {
+              // If we don't have access to ConnectivityInfo, we can't truly populate callback/isMetered, or react to network changes
+              // However, we can still continue with initialization
+              Log.e("MAE", "Exception in HttpClient initialization", e);
             }
       }
     }

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/HttpClient.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/HttpClient.java
@@ -223,17 +223,14 @@ public class HttpClient {
             catch (SecurityException e) {
               // Fetching CONNECTIVITY_SERVICE can throw a SecurityException, especially in Android Work Profile cases
               // "package does not belong to xxxx"
-              Log.e("MAE", "SecurityException in HttpClient initialization", e);
             }
             catch (RuntimeException e) {
               // can throw runtimeException: 
               // https://developer.android.com/reference/android/net/ConnectivityManager#registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback)
-              Log.e("MAE", "RuntimeException in HttpClient initialization", e);
             }
             catch (Exception e) {
               // If we don't have access to ConnectivityInfo, we can't truly populate callback/isMetered, or react to network changes
               // However, we can still continue with initialization
-              Log.e("MAE", "Exception in HttpClient initialization", e);
             }
       }
     }


### PR DESCRIPTION
Calls into ConnectivityManager can sometimes throw exceptions, which causes crashes on HttpClient initialization. According to some posts online, some of these exceptions, such as a SecurityException due to package permissions (might also be relevant to Android Work Profile management), and RuntimeExceptions when too many callbacks are registered, are currently not handled in the Logger code. 

Capturing these calls in a try/catch loop ensures that we can still continue with the proper logger initialization, even if we don't have full insights into the changes in the network state of the device.

Similar issue is reported here: https://github.com/DataDog/dd-sdk-android/issues/413