### PR TITLE
Add mat/config.h include to PayloadDecoder.cpp as it is causing undesired behavior in MS Edge.

### DIFF
--- a/lib/decoder/PayloadDecoder.cpp
+++ b/lib/decoder/PayloadDecoder.cpp
@@ -2,9 +2,9 @@
 // Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
 // SPDX-License-Identifier: Apache-2.0
 //
-#include "PayloadDecoder.hpp"
-
 #include "mat/config.h"
+
+#include "PayloadDecoder.hpp"
 
 #if !defined(HAVE_MAT_ZLIB) || !defined(HAVE_MAT_JSONHPP)
 

--- a/lib/decoder/PayloadDecoder.cpp
+++ b/lib/decoder/PayloadDecoder.cpp
@@ -4,6 +4,8 @@
 //
 #include "PayloadDecoder.hpp"
 
+#include "mat/config.h"
+
 #if !defined(HAVE_MAT_ZLIB) || !defined(HAVE_MAT_JSONHPP)
 
 /* PayloadDecoder functionality requires ZLib and json.hpp.


### PR DESCRIPTION
Add mat/config.h include to ensure that we have access to CONFIG_CUSTOM_H for clients to use customized defines, such as Edge.