### PR TITLE
Fix FuncTests project not loading in VS2017

### DIFF
--- a/tests/functests/FuncTests.vcxproj
+++ b/tests/functests/FuncTests.vcxproj
@@ -94,7 +94,6 @@
   <ImportGroup Label="Shared">
     <Import Project="..\..\Solutions\Clienttelemetry\Clienttelemetry.vcxitems" Label="Shared" />
     <Import Project="..\..\lib\pal\desktop\desktop.vcxitems" Label="Shared" />
-    <Import Project="..\..\lib\decoder\decoder.vcxitems" Label="Shared" />
     <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\filter\filter.vcxitems')" Project="..\..\lib\modules\filter\filter.vcxitems" Label="Shared" />
     <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\dataviewer\dataviewer.vcxitems')" Project="..\..\lib\modules\dataviewer\dataviewer.vcxitems" Label="Shared" />
     <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\azmon\azmon.vcxitems')" Project="..\..\lib\modules\azmon\azmon.vcxitems" Label="Shared" />


### PR DESCRIPTION
Load fails with:
```cpp_client_telemetry\tests\functests\FuncTests.vcxproj : error : Cannot load project with duplicated project items: D:\Git\cpp_client_telemetry\lib\decoder\PayloadDecoder.cpp is included as 'ClCompile' and as 'ClCompile' item types.```

Remove decoder.vcxitems from FuncTests as its contents are duplicated in ClientTelemetry.vcxitems