### PR TITLE
Remove unused mutex that triggers clang-11 compiler warning (and error)

### DIFF
--- a/lib/stats/MetaStats.cpp
+++ b/lib/stats/MetaStats.cpp
@@ -10,11 +10,6 @@
 namespace MAT_NS_BEGIN {
 
     /// <summary>
-    /// Lock metaStats counts when rejected events come in via a separate thread
-    /// </summary>
-    static std::mutex rejected_callback_mtx;
-
-    /// <summary>
     /// Converts RollUpKind enum value to string name.
     /// </summary>
     /// <param name="rollupKind">Kind of the rollup.</param>


### PR DESCRIPTION
This issue appears to be unique to clang-11 on Linux. Compiler triggers warning about unused variable. That warning on latest is now treated as error. Removing the unused mutex to fix the error.