### PR TITLE
Fix CodeQL warnings

### DIFF
--- a/lib/config/RuntimeConfig_Default.hpp
+++ b/lib/config/RuntimeConfig_Default.hpp
@@ -118,7 +118,7 @@ namespace MAT_NS_BEGIN
         virtual std::string GetMetaStatsTenantToken() override
         {
             const char *defaultToken = STATS_TOKEN_PROD;
-            if (config.count(CFG_MAP_METASTATS_CONFIG))
+            if (config.HasConfig(CFG_MAP_METASTATS_CONFIG))
             {
                 const char* token = config[CFG_MAP_METASTATS_CONFIG]["tokenProd"];
                 if (token != nullptr)

--- a/lib/config/RuntimeConfig_Default.hpp
+++ b/lib/config/RuntimeConfig_Default.hpp
@@ -94,6 +94,10 @@ namespace MAT_NS_BEGIN
         virtual std::string GetCollectorUrl() override
         {
             const char* url = config[CFG_STR_COLLECTOR_URL];
+            if (url == nullptr)
+            {
+                return std::string(COLLECTOR_URL_PROD);
+            }
             return std::string(url);
         }
 
@@ -113,8 +117,14 @@ namespace MAT_NS_BEGIN
 
         virtual std::string GetMetaStatsTenantToken() override
         {
-            const char* token = config[CFG_MAP_METASTATS_CONFIG]["tokenProd"];
-            return std::string(token);
+            const char *defaultToken = STATS_TOKEN_PROD;
+            if (config.count(CFG_MAP_METASTATS_CONFIG))
+            {
+                const char* token = config[CFG_MAP_METASTATS_CONFIG]["tokenProd"];
+                if (token != nullptr)
+                    return std::string(token);
+            }
+            return std::string(defaultToken);
         };
 
         virtual unsigned GetMetaStatsSendIntervalSec() override

--- a/lib/offline/SQLiteWrapper.hpp
+++ b/lib/offline/SQLiteWrapper.hpp
@@ -331,7 +331,6 @@ namespace MAT_NS_BEGIN {
                 {
                     m_statements.erase(it);
                     g_sqlite3Proxy->sqlite3_finalize(stmt);
-                    LOG_INFO("--- [%p]");
                 }
             }
         }


### PR DESCRIPTION
Original customer issue reported by email.

There are three CodeQL 'errors' observed with **certain custom ruleset**. None of these issues get reported by our default ruleset on GitHub CodeQL run. And none of them, in essence, are security issues - since on all codepaths the issues described here are "impossible to happen". But I'm fixing these nevertheless to eliminate the 'noise' in the customer's build pipeline.

CodeQL issues are:

| Severity	| Code	| Description	| Project	| File	| Line	| Suppression | State	| Priority |
|---------|---------|---------------|---------|----|---------|--------------|----------|--------|
| Error	| SM02311	|  In GetCollectorUrl result of `[call](1)` to `[operator const char *](2)` is dereferenced here and may be null.	| 	| cpp_client_telemetry/lib/config/RuntimeConfig_Default.hpp	| 97	| Active	| Normal | 
| Error	| SM02311	|  In GetMetaStatsTenantToken result of `[call](1)` to `[operator const char *](2)` is dereferenced here and may be null. | 		|  cpp_client_telemetry/lib/config/RuntimeConfig_Default.hpp | 	117	|  Active	| Normal | 
| Error	| SM01733	|  Format expects 1 arguments but given 0 | 		|  cpp_client_telemetry/lib/offline/SQLiteWrapper.hpp | 334	|  Active	|  Normal | 
	

