### PR TITLE
[Android] Added optional native android build

### DIFF
--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -14,10 +14,12 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
-        externalNativeBuild {
-            cmake {
-                // Passes optional arguments to CMake.
-                arguments "-DANDROID_STL=c++_shared", "-DBUILD_SHARED_LIBS=1", "-DUSE_ROOM=1", "-DCMAKE_SHARED_LINKER_FLAGS=${project.findProperty("CMAKE_SHARED_LINKER_FLAGS") ?: ''}"
+        if(!ext.has("build_cpp_client") || ext.build_cpp_client) {
+            externalNativeBuild {
+                cmake {
+                    // Passes optional arguments to CMake.
+                    arguments "-DANDROID_STL=c++_shared", "-DBUILD_SHARED_LIBS=1", "-DUSE_ROOM=1", "-DCMAKE_SHARED_LINKER_FLAGS=${project.findProperty("CMAKE_SHARED_LINKER_FLAGS") ?: ''}"
+                }
             }
         }
         javaCompileOptions {
@@ -41,11 +43,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-
-    externalNativeBuild {
-        cmake {
-            path "src/main/cpp/CMakeLists.txt"
-            version "3.10.2"
+    if(!ext.has("build_cpp_client") || ext.build_cpp_client) {
+        externalNativeBuild {
+            cmake {
+                path "src/main/cpp/CMakeLists.txt"
+                version "3.10.2"
+            }
         }
     }
     compileOptions {

--- a/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
+++ b/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 11)
 option(BUILD_AZMON        "Build for Azure Monitor" YES)
 option(BUILD_PRIVACYGUARD "Build Privacy Guard"     YES)
 
-string(REPLACE "/lib/android_build/maesdk/src/main/cpp" "" SDK_ROOT ${CMAKE_SOURCE_DIR})
+string(REPLACE "/lib/android_build/maesdk/src/main/cpp" "" SDK_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (USE_CURL)
         add_definitions(-DHAVE_MAT_CURL_HTTP_CLIENT)

--- a/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
+++ b/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
@@ -17,14 +17,7 @@ if (USE_CURL)
         find_package(CURL REQUIRED)
 endif()
 
-include_directories(AFTER
-        ${SDK_ROOT}/lib
-        ${SDK_ROOT}/lib/include/public
-        ${SDK_ROOT}/lib/include
-        ${SDK_ROOT}/lib/include/mat
-        ${SDK_ROOT}/sqlite
-        ${SDK_ROOT}lib/pal
-        ${CURL_INCLUDE_DIRS})
+set(TARGETNAME maesdk)
 
 set(SRCS
         ${SDK_ROOT}/lib/api/AllowedLevelsCollection.cpp
@@ -123,7 +116,16 @@ else()
         list(APPEND SRCS ${SDK_ROOT}/lib/http/HttpClient_Android.cpp)
 endif()
 
-add_library(maesdk ${SRCS})
+add_library(${TARGETNAME} ${SRCS})
+
+target_include_directories(${TARGETNAME} PUBLIC
+        ${SDK_ROOT}/lib
+        ${SDK_ROOT}/lib/include/public
+        ${SDK_ROOT}/lib/include
+        ${SDK_ROOT}/lib/include/mat
+        ${SDK_ROOT}/sqlite
+        ${SDK_ROOT}lib/pal
+        ${CURL_INCLUDE_DIRS})
 
 
 # Creates and names a library, sets it as either STATIC


### PR DESCRIPTION
This PR is targeted on adding support of below features
- Currently including maesdk AAR into any project builds native c++ code as part of it. However this restricts building native code separately. So added a provision to build the native code optionally through _build_cpp_client_ variable. The default behaviour is to build the native code as part of AAR.
- Replaced CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR as CMAKE_SOURCE_DIR will change if not built through AAR
- Currently, include directories are not scoped to any target, this behaviour makes consumers of maesdk library to add maesdk include directories in the consumer target. [while using the LogManager, EventProperties headers]. So scoped the include directories to maesdk library