### PR TITLE
Fix error: ctmacros.hpp file not found with <angled> include

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -10,7 +10,7 @@
 #define BUILD_VERSION 3,5,117,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
-#include <ctmacros.hpp>
+#include "ctmacros.hpp"
 #include <stdint.h>
 
 namespace MAT_NS_BEGIN {

--- a/lib/include/public/Version.hpp.template
+++ b/lib/include/public/Version.hpp.template
@@ -10,7 +10,7 @@
 #define BUILD_VERSION @BUILD_VERSION_MAJOR@,@BUILD_VERSION_MINOR@,@BUILD_VERSION_PATCH@,@BUILD_NUMBER@
 
 #ifndef RESOURCE_COMPILER_INVOKED
-#include <ctmacros.hpp>
+#include "ctmacros.hpp"
 #include <stdint.h>
 
 namespace MAT_NS_BEGIN {


### PR DESCRIPTION
Cherry-picking from release branch to prevent us from having to cherry-pick explicitly to multiple releases.