### PR TITLE
Add support for custom r: device IDs

### DIFF
--- a/lib/api/ContextFieldsProvider.cpp
+++ b/lib/api/ContextFieldsProvider.cpp
@@ -196,6 +196,7 @@ namespace MAT_NS_BEGIN
                         size_t len = strlen(deviceId);
                         if (len >= 2 && deviceId[1] == ':' && (
                             deviceId[0] == 'c' || // c: Custom identifier
+                            deviceId[0] == 'r' || // r: Randomized identifier
                             deviceId[0] == 'u' || // u: Mac OS X UUID
                             deviceId[0] == 'a' || // a: Android ID
                             deviceId[0] == 's' || // s: SQM ID

--- a/lib/pal/desktop/WindowsDesktopSystemInformationImpl.cpp
+++ b/lib/pal/desktop/WindowsDesktopSystemInformationImpl.cpp
@@ -31,12 +31,6 @@
 
 #include <string>
 
-// This define is only available for TH1+
-// Issue #61 now tracks a fix that should work for win7+
-#ifndef RRF_SUBKEY_WOW6464KEY
-#define RRF_SUBKEY_WOW6464KEY  0x00010000  // when opening the subkey (if provided) force open from the 64bit location (only one SUBKEY_WOW64* flag can be set or RegGetValue will fail with ERROR_INVALID_PARAMETER)
-#endif
-
 using namespace MAT;
 
 namespace PAL_NS_BEGIN {

--- a/lib/pal/desktop/WindowsDesktopSystemInformationImpl.cpp
+++ b/lib/pal/desktop/WindowsDesktopSystemInformationImpl.cpp
@@ -31,6 +31,12 @@
 
 #include <string>
 
+// This define is only available for TH1+
+// Issue #61 now tracks a fix that should work for win7+
+#ifndef RRF_SUBKEY_WOW6464KEY
+#define RRF_SUBKEY_WOW6464KEY  0x00010000  // when opening the subkey (if provided) force open from the 64bit location (only one SUBKEY_WOW64* flag can be set or RegGetValue will fail with ERROR_INVALID_PARAMETER)
+#endif
+
 using namespace MAT;
 
 namespace PAL_NS_BEGIN {


### PR DESCRIPTION
Cherry-picking from release branch to prevent us from having to cherry-pick explicitly to multiple releases.