### PR TITLE
Ensure config headers are included once

### DIFF
--- a/lib/include/mat/config-MIP.h
+++ b/lib/include/mat/config-MIP.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(HAVE_PRIVATE_MODULES)
 /* #define HAVE_MAT_EXP */

--- a/lib/include/mat/config-MSIPC.h
+++ b/lib/include/mat/config-MSIPC.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(_WIN32)
 //#define HAVE_MAT_UTC

--- a/lib/include/mat/config-compact-dll.h
+++ b/lib/include/mat/config-compact-dll.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(_WIN32)
 #define HAVE_MAT_UTC

--- a/lib/include/mat/config-compact-exp.h
+++ b/lib/include/mat/config-compact-exp.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(_WIN32)
 #define HAVE_MAT_UTC

--- a/lib/include/mat/config-compact-min.h
+++ b/lib/include/mat/config-compact-min.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(_WIN32)
 #define HAVE_MAT_UTC

--- a/lib/include/mat/config-compact-noutc.h
+++ b/lib/include/mat/config-compact-noutc.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 /* #if defined(_WIN32)          */
 /* #define HAVE_MAT_UTC         */

--- a/lib/include/mat/config-compact.h
+++ b/lib/include/mat/config-compact.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(_WIN32)
 #define HAVE_MAT_UTC

--- a/lib/include/mat/config-default-cs4.h
+++ b/lib/include/mat/config-default-cs4.h
@@ -2,9 +2,18 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
-#if defined(_WIN32) /* && defined(HAVE_PRIVATE_MODULES) */
-#define HAVE_MAT_UTC
+#if defined(_WIN32)
+#if defined __has_include
+#  if __has_include ("modules/azmon/AITelemetrySystem.hpp")
+#    define HAVE_MAT_AI
+#  endif
+#  if __has_include ("modules/utc/UtcTelemetrySystem.hpp")
+#    define HAVE_MAT_UTC
+#  endif
+#endif
 #endif
 #if defined(HAVE_PRIVATE_MODULES)
 #define HAVE_MAT_EXP
@@ -16,6 +25,8 @@
 #define HAVE_MAT_LOGGING
 #define HAVE_MAT_STORAGE
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_MAT_LIVEEVENTINSPECTOR
+#define HAVE_MAT_PRIVACYGUARD
 //#define HAVE_MAT_DEFAULT_FILTER
 #if defined(_WIN32) && !defined(_WINRT_DLL)
 #define HAVE_MAT_NETDETECT

--- a/lib/include/mat/config-default.h
+++ b/lib/include/mat/config-default.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 #if defined(_WIN32)
 #if defined __has_include

--- a/lib/include/mat/config-net40.h
+++ b/lib/include/mat/config-net40.h
@@ -2,6 +2,8 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"
 /*
 #if defined(_WIN32)

--- a/lib/include/mat/config-versionPrefix.h
+++ b/lib/include/mat/config-versionPrefix.h
@@ -2,4 +2,6 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
+#pragma once
+
 #define EVTSDK_VERSION_PREFIX "EVT"


### PR DESCRIPTION
In one of the other PRs I noticed that we _somehow_ end up defining the same feature macros twice.

As a good gesture, appending `#pragma once` where it was missing. The actual `config.h` has the include guards around it, and the expectation has generally been that all other minor feature customization configs get included only from that main file via `#include CONFIG_CUSTOM_H`. So this include rule is violated somewhere around unit tests for custom features. Adding `#pragma once` seems like a good thing to do.

Unrelated to `pragma` - I noticed that recent features were added to `config-default.h` for Common Schema 3 build. But not to `config-default-cs4.h` for Common Schema 4 build, which we were planning to embrace some time this year as the default. I'm adding these new feature flags to that CS4.0 configuration as well, so that the two defaults are fully identical with respect to set of features, and the only difference is schema version.

_UPDATE: it seems like Sid is fixing the actual issue in the other PR ( #844 ) , but mine won't hurt regardless._
