### PR TITLE
[Obj-Wrapper] Set canUseSDk flag to false before pause transmission

### DIFF
--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -269,9 +269,18 @@ static BOOL _initialized = false;
 
 +(void)pauseTransmission
 {
-    PerformActionWithCppExceptionsCatch(^(void) {
+    try
+    {
         LogManager::PauseTransmission();
-    });
+    }
+    catch (const std::exception &e)
+    {
+        if ([ODWLogConfiguration surfaceCppExceptions])
+        {
+            [ODWLogger raiseException: e.what()];
+        }
+        [ODWLogger traceException: e.what()];
+    }
 }
 
 +(void)resumeTransmission
@@ -312,8 +321,8 @@ static BOOL _initialized = false;
     });
 }
 +(void)applicationWillTerminate {
-    [ODWLogManager pauseTransmission];
     canUseSDK = false;
+    [ODWLogManager pauseTransmission];
     [ODWLogManager flushAndTeardown];
 }
 @end


### PR DESCRIPTION
**Background**:
There is a race between last logging and OneDS engine shutdown.
The odds are stacked against us in that race in Teams iOS code. As the last item in -[TeamSpaceApp applicationWillTerminate:] in our code we are logging:
`LogInfoAH(logger, @"appWillTerminate");`

Then we give the control back to the OS, which sends the notification about the same to all registered listeners, including our TSOneDSTelemetryLogManager. The logged info is being dispatched in the background at the same time. So we spend some time before we reach that place where we set `canUseSDK=false`. To speed up the process:

1. do not log that info in the last moment
2. do not rely on iOS NotificationCanter to deliver the applicationWillTerminate message
3. speed up to set the flag by calling the applicationWillTerminate directly

The below PR addresses the first two points in Teams
[Pull Request 351617: Workaround for shutdown timing issue with applicationWillTerminate and OneDS logging engine](https://domoreexp.visualstudio.com/Teamspace/_git/Teamspace-iOS/pullrequest/351617)


**Changes in this PR:**
This PR addresses the point no 3. in this, where we want to set `canUseSDK=false` in `ODWLogManager.mm` as early as possible. So, moved the statement `canUseSDK=false` before calling `pauseTransmission` in `applicationWillTerminate` method of `ODWLogManager.mm`. 
Also, since `pauseTransmission` method of `ODWLogManager.mm` calls the same method of `ILoggerManager`  using `PerformActionWithCppExceptionsCatch`, and which in itself checks for `canUseSDK` , so in this PR, changed the `pauseTransmission` method to directly call the `ILoggerManager's`  `pauseTransmission` method directly.