### PR TITLE
Stop Unit and Func tests from recompiling all of the files that constitute clienttelemetry.lib

### DIFF
--- a/tests/functests/FuncTests.vcxproj
+++ b/tests/functests/FuncTests.vcxproj
@@ -91,16 +91,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-    <Import Project="..\..\Solutions\Clienttelemetry\Clienttelemetry.vcxitems" Label="Shared" />
-    <Import Project="..\..\lib\pal\desktop\desktop.vcxitems" Label="Shared" />
-    <Import Project="..\..\lib\decoder\decoder.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\filter\filter.vcxitems')" Project="..\..\lib\modules\filter\filter.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\dataviewer\dataviewer.vcxitems')" Project="..\..\lib\modules\dataviewer\dataviewer.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\azmon\azmon.vcxitems')" Project="..\..\lib\modules\azmon\azmon.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\privacyguard\privacyguard.vcxitems')" Project="..\..\lib\modules\privacyguard\privacyguard.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\liveeventinspector\liveeventinspector.vcxitems')" Project="..\..\lib\modules\liveeventinspector\liveeventinspector.vcxitems" Label="Shared" />
-  </ImportGroup>
+  <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>

--- a/tests/unittests/UnitTests.vcxproj
+++ b/tests/unittests/UnitTests.vcxproj
@@ -91,14 +91,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-    <Import Project="..\..\Solutions\Clienttelemetry\Clienttelemetry.vcxitems" Label="Shared" />
-    <Import Project="..\..\lib\pal\desktop\desktop.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\filter\filter.vcxitems')" Project="..\..\lib\modules\filter\filter.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\dataviewer\dataviewer.vcxitems')" Project="..\..\lib\modules\dataviewer\dataviewer.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\privacyguard\privacyguard.vcxitems')" Project="..\..\lib\modules\privacyguard\privacyguard.vcxitems" Label="Shared" />
-    <Import Condition="exists('$(MSBuildThisFileDirectory)..\..\lib\modules\azmon\azmon.vcxitems')" Project="..\..\lib\modules\azmon\azmon.vcxitems" Label="Shared" />
-  </ImportGroup>
+  <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>


### PR DESCRIPTION
This yields better build perf as these projects only build the test files they need, rather than compiling the entirety of files contained within ClientTelemetry.lib. 

The tests will, of course, still depend on ClientTelemetry.lib, and any changes in constituent files will require a re-lib and re-link, but it means that we'll be compiling each file N-2 times, which is probably a win :)

On the build perf improvement: Looking at a couple PRs, the Test-Win32 Release loop looks like it's saving 6-7 minutes out of ~20 minutes (or roughly 35%). Not yet at the non-windows loop speeds, but makes my calculator show a smiley face.