### PR TITLE
Fix ODWLogConfiguration.set function

### DIFF
--- a/tests/unittests/obj-c/ODWLogConfigurationTests.mm
+++ b/tests/unittests/obj-c/ODWLogConfigurationTests.mm
@@ -51,7 +51,7 @@ using namespace Microsoft::Applications::Events;
     ODWLogConfiguration *config = [ODWLogConfiguration getLogConfigurationCopy];
     XCTAssertNotNil(config);
     [config set:ODWCFG_STR_COLLECTOR_URL withValue:@"testUrl"];
-    XCTAssertEqual([config valueForKey:ODWCFG_STR_COLLECTOR_URL], @"testUrl");
+    XCTAssertEqualObjects([config valueForKey:ODWCFG_STR_COLLECTOR_URL], @"testUrl");
 }
 
 @end

--- a/tests/unittests/obj-c/ODWLogConfigurationTests.mm
+++ b/tests/unittests/obj-c/ODWLogConfigurationTests.mm
@@ -47,4 +47,11 @@ using namespace Microsoft::Applications::Events;
     XCTAssertEqual([ODWLogConfiguration surfaceCppExceptions], false);
 }
 
+- (void)testSetWithValue {
+    ODWLogConfiguration *config = [ODWLogConfiguration getLogConfigurationCopy];
+    XCTAssertNotNil(config);
+    [config set:ODWCFG_STR_COLLECTOR_URL withValue:@"testUrl"];
+    XCTAssertEqual([config valueForKey:ODWCFG_STR_COLLECTOR_URL], @"testUrl");
+}
+
 @end

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -393,6 +393,11 @@ extern NSString * _Nonnull const ODWCFG_BOOL_SESSION_RESET_ENABLED;
 */
 -(void)set:(nonnull NSString *)key withValue:(nonnull NSString *)value;
 
+/*!
+@brief Returns the value for the given key.
+*/
+-(nullable NSString *)valueForKey:(nonnull NSString *)key;
+
 @end
 
 #include "objc_end.h"

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -428,8 +428,17 @@ NSString *const ODWCFG_BOOL_SESSION_RESET_ENABLED = @"sessionResetEnabled";
 
 -(void)set:(nonnull NSString *)key withValue:(nonnull NSString *)value
 {
-    ILogConfiguration wrappedConfig = *_wrappedConfiguration;
-    wrappedConfig[[key UTF8String]] = [value UTF8String];
+    (*_wrappedConfiguration)[[key UTF8String]] = [value UTF8String];
+}
+
+-(nullable NSString *)valueForKey:(nonnull NSString *)key
+{
+    std::string strValue = (*_wrappedConfiguration)[[key UTF8String]];
+    if (strValue.empty())
+    {
+         return nil;
+    }
+    return [NSString stringWithCString:strValue.c_str() encoding:NSUTF8StringEncoding];
 }
 
 @end


### PR DESCRIPTION
The `ODWLogConfiguration.set` function is not behaving as expected. Update the function and add a unit test