### PR TITLE
Add Multiple LogManager support for Privacy Guard

### DIFF
--- a/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
+++ b/lib/android_build/maesdk/src/main/cpp/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 
 if(EXISTS ${SDK_ROOT}/lib/modules/privacyguard/ AND BUILD_PRIVACYGUARD)
         list(APPEND SRCS
+                ${SDK_ROOT}/lib/jni/PrivacyGuardState.cpp
                 ${SDK_ROOT}/lib/jni/PrivacyGuard_jni.cpp
                 ${SDK_ROOT}/lib/modules/privacyguard/SummaryStatistics.cpp
                 ${SDK_ROOT}/lib/modules/privacyguard/PrivacyGuard.cpp

--- a/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
+++ b/lib/android_build/maesdk/src/main/java/com/microsoft/applications/events/LogManagerProvider.java
@@ -271,5 +271,61 @@ public class LogManagerProvider {
     public void removeEventListener(DebugEventType eventType, DebugEventListener listener) {
       nativeRemoveEventListener(nativeLogManager, eventType.value(), listener.nativeIdentity);
     }
+
+    private native boolean nativeInitializePrivacyGuardWithoutDataContext(long nativeLogManager, long iLoggerNativePtr);
+    private native boolean nativeInitializePrivacyGuardWithDataContext(long nativeLogManager, long iLoggerNativePtr,
+                                                                    String domainName,
+                                                                    String machineName,
+                                                                    String userName,
+                                                                    String userAlias,
+                                                                    Object[] ipAddresses,
+                                                                    Object[] languageIdentifiers,
+                                                                    Object[] machineIds,
+                                                                    Object[] outOfScopeIdentifiers);
+
+    /**
+     * Initialize and register an instance of Privacy Guard to the current LogManager.
+     * @apiNote If an instance of Privacy Guard was already initialized, that instance will be reused and the provided
+     * loggerInstance and dataContext will not be used.
+     * @param loggerInstance logger where the Privacy Concerns should be logged.
+     * @param dataContext data context for the current instance of Privacy Guard.
+     * @return true if the registration was successful, false otherwise.
+     */
+    public boolean initializePrivacyGuard(ILogger loggerInstance, final CommonDataContext dataContext)
+    {
+      if(loggerInstance == null)
+      {
+        throw new IllegalArgumentException(("loggerInstance cannot be null."));
+      }
+
+      if(dataContext == null)
+      {
+        return nativeInitializePrivacyGuardWithoutDataContext(nativeLogManager, loggerInstance.getNativeILoggerPtr());
+      }
+      else
+      {
+        return nativeInitializePrivacyGuardWithDataContext(
+                nativeLogManager,
+                loggerInstance.getNativeILoggerPtr(),
+                dataContext.domainName,
+                dataContext.machineName,
+                dataContext.userName,
+                dataContext.userAlias,
+                dataContext.ipAddresses.toArray(),
+                dataContext.languageIdentifiers.toArray(),
+                dataContext.machineIds.toArray(),
+                dataContext.outOfScopeIdentifiers.toArray());
+      }
+    }
+
+    private native boolean nativeUnregisterPrivacyGuard(long nativeLogManager);
+    /**
+     * Unregister Privacy Guard from the current LogManager
+     * @return True if unregistered successfully, false otherwise.
+     */
+    public boolean unregisterPrivacyGuard()
+    {
+      return nativeUnregisterPrivacyGuard(nativeLogManager);
+    }
   }
 }

--- a/lib/jni/PrivacyGuardState.cpp
+++ b/lib/jni/PrivacyGuardState.cpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "PrivacyGuardState.hpp"
+#include "JniConvertors.hpp"
+
+namespace MAT_NS_BEGIN
+{
+
+/*static*/ CommonDataContext PrivacyGuardState::GenerateCommonDataContextObject(JNIEnv* env,
+                                                  jstring domainName,
+                                                  jstring machineName,
+                                                  jstring userName,
+                                                  jstring userAlias,
+                                                  jobjectArray ipAddresses,
+                                                  jobjectArray languageIdentifiers,
+                                                  jobjectArray machineIds,
+                                                  jobjectArray outOfScopeIdentifiers)
+{
+    CommonDataContext cdc;
+    cdc.DomainName = JStringToStdString(env, domainName);
+    cdc.MachineName = JStringToStdString(env, machineName);
+    cdc.UserName = JStringToStdString(env, userName);
+    cdc.UserAlias = JStringToStdString(env, userAlias);
+    cdc.IpAddresses = ConvertJObjectArrayToStdStringVector(env, ipAddresses);
+    cdc.LanguageIdentifiers = ConvertJObjectArrayToStdStringVector(env, languageIdentifiers);
+    cdc.MachineIds = ConvertJObjectArrayToStdStringVector(env, machineIds);
+    cdc.OutOfScopeIdentifiers = ConvertJObjectArrayToStdStringVector(env, outOfScopeIdentifiers);
+    return cdc;
+}
+
+/*static*/ std::shared_ptr<PrivacyGuard> PrivacyGuardState::getPrivacyGuardInstance()
+{
+    std::lock_guard<std::mutex> lock(m_pgInstanceGuard);
+    return m_pgInstance;
+}
+
+/*static*/ void PrivacyGuardState::setPrivacyGuardInstance(std::shared_ptr<PrivacyGuard> spPrivacyGuard)
+{
+    std::lock_guard<std::mutex> lock(m_pgInstanceGuard);
+    m_pgInstance.swap(spPrivacyGuard);
+}
+
+/*static*/ void PrivacyGuardState::resetPrivacyGuardInstance()
+{
+    std::lock_guard<std::mutex> lock(m_pgInstanceGuard);
+    m_pgInstance.reset();
+}
+
+/*static*/ bool PrivacyGuardState::isPrivacyGuardInstanceInitialized()
+{
+    std::lock_guard<std::mutex> lock(m_pgInstanceGuard);
+    return m_pgInstance != nullptr;
+}
+
+} MAT_NS_END
+

--- a/lib/jni/PrivacyGuardState.hpp
+++ b/lib/jni/PrivacyGuardState.hpp
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <jni.h>
+#include <modules/privacyguard/CommonDataContext.hpp>
+#include <modules/privacyguard/PrivacyGuard.hpp>
+#include "ctmacros.hpp"
+
+namespace MAT_NS_BEGIN
+{
+
+class PrivacyGuardState
+{
+private:
+    static std::mutex m_pgInstanceGuard;
+    static std::shared_ptr<PrivacyGuard> m_pgInstance;
+public:
+    /**
+   * Generated a CommonDataContext Object from java values.
+   * @param env
+   * @param domainName
+   * @param machineName
+   * @param userName
+   * @param userAlias
+   * @param ipAddresses
+   * @param languageIdentifiers
+   * @param machineIds
+   * @param outOfScopeIdentifiers
+   * @return
+   */
+    static CommonDataContext GenerateCommonDataContextObject(JNIEnv* env,
+                                                      jstring domainName,
+                                                      jstring machineName,
+                                                      jstring userName,
+                                                      jstring userAlias,
+                                                      jobjectArray ipAddresses,
+                                                      jobjectArray languageIdentifiers,
+                                                      jobjectArray machineIds,
+                                                      jobjectArray outOfScopeIdentifiers);
+
+    static std::shared_ptr<PrivacyGuard> getPrivacyGuardInstance();
+    static void setPrivacyGuardInstance(std::shared_ptr<PrivacyGuard> spPrivacyGuard);
+    static void resetPrivacyGuardInstance();
+    static bool isPrivacyGuardInstanceInitialized();
+};
+
+} MAT_NS_END
+

--- a/lib/jni/PrivacyGuard_jni.cpp
+++ b/lib/jni/PrivacyGuard_jni.cpp
@@ -4,46 +4,24 @@
 //
 #include "JniConvertors.hpp"
 #include "modules/privacyguard/PrivacyGuard.hpp"
+#include "PrivacyGuardState.hpp"
 #include "WrapperLogManager.hpp"
 
 using namespace MAT;
 
-CommonDataContext GenerateCommonDataContextObject(JNIEnv* env,
-                                                  jstring domainName,
-                                                  jstring machineName,
-                                                  jstring userName,
-                                                  jstring userAlias,
-                                                  jobjectArray ipAddresses,
-                                                  jobjectArray languageIdentifiers,
-                                                  jobjectArray machineIds,
-                                                  jobjectArray outOfScopeIdentifiers)
-{
-    CommonDataContext cdc;
-    cdc.DomainName = JStringToStdString(env, domainName);
-    cdc.MachineName = JStringToStdString(env, machineName);
-    cdc.UserName = JStringToStdString(env, userName);
-    cdc.UserAlias = JStringToStdString(env, userAlias);
-    cdc.IpAddresses = ConvertJObjectArrayToStdStringVector(env, ipAddresses);
-    cdc.LanguageIdentifiers = ConvertJObjectArrayToStdStringVector(env, languageIdentifiers);
-    cdc.MachineIds = ConvertJObjectArrayToStdStringVector(env, machineIds);
-    cdc.OutOfScopeIdentifiers = ConvertJObjectArrayToStdStringVector(env, outOfScopeIdentifiers);
-    return cdc;
-}
-
 extern "C"
 {
-std::shared_ptr<PrivacyGuard> spPrivacyGuard;
-
 JNIEXPORT jboolean JNICALL
 Java_com_microsoft_applications_events_PrivacyGuard_nativeInitializePrivacyGuardWithoutCommonDataContext(
         JNIEnv *env, jclass /* this */, jlong iLoggerNativePtr) {
-    if (spPrivacyGuard != nullptr) {
+    if (PrivacyGuardState::isPrivacyGuardInstanceInitialized()) {
         return false;
     }
 
     InitializationConfiguration config;
     config.LoggerInstance = reinterpret_cast<ILogger*>(iLoggerNativePtr);
-    spPrivacyGuard = std::make_shared<PrivacyGuard>(config);
+    auto spPrivacyGuard = std::make_shared<PrivacyGuard>(config);
+    PrivacyGuardState::setPrivacyGuardInstance((spPrivacyGuard));
     WrapperLogManager::GetInstance()->SetDataInspector(spPrivacyGuard);
     return true;
 }
@@ -59,12 +37,12 @@ Java_com_microsoft_applications_events_PrivacyGuard_nativeInitializePrivacyGuard
         jobjectArray languageIdentifiers,
         jobjectArray machineIds,
         jobjectArray outOfScopeIdentifiers) {
-    if (spPrivacyGuard != nullptr) {
+    if (PrivacyGuardState::isPrivacyGuardInstanceInitialized()) {
         return false;
     }
 
     InitializationConfiguration config;
-    config.CommonContext = GenerateCommonDataContextObject(env,
+    config.CommonContext = PrivacyGuardState::GenerateCommonDataContextObject(env,
                                                            domainName,
                                                            machineName,
                                                            userName,
@@ -75,7 +53,8 @@ Java_com_microsoft_applications_events_PrivacyGuard_nativeInitializePrivacyGuard
                                                            outOfScopeIdentifiers);
 
     config.LoggerInstance = reinterpret_cast<ILogger *>(iLoggerNativePtr);
-    spPrivacyGuard = std::make_shared<PrivacyGuard>(config);
+    auto spPrivacyGuard = std::make_shared<PrivacyGuard>(config);
+    PrivacyGuardState::setPrivacyGuardInstance((spPrivacyGuard));
     WrapperLogManager::GetInstance()->SetDataInspector(spPrivacyGuard);
     return true;
 }
@@ -83,30 +62,28 @@ Java_com_microsoft_applications_events_PrivacyGuard_nativeInitializePrivacyGuard
 JNIEXPORT jboolean JNICALL
         Java_com_microsoft_applications_events_PrivacyGuard_uninitializePrivacyGuard(JNIEnv *env, jclass /*this*/)
 {
-    if(spPrivacyGuard == nullptr)
+    if(!PrivacyGuardState::isPrivacyGuardInstanceInitialized())
     {
         return false;
     }
 
-    WrapperLogManager::GetInstance()->ClearDataInspectors();
-    spPrivacyGuard.reset();
-
+    WrapperLogManager::GetInstance()->RemoveDataInspector(PrivacyGuardState::getPrivacyGuardInstance()->GetName());
     return true;
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_microsoft_applications_events_PrivacyGuard_setEnabled(JNIEnv *env, jclass /*this*/,
                                                                jboolean isEnabled) {
-    if (spPrivacyGuard == nullptr) {
+    if (!PrivacyGuardState::isPrivacyGuardInstanceInitialized()) {
         return false;
     }
-    spPrivacyGuard->SetEnabled(static_cast<bool>(isEnabled));
+    PrivacyGuardState::getPrivacyGuardInstance()->SetEnabled(static_cast<bool>(isEnabled));
     return true;
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_microsoft_applications_events_PrivacyGuard_isEnabled(JNIEnv *env, jclass /*this*/) {
-    return spPrivacyGuard != nullptr && spPrivacyGuard->IsEnabled();
+    return PrivacyGuardState::isPrivacyGuardInstanceInitialized() && PrivacyGuardState::getPrivacyGuardInstance()->IsEnabled();
 }
 
 JNIEXPORT jboolean JNICALL
@@ -120,11 +97,11 @@ Java_com_microsoft_applications_events_PrivacyGuard_nativeAppendCommonDataContex
         jobjectArray languageIdentifiers,
         jobjectArray machineIds,
         jobjectArray outOfScopeIdentifiers) {
-    if (spPrivacyGuard == nullptr) {
+    if (!PrivacyGuardState::isPrivacyGuardInstanceInitialized()) {
         return false;
     }
 
-    spPrivacyGuard->AppendCommonDataContext(GenerateCommonDataContextObject(env,
+    PrivacyGuardState::getPrivacyGuardInstance()->AppendCommonDataContext(PrivacyGuardState::GenerateCommonDataContextObject(env,
                                                                             domainName,
                                                                             machineName,
                                                                             userName,
@@ -143,14 +120,14 @@ Java_com_microsoft_applications_events_PrivacyGuard_nativeAddIgnoredConcern(JNIE
         jstring eventName,
         jstring fieldName,
         jint dataConcern) {
-    if (spPrivacyGuard == nullptr) {
+    if (!PrivacyGuardState::isPrivacyGuardInstanceInitialized()) {
         return;
     }
 
     auto eventNameStr = JStringToStdString(env, eventName);
     auto fieldNameStr = JStringToStdString(env, fieldName);
     auto dataConcernInt = static_cast<uint8_t>(dataConcern);
-    spPrivacyGuard->AddIgnoredConcern(eventNameStr, fieldNameStr, static_cast<DataConcernType >(dataConcernInt));
+    PrivacyGuardState::getPrivacyGuardInstance()->AddIgnoredConcern(eventNameStr, fieldNameStr, static_cast<DataConcernType >(dataConcernInt));
 }
 
 }


### PR DESCRIPTION
The current implementation of Privacy Guard does not work with multiple log manager scenario.

This change introduces PrivacyGuardState class that holds and maintains the PrivacyGuard shared_ptr. It then conveys the ptr to LogManager_jni or PrivacyGuard_jni as needed. Only the PrivacyGuard initialization and unregister operations are added as LogManager specific, the other operations can still be performed via the PrivacyGuard object directly.