### PR TITLE
Illegal Character Causing Build Errors in MSVC

### DIFF
--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -399,7 +399,7 @@ namespace PAL_NS_BEGIN {
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"  // error: ‘T’ directive output may be truncated writing 1 byte into a region of size between 0 and 16 [-Werror=format-truncation=]
+#pragma GCC diagnostic ignored "-Wformat-truncation"  // error: 'T' directive output may be truncated writing 1 byte into a region of size between 0 and 16 [-Werror=format-truncation=]
 #endif
         (void)snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
                        1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,


### PR DESCRIPTION
When compiling on MSVC, `PAL.cpp` throws this warning (which is treated as an error).
```
warning C4828: The file contains a character starting at offset 0x321a that is illegal in the current source character set (codepage 65001)
```

Changing from the "curly quote" ( ` ‘T’ ` ) to a standard one ( ` 'T' ` ) fixes this issue.