### PR TITLE
Annotate JNI-accessed class and fields

### DIFF
--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/DebugEvent.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/DebugEvent.java
@@ -1,5 +1,8 @@
 package com.microsoft.applications.events;
 
+import androidx.annotation.Keep;
+
+@Keep
 public class DebugEvent {
   /// <summary>The debug event sequence number.</summary>
   public long seq = 0;

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
@@ -4,6 +4,7 @@
 //
 package com.microsoft.applications.events;
 
+import androidx.annotation.Keep;
 import java.util.Date;
 import java.util.UUID;
 
@@ -15,6 +16,7 @@ public class LogManagerProvider {
   protected static native long nativeCreateLogManager(ILogConfiguration config);
 
   static class LogManagerImpl implements ILogManager {
+    @Keep
     long nativeLogManager = 0;
 
     private LogManagerImpl() {}
@@ -214,7 +216,9 @@ public class LogManagerProvider {
     }
 
     protected static class LogSessionDataImpl implements LogSessionData {
+      @Keep
       private long m_first_time;
+      @Keep
       private String m_uuid;
 
       public LogSessionDataImpl() {


### PR DESCRIPTION
Some applications are seeing a Java exception that the field `long nativeLogManager` is not present in the java class LogManagerImpl. Possibly R8 has minified the field out of existence; at any rate, the @Keep annotation should not hurt and might help.