### PR TITLE
Fix bool check for Objective-C

### DIFF
--- a/wrappers/obj-c/ODWLogger.mm
+++ b/wrappers/obj-c/ODWLogger.mm
@@ -66,7 +66,7 @@ using namespace MAT;
         std::string strPropertyName = std::string([propertyName UTF8String]);
         if([value isKindOfClass: [NSNumber class]]){
             NSNumber* num = (NSNumber*)value;
-            if(strcmp([num objCType], @encode(BOOL))==0 ) {
+            if((id)num == (id)kCFBooleanTrue || (id)num == (id)kCFBooleanFalse) {
                 event.SetProperty(strPropertyName, [num boolValue] ? true : false, piiKind);
             }
             else if( (strcmp([num objCType], @encode(float))==0) || (strcmp([num objCType], @encode(double))==0) || (strcmp([num objCType], @encode(long double))==0) ){


### PR DESCRIPTION
Issue:
Our project was sending bools to kusto as longs instead of true, false. We are using the objective-c wrapper of the sdk. I believe there is an issue in the the sdk to check if an objective-c object is actually a bool

```
strcmp([num objCType], @encode(BOOL))==0 
```

However I found several posts saying this will not work for 64-bit systems (most iphones/simulators today) because an Obj-C Bool is actually an unsigned char.

https://stackoverflow.com/questions/23425187/nsnumber-with-bool-is-no-bool-on-64bit/23426415

Solution:
This post seemed to have an acceptable fix
https://github.com/gabriel/MPMessagePack/commit/c8aeebf820c92a7cd9dbd0fabfa758cca34488a8