### PR TITLE
Fix missing header in PayloadDecoder

### DIFF
--- a/lib/decoder/PayloadDecoder.cpp
+++ b/lib/decoder/PayloadDecoder.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include "PayloadDecoder.hpp"
+#include "mat/config.h"
 
 #if !defined(HAVE_MAT_ZLIB) || !defined(HAVE_MAT_JSONHPP)
 


### PR DESCRIPTION
This causes the ZLIB flag to be false and LiveDataInspector, amongst other thing, is unable to decode the data.