### PR TITLE
ID in /etc/os-release on openSUSE contains quotes

### DIFF
--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -225,6 +225,14 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
     // add("proc_loadavg", {"/proc/loadavg", "(.*)[\n]*"});
     // add("proc_uptime", {"/proc/uptime", "(.*)[\n]*"});
 
+    // osName may contain quotes on openSUSE
+    if (get("osName").find('"') == 0)
+    {
+        (*this).erase("osName");
+        cache.erase("osName");
+        add("osName", {"/etc/os-release", ".*ID=\"(.*)\"[\n]+"});
+    }
+
     time_t t = time(NULL);
 
 #if defined(__clang__)

--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -230,7 +230,7 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
     {
         std::string contents = get("osName");
         size_t pos_end_quote = contents.rfind('"');
-        if (pos_end_quote > 0)
+        if (pos_end_quote != std::string::npos && pos_end_quote > 0)
         {
             cache["osName"] = contents.substr(1, pos_end_quote - 1);
         }

--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -228,9 +228,12 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
     // osName may contain quotes on openSUSE
     if (get("osName").find('"') == 0)
     {
-        (*this).erase("osName");
-        cache.erase("osName");
-        add("osName", {"/etc/os-release", ".*ID=\"(.*)\"[\n]+"});
+        std::string contents = get("osName");
+        size_t pos_end_quote = contents.rfind('"');
+        if (pos_end_quote > 0)
+        {
+            cache["osName"] = contents.substr(1, pos_end_quote - 1);
+        }
     }
 
     time_t t = time(NULL);


### PR DESCRIPTION
ext_os_name string on openSUSE may contain quotes for example,
"opensuse-leap"
"opensuse-tumbleweed"
We would like to remove these quotes.