### PR TITLE
Build Privacy Guard for GCC

### DIFF
--- a/lib/include/mat/config-default.h
+++ b/lib/include/mat/config-default.h
@@ -23,10 +23,7 @@
 #define HAVE_MAT_LOGGING
 #define HAVE_MAT_STORAGE
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
-#ifndef __GNUC__
-// PrivacyGuard is not presently compatible with gcc
 #define HAVE_MAT_PRIVACYGUARD
-#endif
 //#define HAVE_MAT_DEFAULT_FILTER
 #if defined(_WIN32) && !defined(_WINRT_DLL)
 #define HAVE_MAT_NETDETECT


### PR DESCRIPTION
We fixed PrivacyGuard build issues with gcc a while back, but the config wasn't updated then. Fixing it now.