### PR TITLE
Add PauseManager to API

### DIFF
--- a/Solutions/Clienttelemetry/Clienttelemetry.vcxitems
+++ b/Solutions/Clienttelemetry/Clienttelemetry.vcxitems
@@ -28,6 +28,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\api\LogManagerImpl.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\api\DataViewerCollection.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\api\LogManagerProvider.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\api\PauseManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\api\LogSessionData.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\backoff\IBackoff.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\bond\BondSerializer.cpp" />

--- a/Solutions/Clienttelemetry/Clienttelemetry.vcxitems.filters
+++ b/Solutions/Clienttelemetry/Clienttelemetry.vcxitems.filters
@@ -52,6 +52,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\utils\StringUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\utils\ZlibUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\utils\Utils.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\api\PauseManager.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\decoder\PayloadDecoder.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\api\AllowedLevelsCollection.hpp" />
@@ -150,11 +152,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\KillSwitchManager.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\LogSessionDataProvider.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\MemoryStorage.hpp" />
-    
-    
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\offline\OfflineStorageFactory.cpp" />
-    
-    
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\OfflineStorageHandler.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\OfflineStorage_SQLite.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\lib\offline\SQLiteWrapper.hpp" />

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRCS decorators/BaseDecorator.cpp
   api/LogSessionData.cpp
   api/Logger.cpp
   api/LogManagerProvider.cpp
+  api/PauseManager.cpp
   api/CorrelationVector.cpp
   api/LogConfiguration.cpp
   api/AuthTokensController.cpp
@@ -218,7 +219,7 @@ endif()
 
 if(BUILD_SHARED_LIBS STREQUAL "ON")
   message("-- Building shared SDK library")
-  
+
   # include(FindCURL)
   # find_package(CURL REQUIRED)
   # set(CMAKE_REQUIRED_LIBRARIES "${CURL_LIBRARIES}")
@@ -273,4 +274,3 @@ message("-- Library will be installed to ${INSTALL_LIB_DIR}")
 #  #target_link_libraries(mat PUBLIC libcurl.a libz.a libssl.a libcrypto.a "${SQLITE_LIBRARY}" "${CMAKE_THREAD_LIBS_INIT}" "${CMAKE_DL_LIBS}" )
 #  #target_link_libraries(mat PUBLIC libsqlite3.a libz.a ${LIBS} "${CMAKE_THREAD_LIBS_INIT}" "${CMAKE_DL_LIBS}" )
 #endif()
-

--- a/lib/android_build/app/src/main/cpp/CMakeLists.txt
+++ b/lib/android_build/app/src/main/cpp/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TESTS_SRCS
         ${SDK_ROOT}/tests/unittests/OfflineStorageTests_Room.cpp
         ${SDK_ROOT}/tests/unittests/PackagerTests.cpp
         ${SDK_ROOT}/tests/unittests/PalTests.cpp
+        ${SDK_ROOT}/tests/unittests/PauseManagerTests.cpp
         ${SDK_ROOT}/tests/unittests/RouteTests.cpp
         ${SDK_ROOT}/tests/unittests/StringUtilsTests.cpp
         ${SDK_ROOT}/tests/unittests/TaskDispatcherCAPITests.cpp

--- a/lib/android_build/build.gradle
+++ b/lib/android_build/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lib/android_build/gradle/wrapper/gradle-wrapper.properties
+++ b/lib/android_build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 05 11:46:20 PDT 2020
+#Mon Apr 05 16:09:19 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
+++ b/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
         ${SDK_ROOT}/lib/api/LogManagerProvider.cpp
         ${SDK_ROOT}/lib/api/LogSessionData.cpp
         ${SDK_ROOT}/lib/api/Logger.cpp
+        ${SDK_ROOT}/lib/api/PauseManager.cpp
         ${SDK_ROOT}/lib/api/capi.cpp
         ${SDK_ROOT}/lib/backoff/IBackoff.cpp
         ${SDK_ROOT}/lib/bond/BondSerializer.cpp

--- a/lib/api/Logger.cpp
+++ b/lib/api/Logger.cpp
@@ -236,7 +236,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
-
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return;
+        }
         LOG_TRACE("%p: LogAppLifecycle(state=%u, properties.name=\"%s\", ...)",
                   this, state, properties.GetName().empty() ? "<unnamed>" : properties.GetName().c_str());
 
@@ -351,7 +354,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
-
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return;
+        }
         LOG_TRACE("%p: LogFailure(signature=\"%s\", properties.name=\"%s\", ...)",
                   this, signature.c_str(), properties.GetName().empty() ? "<unnamed>" : properties.GetName().c_str());
 
@@ -400,6 +406,10 @@ namespace MAT_NS_BEGIN
         ActiveLoggerCall active(*this);
         if (active.LoggerIsDead())
         {
+            return;
+        }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
             return;
         }
 
@@ -456,6 +466,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return;
+        }
 
         LOG_TRACE("%p: LogPageAction(pageActionData.actionType=%u, properties.name=\"%s\", ...)",
                   this, pageActionData.actionType, properties.GetName().empty() ? "<unnamed>" : properties.GetName().c_str());
@@ -497,6 +511,10 @@ namespace MAT_NS_BEGIN
         {
             return false;
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return false;
+        }
 
         record.name = properties.GetName();
         record.baseType = EVENTRECORD_TYPE_CUSTOM_EVENT;
@@ -526,6 +544,10 @@ namespace MAT_NS_BEGIN
         ActiveLoggerCall active(*this);
         if (active.LoggerIsDead())
         {
+            return;
+        }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
             return;
         }
 
@@ -588,6 +610,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return;
+        }
 
         LOG_INFO("This method is executed from worker thread");
     }
@@ -604,6 +630,10 @@ namespace MAT_NS_BEGIN
         ActiveLoggerCall active(*this);
         if (active.LoggerIsDead())
         {
+            return;
+        }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
             return;
         }
 
@@ -662,6 +692,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return;
+        }
 
         LOG_TRACE("%p: LogAggregatedMetric(name=\"%s\", properties.name=\"%s\", ...)",
                   this, metricData.name.c_str(), properties.GetName().empty() ? "<unnamed>" : properties.GetName().c_str());
@@ -700,6 +734,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return;
+        }
 
         LOG_TRACE("%p: LogTrace(level=%u, properties.name=\"%s\", ...)",
                   this, level, properties.GetName().empty() ? "<unnamed>" : properties.GetName().c_str());
@@ -736,6 +774,10 @@ namespace MAT_NS_BEGIN
         ActiveLoggerCall active(*this);
         if (active.LoggerIsDead())
         {
+            return;
+        }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
             return;
         }
 
@@ -777,6 +819,10 @@ namespace MAT_NS_BEGIN
         ActiveLoggerCall active(*this);
         if (active.LoggerIsDead())
         {
+            return;
+        }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
             return;
         }
 
@@ -885,6 +931,10 @@ namespace MAT_NS_BEGIN
         {
             return nullManager;
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return nullManager;
+        }
 
         return m_logManager;
     }
@@ -896,6 +946,10 @@ namespace MAT_NS_BEGIN
         {
             return nullManager.GetLogSessionData();
         }
+        PauseManager::Lock lock;
+        if (lock.isPaused()) {
+            return nullManager.GetLogSessionData();
+        }
 
         return m_logManager.GetLogSessionData();
     }
@@ -903,8 +957,8 @@ namespace MAT_NS_BEGIN
     IAuthTokensController* Logger::GetAuthTokensController()
     {
         ActiveLoggerCall active(*this);
-        if (active.LoggerIsDead())
-        {
+        PauseManager::Lock lock;
+        if (active.LoggerIsDead() || lock.isPaused()) {
             return nullManager.GetAuthTokensController();
         }
 
@@ -914,7 +968,8 @@ namespace MAT_NS_BEGIN
     bool Logger::DispatchEvent(DebugEvent evt)
     {
         ActiveLoggerCall active(*this);
-        if (active.LoggerIsDead())
+        PauseManager::Lock lock;
+        if (active.LoggerIsDead() || lock.isPaused())
         {
             return nullManager.DispatchEvent(std::move(evt));
         }
@@ -935,7 +990,8 @@ namespace MAT_NS_BEGIN
     bool Logger::CanEventPropertiesBeSent(EventProperties const& properties) const noexcept
     {
         ActiveLoggerCall active(*this);
-        if (active.LoggerIsDead())
+        PauseManager::Lock lock;
+        if (active.LoggerIsDead() || lock.isPaused())
         {
             return false;
         }

--- a/lib/api/Logger.cpp
+++ b/lib/api/Logger.cpp
@@ -7,6 +7,7 @@
 #include "CommonFields.h"
 #include "LogSessionData.hpp"
 #include "NullObjects.hpp"
+#include "PauseManager.hpp"
 #include "utils/Utils.hpp"
 
 #include <algorithm>
@@ -273,6 +274,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
+        PauseManager::Lock pauseLock;
+        if (pauseLock.isPaused()) {
+            return;
+        }
 
         EventProperties event(name);
         LogEvent(event);
@@ -289,7 +294,10 @@ namespace MAT_NS_BEGIN
         {
             return;
         }
-
+        PauseManager::Lock pauseLock;
+        if (pauseLock.isPaused()) {
+            return;
+        }
         // SendAsJSON(properties, m_tenantToken);
 
         LOG_TRACE("%p: LogEvent(properties.name=\"%s\", ...)",
@@ -828,7 +836,7 @@ namespace MAT_NS_BEGIN
             }
             sessionDuration = PAL::getUtcSystemTime() - m_sessionStartTime;
 
-            if (m_resetSessionOnEnd) 
+            if (m_resetSessionOnEnd)
             {
                 // reset the time of the session to 0 and get a new sessionId
                 m_sessionStartTime = 0;
@@ -891,7 +899,7 @@ namespace MAT_NS_BEGIN
 
         return m_logManager.GetLogSessionData();
     }
-    
+
     IAuthTokensController* Logger::GetAuthTokensController()
     {
         ActiveLoggerCall active(*this);

--- a/lib/api/PauseManager.cpp
+++ b/lib/api/PauseManager.cpp
@@ -6,41 +6,60 @@ namespace MAT_NS_BEGIN
     std::atomic<uint64_t> PauseManager::s_pause_manager_state(0);
     std::condition_variable PauseManager::s_pause_manager_cv;
 
+    // Move from active to pausing/paused state: prevent new activities from starting.
     void PauseManager::PauseActivity() noexcept
     {
         auto state = s_pause_manager_state.load();
+        // if we are running (state & 1 is zero), set the pausing/paused bit
         while ((state & 1) == 0 && !s_pause_manager_state.compare_exchange_weak(state, state + 1));
 
+        // if we set the pausing/paused bit and we have no outstanding activity (state < 2),
+        // wake up listeners.
         if (state < 2) {
             s_pause_manager_cv.notify_all();
         }
     }
 
+    // Move from pausing/paused to active: new activities may start
     void PauseManager::ResumeActivity() noexcept
     {
         auto state = s_pause_manager_state.load();
+        // if we are pausing/paused (state & 1), clear the pausing/paused bit in state.
         while ((state & 1) && !s_pause_manager_state.compare_exchange_weak(state, state - 1));
+        // notify any listeners: we are active, so any thread waiting for quiesce should
+        // wake up.
         s_pause_manager_cv.notify_all();
     }
 
+    // Wait indefinitely for either the paused (no remaining activity) or running state.
+    // If another thead might call ResumeActivity(), the calling thread can wake up
+    // on the transition back to the running state, and may need to coordinate
+    // with that ResumeActivity().
     void PauseManager::QuiesceWait() noexcept
     {
         std::unique_lock<std::mutex> lock(s_pause_manager_mutex);
-        s_pause_manager_cv.wait(lock, [] () {
+        s_pause_manager_cv.wait(lock, [] () -> bool {
             auto state = s_pause_manager_state.load();
+            // we wait until either we quiesce (state < 2) or
+            // we are active (!state & 1).
             return state < 2 || !(state & 1);
         });
     }
 
+    // Wait for quiesce, but return unconditionally after the supplied
+    // timeout duration if quiesce does not happen earlier.
     void PauseManager::QuiesceWaitFor(std::chrono::milliseconds timeout) noexcept
     {
         std::unique_lock<std::mutex> lock(s_pause_manager_mutex);
-        s_pause_manager_cv.wait_for(lock, timeout, [] () {
+        s_pause_manager_cv.wait_for(lock, timeout, [] () -> bool {
             auto state = s_pause_manager_state.load();
             return state < 2 || !(state & 1);
         });
     }
 
+    // PauseManager::Lock uses TryLock, and client code should
+    // use an instance (typically on the stack) of PauseManager::Lock
+    // rather than calling TryLock and ReleaseLock explicitly.
     bool PauseManager::TryLock() noexcept
     {
         auto state = PauseManager::s_pause_manager_state.load();
@@ -52,6 +71,9 @@ namespace MAT_NS_BEGIN
         return (state & 1) == 0;
     }
 
+    // Only call ReleaseLock if TryLock returned true. Calling ReleaseLock when
+    // TryLock returned false or calling ReleaseLock without a corresponding
+    // TryLock will set an invalid active count in our state variable.
     void PauseManager::ReleaseLock() noexcept
     {
         auto state = s_pause_manager_state.load();
@@ -65,11 +87,13 @@ namespace MAT_NS_BEGIN
         }
     }
 
+    // On construction, try to acquire a lock. Record whether we received one.
     PauseManager::Lock::Lock()
     {
         acquired_lock = PauseManager::TryLock();
     }
 
+    // On destruction, release a lock if we received one in the constructor.
     PauseManager::Lock::~Lock()
     {
         if (acquired_lock) {
@@ -77,6 +101,7 @@ namespace MAT_NS_BEGIN
         }
     }
 
+    // We are paused if we did not receive a lock from the PauseManager.
     bool PauseManager::Lock::isPaused() const noexcept
     {
         return !acquired_lock;

--- a/lib/api/PauseManager.cpp
+++ b/lib/api/PauseManager.cpp
@@ -1,0 +1,85 @@
+#include "PauseManager.hpp"
+
+namespace MAT_NS_BEGIN
+{
+    std::mutex PauseManager::s_pause_manager_mutex;
+    std::atomic<uint64_t> PauseManager::s_pause_manager_state(0);
+    std::condition_variable PauseManager::s_pause_manager_cv;
+
+    void PauseManager::PauseActivity() noexcept
+    {
+        auto state = s_pause_manager_state.load();
+        while ((state & 1) == 0 && !s_pause_manager_state.compare_exchange_weak(state, state + 1));
+
+        if (state < 2) {
+            s_pause_manager_cv.notify_all();
+        }
+    }
+
+    void PauseManager::ResumeActivity() noexcept
+    {
+        auto state = s_pause_manager_state.load();
+        while ((state & 1) && !s_pause_manager_state.compare_exchange_weak(state, state - 1));
+        s_pause_manager_cv.notify_all();
+    }
+
+    void PauseManager::QuiesceWait() noexcept
+    {
+        std::unique_lock<std::mutex> lock(s_pause_manager_mutex);
+        s_pause_manager_cv.wait(lock, [] () {
+            auto state = s_pause_manager_state.load();
+            return state < 2 || !(state & 1);
+        });
+    }
+
+    void PauseManager::QuiesceWaitFor(std::chrono::milliseconds timeout) noexcept
+    {
+        std::unique_lock<std::mutex> lock(s_pause_manager_mutex);
+        s_pause_manager_cv.wait_for(lock, timeout, [] () {
+            auto state = s_pause_manager_state.load();
+            return state < 2 || !(state & 1);
+        });
+    }
+
+    bool PauseManager::TryLock() noexcept
+    {
+        auto state = PauseManager::s_pause_manager_state.load();
+        do {
+            if (state & 1) {
+                break;
+            }
+        } while(!PauseManager::s_pause_manager_state.compare_exchange_weak(state, state + 2));
+        return (state & 1) == 0;
+    }
+
+    void PauseManager::ReleaseLock() noexcept
+    {
+        auto state = s_pause_manager_state.load();
+        do {
+            if (state < 2) {
+                break;
+            }
+        } while (!s_pause_manager_state.compare_exchange_weak(state, state - 2));
+        if (state < 2) {
+            s_pause_manager_cv.notify_all();
+        }
+    }
+
+    PauseManager::Lock::Lock()
+    {
+        acquired_lock = PauseManager::TryLock();
+    }
+
+    PauseManager::Lock::~Lock()
+    {
+        if (acquired_lock) {
+            PauseManager::ReleaseLock();
+        }
+    }
+
+    bool PauseManager::Lock::isPaused() const noexcept
+    {
+        return !acquired_lock;
+    }
+}
+MAT_NS_END

--- a/lib/include/public/PauseManager.hpp
+++ b/lib/include/public/PauseManager.hpp
@@ -5,6 +5,7 @@
 #ifndef PAUSEMANAGER_HPP
 #define PAUSEMANAGER_HPP
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>

--- a/lib/include/public/PauseManager.hpp
+++ b/lib/include/public/PauseManager.hpp
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+#ifndef PAUSEMANAGER_HPP
+#define PAUSEMANAGER_HPP
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+#include "ctmacros.hpp"
+
+namespace MAT_NS_BEGIN
+{
+    class PauseManager {
+        public:
+
+        static void PauseActivity() noexcept;
+        static void ResumeActivity() noexcept;
+        static void QuiesceWait() noexcept;
+        static void QuiesceWaitFor(std::chrono::milliseconds timeout) noexcept;
+        static bool TryLock() noexcept;
+        static void ReleaseLock() noexcept;
+
+        class Lock {
+        public:
+
+            Lock();
+            ~Lock();
+
+            bool isPaused() const noexcept;
+
+        private:
+            bool acquired_lock;
+        };
+
+        private:
+
+        static std::mutex s_pause_manager_mutex;
+        static std::atomic<uint64_t> s_pause_manager_state;
+        static std::condition_variable s_pause_manager_cv;
+    };
+}
+MAT_NS_END
+
+#endif

--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.5.89.1"
-#define BUILD_VERSION 3,5,89,1
+#define BUILD_VERSION_STR "3.5.96.1"
+#define BUILD_VERSION 3,5,96,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include <ctmacros.hpp>
@@ -18,7 +18,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)5 << 32) |
-    ((uint64_t)89 << 16) |
+    ((uint64_t)96 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
   OfflineStorageTests_SQLite.cpp
   PackagerTests.cpp
   PalTests.cpp
+  PauseManagerTests.cpp
   RouteTests.cpp
   StringUtilsTests.cpp
   TaskDispatcherCAPITests.cpp
@@ -56,12 +57,12 @@ endif()
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests)
     list(APPEND SRCS
-        ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/unittests/ECSConfigCacheTests.cpp 
+        ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/unittests/ECSConfigCacheTests.cpp
         ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/unittests/ECSClientUtilsTests.cpp
         ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/unittests/ECSClientTests.cpp
         )
 endif()
-        
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/modules/privacyguard/ AND BUILD_PRIVACYGUARD)
   add_definitions(-DHAVE_MAT_PRIVACYGUARD)
   list(APPEND SRCS
@@ -154,7 +155,7 @@ else()
     ${CMAKE_CURRENT_SOURCE_DIR}/../../googletest/build/lib/
   )
 
-  target_link_libraries(UnitTests 
+  target_link_libraries(UnitTests
     ${LIBGTEST}
     ${LIBGMOCK}
     mat

--- a/tests/unittests/PauseManagerTests.cpp
+++ b/tests/unittests/PauseManagerTests.cpp
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2015-2021 Microsoft Corporation and Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common/Common.hpp"
+#include "PauseManager.hpp"
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+using namespace testing;
+using namespace MAT;
+
+class PauseManagerTests : public StrictMock<Test> {
+  public:
+
+};
+
+TEST_F(PauseManagerTests, InitializedAsRunning)
+{
+    PauseManager::Lock lock;
+    EXPECT_THAT(lock.isPaused(), false);
+}
+
+TEST_F(PauseManagerTests, CanPause)
+{
+    PauseManager::PauseActivity();
+    PauseManager::Lock lock;
+    EXPECT_THAT(lock.isPaused(), true);
+    PauseManager::ResumeActivity();
+}
+
+TEST_F(PauseManagerTests, WaitReturnsIfRunning)
+{
+    PauseManager::Lock lock;
+    EXPECT_THAT(lock.isPaused(), false);
+    PauseManager::QuiesceWait();
+}
+
+TEST_F(PauseManagerTests, WaitReturnsIfPaused)
+{
+    PauseManager::PauseActivity();
+    PauseManager::Lock lock;
+    EXPECT_THAT(lock.isPaused(), true);
+    PauseManager::QuiesceWait();
+    PauseManager::ResumeActivity();
+}
+
+TEST_F(PauseManagerTests, WaitWaitsIfPausing)
+{
+    std::unique_ptr<PauseManager::Lock> lock = std::make_unique<PauseManager::Lock>();
+    EXPECT_THAT(lock->isPaused(), false);
+    PauseManager::PauseActivity();
+    auto hasPaused = std::async(std::launch::async,
+        [] () -> void {
+            PauseManager::QuiesceWait();
+        }
+    );
+    auto status = hasPaused.wait_for(std::chrono::milliseconds(0));
+    EXPECT_THAT(status, std::future_status::timeout);
+    lock.reset();
+    auto pausedStatus = hasPaused.wait_for(std::chrono::seconds(1));
+    EXPECT_THAT(pausedStatus, std::future_status::ready);
+    hasPaused.get();
+    PauseManager::ResumeActivity();
+}
+
+TEST_F(PauseManagerTests, WaitWaitsUntilResume)
+{
+    PauseManager::Lock lock;
+    EXPECT_THAT(lock.isPaused(), false);
+    PauseManager::PauseActivity();
+    auto hasPaused = std::async(std::launch::async,
+        [] () -> void {
+            PauseManager::QuiesceWait();
+        }
+    );
+    auto status = hasPaused.wait_for(std::chrono::milliseconds(0));
+    EXPECT_THAT(status, std::future_status::timeout);
+    PauseManager::ResumeActivity();
+    auto resumedStatus = hasPaused.wait_for(std::chrono::seconds(1));
+    EXPECT_THAT(resumedStatus, std::future_status::ready);
+    hasPaused.get();
+    PauseManager::Lock anotherLock;
+    EXPECT_THAT(anotherLock.isPaused(), false);
+}
+
+TEST_F(PauseManagerTests, WaitForCompletes)
+{
+    std::unique_ptr<PauseManager::Lock> lock = std::make_unique<PauseManager::Lock>();
+    EXPECT_THAT(lock->isPaused(), false);
+    PauseManager::PauseActivity();
+    auto hasPaused = std::async(std::launch::async,
+        [] () -> void {
+            PauseManager::QuiesceWaitFor(std::chrono::seconds(1));
+        }
+    );
+    lock.reset();
+    auto status = hasPaused.wait_for(std::chrono::milliseconds(75));
+    EXPECT_THAT(status, std::future_status::ready);
+    hasPaused.get();
+    PauseManager::ResumeActivity();
+}
+
+TEST_F(PauseManagerTests, WaitForTimesOut)
+{
+    std::unique_ptr<PauseManager::Lock> lock = std::make_unique<PauseManager::Lock>();
+    EXPECT_THAT(lock->isPaused(), false);
+    PauseManager::PauseActivity();
+    auto hasPaused = std::async(std::launch::async,
+        [] () -> void {
+            PauseManager::QuiesceWaitFor(std::chrono::milliseconds(50));
+        }
+    );
+    auto status = hasPaused.wait_for(std::chrono::milliseconds(0));
+    EXPECT_THAT(status, std::future_status::timeout);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    auto timedOut = hasPaused.wait_for(std::chrono::milliseconds(0));
+    EXPECT_THAT(timedOut, std::future_status::ready);
+    hasPaused.get();
+    PauseManager::ResumeActivity();
+}

--- a/tests/unittests/PauseManagerTests.cpp
+++ b/tests/unittests/PauseManagerTests.cpp
@@ -116,8 +116,7 @@ TEST_F(PauseManagerTests, WaitForTimesOut)
     );
     auto status = hasPaused.wait_for(std::chrono::milliseconds(0));
     EXPECT_THAT(status, std::future_status::timeout);
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    auto timedOut = hasPaused.wait_for(std::chrono::milliseconds(0));
+    auto timedOut = hasPaused.wait_for(std::chrono::milliseconds(100));
     EXPECT_THAT(timedOut, std::future_status::ready);
     hasPaused.get();
     PauseManager::ResumeActivity();

--- a/tests/unittests/UnitTests.vcxproj
+++ b/tests/unittests/UnitTests.vcxproj
@@ -465,6 +465,7 @@
     <ClCompile Include="$(ProjectDir)\ZlibUtilsTests.cpp" />
     <ClCompile Include="$(ProjectDir)\AIJsonSerializerTests.cpp" />
     <ClCompile Include="$(ProjectDir)\AITelemetrySystemTests.cpp" />
+    <ClCompile Include="$(ProjectDir)\PauseManagerTests.cpp" />
     <ClInclude Include="$(ProjectDir)..\common\Common.hpp" />
     <ClInclude Include="$(ProjectDir)..\common\HttpServer.hpp" />
     <ClCompile Include="$(ProjectDir)..\common\Reactor.cpp" />

--- a/tests/unittests/UnitTests.vcxproj.filters
+++ b/tests/unittests/UnitTests.vcxproj.filters
@@ -58,6 +58,7 @@
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientUtilsTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyGuardTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\dataviewer\tests\unittests\DefaultDataViewerTests.cpp" />
+    <ClCompile Include="$(ProjectDir)\PauseManagerTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(ProjectDir)..\common\MockIHttpClient.hpp">


### PR DESCRIPTION
Adds a component called PauseManager to the SDK. The intended use case is a multithreaded application that wishes to pause the SDK and wait for it to quiesce.

This is compatible with the current API: if nothing calls the PauseManager::PauseActivity() method, the only effect is to add a compare_and_exchange_weak call and test to some API methods, and everything works as it does today.

Once PauseActivity() is called, future (for the usual sequential-consistency definition of "future") calls to protected methods will return immediately. Past (again, by the sequential-consistency definition) calls are allowed to complete and return normally.

The PauseManger QuiesceWait and QuiesceWaitFor methods will block the calling thread until all in-flight API calls complete.