### PR TITLE
Add CI for dev branch

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,12 +4,17 @@ on:
   push:
     branches:
     - master
+    - dev
+    - dev/*
     - release/*
     - buildme/*
     - maharrim/*
+
   pull_request:
     branches:
     - master
+    - dev
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build-ios-latest.yml
+++ b/.github/workflows/build-ios-latest.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches:
     - master
+    - dev
+    - dev/*
     - release/*
     - buildme/*
+
   pull_request:
     branches:
     - master
+    - dev
+
   schedule:
   - cron: 0 2 * * 1-5
 

--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches:
     - master
+    - dev
+    - dev/*
     - release/*
     - buildme/*
+
   pull_request:
     branches:
     - master
+    - dev
+
   schedule:
   - cron: 0 2 * * 1-5
 

--- a/.github/workflows/build-windows-clang.yaml.off
+++ b/.github/workflows/build-windows-clang.yaml.off
@@ -4,9 +4,12 @@ on:
   push:
     branches:
     - master
+    - dev
+
   pull_request:
     branches:
     - master
+    - dev
 
 jobs:
   build:

--- a/.github/workflows/build-windows-vs2017.yaml.off
+++ b/.github/workflows/build-windows-vs2017.yaml.off
@@ -4,9 +4,12 @@ on:
   push:
     branches:
     - master
+    - dev
+
   pull_request:
     branches:
     - master
+    - dev
 
 jobs:
   build:

--- a/.github/workflows/build-windows-vs2019.yaml
+++ b/.github/workflows/build-windows-vs2019.yaml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
     - master
+    - dev
+
   pull_request:
     branches:
     - master
+    - dev
 
 jobs:
   build:

--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -4,12 +4,17 @@ on:
   push:
     branches:
     - master
+    - dev
+    - dev/*
     - release/*
     - buildme/*
     - maharrim/*
+
   pull_request:
     branches:
     - master
+    - dev
+
   schedule:
     - cron: '17 */4 * * *'
 jobs:

--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches:
     - master
+    - dev
+    - dev/*
     - release/*
     - buildme/*
+
   pull_request:
     branches:
     - master
+    - dev
+
   schedule:
   - cron: 0 2 * * 1-5
 


### PR DESCRIPTION
Add `dev` branch to CI and Pull Request process. This would guarantee that any changes we implement in `v4` are stable and mergeable back into `master` ( `main` ) as a full-promote, whenever we are ready for that.