### PR TITLE
Move setting initialized to inner function

### DIFF
--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -106,7 +106,6 @@ static BOOL _initialized = false;
 +(nullable ODWLogger *)initForTenant:(nonnull NSString *)tenantToken withConfig:(nullable NSDictionary *)config
 {
     ILogger *logger = [ODWLogManager initializeLogManager:tenantToken withConfig:config];
-    _initialized = logger != NULL;
 
     if (!logger) return nil;
 
@@ -194,6 +193,8 @@ static BOOL _initialized = false;
         }
         [ODWLogger traceException: e.what()];
     }
+
+    _initialized = logger != NULL;
     return logger;
 }
 


### PR DESCRIPTION
Right now we only set the initialized property when the `init` function is called. This property should be set in the inner function which is called from other functions as well.