### PR TITLE
ID in /etc/os-release on openSUSE contains quotes

### DIFF
--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -218,7 +218,7 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
 #if defined(__linux__)
     // Obtain Linux system information from filesystem
     add("devId", { "/etc/machine-id", "*"});
-    add("osName", {"/etc/os-release", ".*ID=(.*)[\n]+"});
+    add("osName", {"/etc/os-release", ".*ID=\"(.*)\"[\n]+|.*ID=(.*)[\n]+"});
     add("osVer", {"/etc/os-release", ".*VERSION_ID=\"(.*)\".*"});
     add("osRel", {"/etc/os-release", ".*VERSION=\"(.*)\".*"});
     add("osBuild", {"/proc/version", "(.*)[\n]+"});


### PR DESCRIPTION
ext_os_name string on openSUSE may contain quotes for example,
"opensuse-leap"
"opensuse-tumbleweed"
We would like to remove these quotes.