### PR TITLE
Pause and resume-or-terminate

### DIFF
--- a/docs/use-after-free.md
+++ b/docs/use-after-free.md
@@ -1,0 +1,30 @@
+# How to Not Crash on Shutdown
+
+In any concurrent application, there is a race on shutdown between the destruction of SDK components and threads that may be calling SDK methods. This can occur both with static destructors (e.g., the static `LogManager` instance) and destructors for heap-allocated log manager instances. The most common symptom is a read-dereference crash in a `LogEvent` call stack caused by a read-after-free of the internal state of a log manager (less frequently one may see a read-after-free in the background threads of the a log manager; `LogEvent` is typically called more frequently than these background tasks, so it predominates).
+
+As an interim solution, the SDK has added the `PauseActivity` and `WaitPause` methods, and modified the `FlushAndTeardown` method. Applications can reduce or eliminate use-after-free crashes by managing SDK lifetime and using these methods on shutdown.
+
+## PauseActivity and WaitPause
+
+The `PauseActivity` and `WaitPause` methods provide a reliable mechanism to completely quiesce the SDK prior to shutdown. While the SDK is quiesced, calls to `LogEvent`, `Flush`, and `UploadNow` will have no effect (they will return immediately without doing anything), and the SDK's background threads will not run.
+
+`PauseActivity` starts the process of quiescing the SDK. It does not abort calls-in-progress from either other application threads into SDK methods, or from SDK background jobs. The SDK will quiesce once those calls in progress complete.
+
+`WaitPause` waits for these calls to complete. It will return once the SDK is completely quiesced. The time required is potentially unbounded (as with any concurrent operation) though in practice the bound should be on the order of the time required to complete synchronous writes to the persistent database.
+
+For shutdown, the suggested sequence of SDK calls is:
+
+- `Flush` to persist all current telemetry to persistent storage.
+- `PauseActivity` to start the quiesce.
+- `WaitPause` to ensure that the quiesce completed.
+- proceed with other shutdown activity as needed.
+- ideally use `join` or similar mechanisms to quiesce all application threads before shutdown.
+- Since the application should be quiesced, use `SIGKILL` or similar immediate-exit mechanisms to avoid firing destructors and freeing heap at exit, thus avoiding use-after-free crashes on application exit.
+
+## SDK Lifetime Management
+
+The final two steps in that suggested sequence (`join` and `SIGKILL`) should ensure that the SDK outlives potential callers. The `join` step requires potentially unbounded time to complete, and the time in practice depends on application architecture. Thus the suggestion to use `SIGKILL` to terminate execution, possibly before the `join` completes. The immediate-exit effects are no more disruptive than use-after-free crashes, should you be worried about in-flight write operations at exit.
+
+## FlushAndTeardown
+
+The pull request that introduces `PauseActivity` adds calls to `PauseActivity` followed by `WaitPause` in the existing `FlushAndTeardown` method. If one wishes to use this backstop to quiesce the SDK, the application should call `Flush` before `FlushAndTeardown`. This looks redundant (doesn't FlushAndTeardown actually flush, you might ask), but despite the method name `FlushAndTeardown`, the call to `Flush` is required to ensure persistence before the `PauseActivity` quiesce.

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/ILogManager.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/ILogManager.java
@@ -68,4 +68,10 @@ public interface ILogManager extends AutoCloseable {
   public boolean registerPrivacyGuard();
 
   public boolean unregisterPrivacyGuard();
+  
+  public void pauseActivity();
+  public void resumeActivity();
+  public void waitPause();
+  public boolean startActivity();
+  public void endActivity();
 }

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManager.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManager.java
@@ -932,5 +932,11 @@ public class LogManager {
     // we should let LogManager remove it when it d'tors.
     return PrivacyGuard.isInitialized() && nativeUnregisterPrivacyGuardOnDefaultLogManager();
   }
-}
+  public native static String getCurrentEndpoint();
 
+  public static native void pauseActivity();
+  public static native void resumeActivity();
+  public static native void waitPause();
+  public static native boolean startActivity();
+  public static native void endActivity();
+}

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManager.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManager.java
@@ -932,7 +932,6 @@ public class LogManager {
     // we should let LogManager remove it when it d'tors.
     return PrivacyGuard.isInitialized() && nativeUnregisterPrivacyGuardOnDefaultLogManager();
   }
-  public native static String getCurrentEndpoint();
 
   public static native void pauseActivity();
   public static native void resumeActivity();

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
@@ -293,5 +293,36 @@ public class LogManagerProvider {
     public boolean unregisterPrivacyGuard() {
       return PrivacyGuard.isInitialized() && nativeUnregisterPrivacyGuard(nativeLogManager);
     }
+    
+    protected native void nativePauseActivity(long nativeLogManager);
+    protected native void nativeResumeActivity(long nativeLogManager);
+    protected native void nativeWaitPause(long nativeLogManager);
+    protected native boolean nativeStartActivity(long nativeLogManager);
+    protected native void nativeEndActivity(long nativeLogManager);
+
+    @Override
+    public void pauseActivity() {
+      nativePauseActivity(nativeLogManager);
+    }
+
+    @Override
+    public void resumeActivity() {
+      nativeResumeActivity(nativeLogManager);
+    }
+
+    @Override
+    public void waitPause() {
+      nativeWaitPause(nativeLogManager);
+    }
+
+    @Override
+    public boolean startActivity() {
+      return nativeStartActivity(nativeLogManager);
+    }
+
+    @Override
+    public void endActivity() {
+      nativeEndActivity(nativeLogManager);
+    }
   }
 }

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -364,6 +364,8 @@ namespace MAT_NS_BEGIN
 
     void LogManagerImpl::FlushAndTeardown()
     {
+        PauseActivity();
+        WaitPause();
         LOG_INFO("Shutting down...");
         LOCKGUARD(m_lock);
         if (m_alive)
@@ -754,7 +756,7 @@ namespace MAT_NS_BEGIN
 
     void LogManagerImpl::ResetLogSessionData()
     {
-        if (m_logSessionDataProvider) 
+        if (m_logSessionDataProvider)
         {
             m_logSessionDataProvider->ResetLogSessionData();
         }
@@ -868,25 +870,93 @@ namespace MAT_NS_BEGIN
     {
 
         LOCKGUARD(m_lock);
-        if (GetSystem()) 
+        if (GetSystem())
         {
             // cleanup pending http requests
-            GetSystem()->cleanup(); 
-        
+            GetSystem()->cleanup();
+
             // cleanup log session ( UUID)
             if (m_logSessionDataProvider)
             {
                 m_logSessionDataProvider->DeleteLogSessionData();
             }
-    
+
             // cleanup offline storage ( this will also cleanup retry queue for http requests
-            if (m_offlineStorage) 
-            {	
-                m_offlineStorage->DeleteAllRecords();	
+            if (m_offlineStorage)
+            {
+                m_offlineStorage->DeleteAllRecords();
             }
         }
         return STATUS_SUCCESS;
     }
+
+    // Pause/Resume interface
+
+    void LogManagerImpl::PauseActivity()
+    {
+        std::unique_lock<std::mutex> lock(m_pause_mutex);
+        if (m_pause_state != PauseState::Active) {
+            return;
+        }
+
+        if (m_pause_active_count == 0)
+        {
+            m_pause_state = PauseState::Paused;
+            // notify under lock because a waiting thread
+            // may destroy objects (including this object)
+            m_pause_cv.notify_all();
+        }
+        else
+        {
+            m_pause_state = PauseState::Pausing;
+        }
+    }
+
+    void LogManagerImpl::ResumeActivity()
+    {
+        std::unique_lock<std::mutex> lock(m_pause_mutex);
+        if (m_pause_state == PauseState::Active) {
+            return;
+        }
+        m_pause_state = PauseState::Active;
+        m_pause_cv.notify_all();
+    }
+
+    void LogManagerImpl::WaitPause()
+    {
+        std::unique_lock<std::mutex> lock(m_pause_mutex);
+        if (m_pause_state != PauseState::Pausing) {
+            return;
+        }
+        m_pause_cv.wait(lock, [this]() -> bool {
+            return m_pause_state != PauseState::Pausing;
+        });
+    }
+
+    bool LogManagerImpl::StartActivity()
+    {
+        std::unique_lock<std::mutex> lock(m_pause_mutex);
+        if (m_pause_state != PauseState::Active) {
+            return false;
+        }
+        m_pause_active_count += 1;
+        return true;
+    }
+
+    void LogManagerImpl::EndActivity()
+    {
+        std::unique_lock<std::mutex> lock(m_pause_mutex);
+        if (m_pause_active_count == 0) {
+            return;
+        }
+        m_pause_active_count -= 1;
+        if (m_pause_active_count > 0) {
+            return;
+        }
+        if (m_pause_state == PauseState::Pausing) {
+            m_pause_state = PauseState::Paused;
+            m_pause_cv.notify_all();
+        }
+    }
 }
 MAT_NS_END
-

--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -32,6 +32,7 @@
 #include "IDataInspector.hpp"
 #include "offline/LogSessionDataProvider.hpp"
 
+#include <condition_variable>
 #include <mutex>
 #include <set>
 
@@ -301,6 +302,12 @@ namespace MAT_NS_BEGIN
         virtual void RemoveDataInspector(const std::string& name) override;
         virtual std::shared_ptr<IDataInspector> GetDataInspector(const std::string& name) noexcept override;
 
+        virtual void PauseActivity() override;
+        virtual void ResumeActivity() override;
+        virtual void WaitPause() override;
+        virtual bool StartActivity() override;
+        virtual void EndActivity() override;
+
        protected:
         std::unique_ptr<ITelemetrySystem>& GetSystem();
         void InitializeModules() noexcept;
@@ -340,10 +347,20 @@ namespace MAT_NS_BEGIN
         DataViewerCollection m_dataViewerCollection;
         std::vector<std::shared_ptr<IDataInspector>> m_dataInspectors;
         std::recursive_mutex m_dataInspectorGuard;
+
+        std::mutex m_pause_mutex;
+        std::condition_variable m_pause_cv;
+        uint64_t m_pause_active_count = 0;
+        enum class PauseState : uint8_t
+        {
+            Active,
+            Pausing,
+            Paused
+        };
+        PauseState m_pause_state = PauseState::Active;
     };
 
 }
 MAT_NS_END
 
 #endif
-

--- a/lib/include/public/ILogManager.hpp
+++ b/lib/include/public/ILogManager.hpp
@@ -402,10 +402,36 @@ namespace MAT_NS_BEGIN
         /// </summary>
         /// <returns>Selected instance of IDataInspector if available, nullptr otherwise.</returns>
         virtual std::shared_ptr<IDataInspector> GetDataInspector() noexcept { return GetDataInspector(std::string{}); }
+
+        /// <summary>
+        /// Ask the log manager to pause activity
+        /// </summary>
+        virtual void PauseActivity() = 0;
+
+        /// <summary>
+        /// Ask the log manager to resume activity
+        /// </summary>
+        virtual void ResumeActivity() = 0;
+
+        /// <summary>
+        /// Wait for pause to complete (no active calls) or resume
+        /// </summary>
+        virtual void WaitPause() = 0;
+
+        /// <summary>
+        /// Start an activity
+        /// </summary>
+        /// <returns>True if we are not paused and the activity may continue.</returns>
+        virtual bool StartActivity() = 0;
+
+        /// <summary>
+        /// End an activity. StartActivity MUST have returned true: do not call this
+        /// method if StartActivity returned true.
+        /// </summary>
+        virtual void EndActivity() = 0;
     };
 
 }
 MAT_NS_END
 
 #endif
-

--- a/lib/include/public/LogManagerBase.hpp
+++ b/lib/include/public/LogManagerBase.hpp
@@ -694,6 +694,36 @@ namespace MAT_NS_BEGIN
 #endif
         }
 
+        static void PauseActivity()
+        {
+            LM_SAFE_CALL_VOID(PauseActivity);
+        }
+
+        static void ResumeActivity()
+        {
+            LM_SAFE_CALL_VOID(ResumeActivity)
+        }
+
+        static void WaitPause()
+        {
+            auto instance = GetInstance();
+            if (instance) {
+                // do not hold the stateLock() here!
+                instance->WaitPause();
+            }
+        }
+
+        static bool StartActivity()
+        {
+            LM_SAFE_CALL_RETURN(StartActivity);
+            return false;
+        }
+
+        static void EndActivity()
+        {
+            LM_SAFE_CALL_VOID(EndActivity);
+        }
+
         /// <summary>
         /// Obtain a raw pointer to the ILogManager singleton instance.
         /// NOTE: this API should not be used concurrently with Initialize or FlushAndTeardown API calls.

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -379,10 +379,19 @@ namespace MAT_NS_BEGIN
             return nullptr;
         }
 
-        virtual status_t DeleteData() noexcept override 
-        { 
+        virtual status_t DeleteData() noexcept override
+        {
             return STATUS_ENOSYS;
         }
+
+        virtual void PauseActivity() override {}
+        virtual void ResumeActivity() override {}
+        virtual void WaitPause() override {}
+        virtual bool StartActivity() override
+        {
+            return true;
+        }
+        virtual void EndActivity() override {}
 
         private:
             NullDataViewerCollection nullDataViewerCollection;
@@ -392,4 +401,3 @@ namespace MAT_NS_BEGIN
 } MAT_NS_END
 
 #endif
-

--- a/lib/jni/LogManager_jni.cpp
+++ b/lib/jni/LogManager_jni.cpp
@@ -1576,6 +1576,63 @@ Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_na
     }
 #endif
     return false;
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManager_pauseActivity(JNIEnv *env, jclass clazz) {
+    WrapperLogManager::PauseActivity();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManager_resumeActivity(JNIEnv *env, jclass clazz) {
+    WrapperLogManager::ResumeActivity();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManager_waitPause(JNIEnv *env, jclass clazz) {
+    WrapperLogManager::WaitPause();
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_microsoft_applications_events_LogManager_startActivity(JNIEnv *env, jclass clazz) {
+    return WrapperLogManager::StartActivity() ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManager_endActivity(JNIEnv *env, jclass clazz) {
+    WrapperLogManager::EndActivity();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_nativePauseActivity(
+        JNIEnv *env, jobject thiz, jlong native_log_manager) {
+    auto logManager = getLogManager(native_log_manager);
+    if (logManager) {
+        logManager->PauseActivity();
+    }
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_nativeResumeActivity(
+        JNIEnv *env, jobject thiz, jlong native_log_manager) {
+    auto logManager = getLogManager(native_log_manager);
+    if (logManager) {
+        logManager->ResumeActivity();
+    }
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_nativeWaitPause(
+        JNIEnv *env, jobject thiz, jlong native_log_manager) {
+    auto logManager = getLogManager(native_log_manager);
+    if (logManager) {
+        logManager->WaitPause();
+    }
 }
 
 extern "C"
@@ -1595,3 +1652,21 @@ Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_na
     return false;
 }
 
+Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_nativeStartActivity(
+        JNIEnv *env, jobject thiz, jlong native_log_manager) {
+    auto logManager = getLogManager(native_log_manager);
+    if (logManager) {
+        return logManager->StartActivity() ? JNI_TRUE : JNI_FALSE;
+    }
+    return JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_nativeEndActivity(
+        JNIEnv *env, jobject thiz, jlong native_log_manager) {
+    auto logManager = getLogManager(native_log_manager);
+    if (logManager) {
+        logManager->EndActivity();
+    }
+}

--- a/lib/jni/LogManager_jni.cpp
+++ b/lib/jni/LogManager_jni.cpp
@@ -1576,6 +1576,9 @@ Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_na
     }
 #endif
     return false;
+}
+
+extern "C"
 JNIEXPORT void JNICALL
 Java_com_microsoft_applications_events_LogManager_pauseActivity(JNIEnv *env, jclass clazz) {
     WrapperLogManager::PauseActivity();
@@ -1652,6 +1655,8 @@ Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_na
     return false;
 }
 
+extern "C"
+JNIEXPORT jboolean JNICALL
 Java_com_microsoft_applications_events_LogManagerProvider_00024LogManagerImpl_nativeStartActivity(
         JNIEnv *env, jobject thiz, jlong native_log_manager) {
     auto logManager = getLogManager(native_log_manager);

--- a/lib/offline/OfflineStorageHandler.cpp
+++ b/lib/offline/OfflineStorageHandler.cpp
@@ -152,6 +152,9 @@ namespace MAT_NS_BEGIN {
 
     void OfflineStorageHandler::Flush()
     {
+        if (!m_logManager.StartActivity()) {
+            return;
+        }
         // Flush could be executed from context of worker thread, as well as from TPM and
         // after HTTP callback. Make sure it is atomic / thread-safe.
         LOCKGUARD(m_flushLock);
@@ -201,6 +204,7 @@ namespace MAT_NS_BEGIN {
         // Flush is done, notify the waiters
         m_flushComplete.post();
         m_flushPending = false;
+        m_logManager.EndActivity();
     }
 
     bool OfflineStorageHandler::StoreRecord(StorageRecord const& record)
@@ -367,7 +371,7 @@ namespace MAT_NS_BEGIN {
      * Delete all records locally".
      */
 
-    void OfflineStorageHandler::DeleteAllRecords() 
+    void OfflineStorageHandler::DeleteAllRecords()
     {
         for (const auto storagePtr : { m_offlineStorageMemory.get() , m_offlineStorageDisk.get() })
         {
@@ -534,4 +538,3 @@ namespace MAT_NS_BEGIN {
     }
 
 } MAT_NS_END
-

--- a/lib/tpm/TransmissionPolicyManager.cpp
+++ b/lib/tpm/TransmissionPolicyManager.cpp
@@ -11,6 +11,30 @@
 
 namespace MAT_NS_BEGIN {
 
+    class PauseGuard {
+    public:
+        PauseGuard() = delete;
+        PauseGuard(ILogManager & logManager)
+        : m_logManager(logManager)
+        , m_unpaused(m_logManager.StartActivity())
+        {}
+
+        ~PauseGuard()
+        {
+            if (m_unpaused) {
+                m_logManager.EndActivity();
+            }
+        }
+
+        bool isPaused()
+        {
+            return !m_unpaused;
+        }
+    private:
+        ILogManager& m_logManager;
+        bool m_unpaused;
+    };
+
     template<typename T>
     constexpr T Abs64(const T& a, const T& b) noexcept
     {
@@ -78,8 +102,12 @@ namespace MAT_NS_BEGIN {
     // If delayInMs is negative, do not schedule.
     void TransmissionPolicyManager::scheduleUpload(const std::chrono::milliseconds& delay, EventLatency latency, bool force)
     {
+        PauseGuard guard(m_system.getLogManager());
+        if (guard.isPaused()) {
+            return;
+        }
         LOCKGUARD(m_scheduledUploadMutex);
-        if (delay.count() < 0 || m_timerdelay.count() < 0) 
+        if (delay.count() < 0 || m_timerdelay.count() < 0)
         {
             LOG_TRACE("Negative delay(%d) or m_timerdelay(%d), no upload", delay.count(), m_timerdelay.count());
             return;
@@ -147,6 +175,10 @@ namespace MAT_NS_BEGIN {
 
     void TransmissionPolicyManager::uploadAsync(EventLatency latency)
     {
+        PauseGuard guard(m_system.getLogManager());
+        if (guard.isPaused()) {
+            return;
+        }
         m_runningLatency = latency;
         m_scheduledUploadTime = std::numeric_limits<uint64_t>::max();
 
@@ -194,6 +226,10 @@ namespace MAT_NS_BEGIN {
             LOG_WARN("HTTP NOT removing non-existing ctx from active uploads ctx=%p", ctx.get());
         }
 
+        PauseGuard guard(m_system.getLogManager());
+        if (guard.isPaused()) {
+            return;
+        }
         // Rescheduling upload
         if (nextUpload.count() >= 0)
         {
@@ -257,7 +293,7 @@ namespace MAT_NS_BEGIN {
     }
 
     /**
-     * Wait for pending uploads to finish. This handler is invoked from 
+     * Wait for pending uploads to finish. This handler is invoked from
      * TelemetrySystem::onCleanup after HCM has attempted to cancel all pending
      * requests via hcm.cancelAllRequests. This won't abort the uploads in the end
      * and is possible to resume the transmission
@@ -402,6 +438,7 @@ namespace MAT_NS_BEGIN {
 
     void TransmissionPolicyManager::pauseAllUploads()
     {
+        PauseGuard guard(m_system.getLogManager());
         m_isPaused = true;
         cancelUploadTask();
     }
@@ -443,4 +480,3 @@ namespace MAT_NS_BEGIN {
     }
 
 } MAT_NS_END
-


### PR DESCRIPTION
Adds methods to ILogManager to support pause and resume. During pause, loggers do not log, flush does not flush, and tpm does not start uploads.

This allows client software to quiesce these activities, either for an operating-system "you are in the background" state change (iOS wants background apps to negotiate for time to do activities like persisting to the database) or a "you are about to tear down all objects" (iOS, again).

Happily, Android kills applications with SIGKILL and there is no such thing as a bad application exit, but even on that platform one might want to sleep-hard or know when the SDK is idle and paused.

No iOS ObjC wrapper in this PR because I do not have a Mac and therefore no xcode.'

This PR includes the Java wrapper changes and Java tests for the interface, and C++ unit tests.