### PR TITLE
Error checking for introspection failures

### DIFF
--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
@@ -29,7 +29,11 @@ public class LogManagerProvider {
 
     @Override
     public ILogger getLogger(String token, String source, String scope) {
-      return new Logger(nativeGetLogger(token, source, scope));
+      long nativeLogger = nativeGetLogger(token, source, scope);
+      if (nativeLogger == 0) {
+        throw new NullPointerException("Null native logger pointer");
+      }
+      return new Logger(nativeLogger);
     }
 
     @Override

--- a/lib/jni/LogManager_jni.cpp
+++ b/lib/jni/LogManager_jni.cpp
@@ -869,10 +869,28 @@ Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_na
     jstring jSource,
     jstring jScope)
 {
+    if (!thiz) {
+        return 0;
+    }
     auto LogManagerProviderClassID = env->GetObjectClass(thiz);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        return 0;
+    }
+    if (!LogManagerProviderClassID) {
+        return 0;
+    }
     auto nativeLogManagerID =
         env->GetFieldID(LogManagerProviderClassID, "nativeLogManager", "J");
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        return 0;
+    }
     auto nativeLogManagerIndex = env->GetLongField(thiz, nativeLogManagerID);
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        return 0;
+    }
     ManagerAndConfig* mc;
     {
         std::lock_guard<std::mutex> lock(jniManagersMutex);


### PR DESCRIPTION
Add error checking in the getLogger method. Some applications are
seeing Java exceptions (no such field) from the nativeGetLogger method.