### PR TITLE
Add configuration example that includes A/B EXP feature

### DIFF
--- a/lib/include/mat/config-default-exp.h
+++ b/lib/include/mat/config-default-exp.h
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2015-2020 Microsoft Corporation and Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#define EVTSDK_VERSION_PREFIX "EVT"
+#if defined(_WIN32)
+#if defined __has_include
+#  if __has_include ("modules/azmon/AITelemetrySystem.hpp")
+#    define HAVE_MAT_AI
+#  endif
+#  if __has_include ("modules/utc/UtcTelemetrySystem.hpp")
+#    define HAVE_MAT_UTC
+#  endif
+#endif
+#endif
+#define HAVE_MAT_EXP
+#define HAVE_MAT_FIFOSTORAGE
+//#define HAVE_MAT_DEFAULTDATAVIEWER
+#define HAVE_MAT_JSONHPP
+#define HAVE_MAT_ZLIB
+#define HAVE_MAT_LOGGING
+#define HAVE_MAT_STORAGE
+#define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_MAT_LIVEEVENTINSPECTOR
+#define HAVE_MAT_PRIVACYGUARD
+//#define HAVE_MAT_DEFAULT_FILTER
+#if defined(_WIN32) && !defined(_WINRT_DLL)
+#define HAVE_MAT_NETDETECT
+#endif
+#define HAVE_CS3
+//#define HAVE_CS4
+//#define HAVE_CS4_FULL
+


### PR DESCRIPTION
New build config. Follow [this process](https://github.com/microsoft/cpp_client_telemetry/blob/master/docs/building-custom-SKU.md) to build with EXP. Use `CONFIG_CUSTOM_H=config-default-exp.h`.

@anaaru - alternatively you may also use this to diff against the standard `config-default.h` and just patch it as part of vcpkg process. The only change is removing gated check around `HAVE_MAT_EXP` and `HAVE_MAT_FIFOSTORAGE`.

Third option is to pass `HAVE_PRIVATE_MODULES`, I think you already handled that.