### PR TITLE
Fix Visual Studio 2019 build issues in samples

### DIFF
--- a/Solutions/win10-cs/win10-cs.vcxproj
+++ b/Solutions/win10-cs/win10-cs.vcxproj
@@ -47,6 +47,15 @@
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
+    <!-- Try to autodetect the PlatformToolset depending on VisualStudioVersion                       -->
+    <!-- NOTE: please use your best judgement as to what PlatformToolset is required for your project -->
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <!-- Fallback to Visual Studio 2017 (v141) toolset by default -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="ExcludeSqlite" Condition="'$(NOSQLITE)'=='TRUE'">
     <NoSqlite>TRUE</NoSqlite>

--- a/Solutions/win10-lib/win10-lib.vcxproj
+++ b/Solutions/win10-lib/win10-lib.vcxproj
@@ -48,6 +48,15 @@
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ProjectName>win10-lib</ProjectName>
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
+    <!-- Try to autodetect the PlatformToolset depending on VisualStudioVersion                       -->
+    <!-- NOTE: please use your best judgement as to what PlatformToolset is required for your project -->
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <!-- Fallback to Visual Studio 2017 (v141) toolset by default -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/examples/c/SampleC/SampleC.vcxproj
+++ b/examples/c/SampleC/SampleC.vcxproj
@@ -14,6 +14,19 @@
     <ProjectGuid>{277AEB2C-E995-4A40-B63A-B16B8A3A4550}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SampleC</RootNamespace>
+    <!-- This project can even be compiled using Visual Studio 2010 (v100) because C API is C89 compatible. -->
+    <!-- But it is virtually impossible to find a customer who'd be needing that in 2021.                   -->
+    <!-- Moreover, it is impractical for a developer to have Visual Studio 2010 installed on machine.       -->
+    <!-- Given the circumstances, we make a tough call to upgrade this C sample from v100 to at least v141. -->
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
+    <!-- Try to autodetect the PlatformToolset depending on VisualStudioVersion                       -->
+    <!-- NOTE: please use your best judgement as to what PlatformToolset is required for your project -->
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <!-- Fallback to Visual Studio 2017 (v141) toolset by default -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/examples/cpp/SampleCppUWP/SampleCppUWP.vcxproj
+++ b/examples/cpp/SampleCppUWP/SampleCppUWP.vcxproj
@@ -8,7 +8,6 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ProjectName>SampleCppUWP</ProjectName>
     <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>

--- a/examples/cpp/SampleCppUWP/SampleCppUWP.vcxproj
+++ b/examples/cpp/SampleCppUWP/SampleCppUWP.vcxproj
@@ -11,6 +11,15 @@
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ProjectName>SampleCppUWP</ProjectName>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
+    <!-- Try to autodetect the PlatformToolset depending on VisualStudioVersion                       -->
+    <!-- NOTE: please use your best judgement as to what PlatformToolset is required for your project -->
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <!-- Fallback to Visual Studio 2017 (v141) toolset by default -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
@@ -50,46 +59,38 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
In short, the essence of this fix:
1. Try to autodetect the latest Windows 10 SDK.
2. Try to autodetect the Visual Studio version:
- if Visual Studio 2019 is detected, then use `v142` tooling for the samples.
- if Visual Studio 2017 is detected, then use `v141` tooling for the samples.

This ensures that if we "Build All..." in Visual Studio 2019 IDE, even without v141 (vs2017) tools installed, all projects including samples are built successfully.