### PR TITLE
[WIP] Disable linter for Android builds to unblock / resolve CI failures

### DIFF
--- a/lib/android_build/app/build.gradle
+++ b/lib/android_build/app/build.gradle
@@ -3,6 +3,12 @@ apply plugin: 'com.android.application'
 apply from: "$rootProject.projectDir/tools.gradle"
 
 android {
+
+    lintOptions {
+        checkReleaseBuilds false
+        abortOnError false
+    }
+
     defaultConfig {
         applicationId "com.microsoft.applications.events.maesdktest"
         versionCode 1


### PR DESCRIPTION
This is slightly outside of my ownership domain. But since this is blocking our CI, I feel we need to solve the issue.

CI fails because it can't download `groovy-all-2.4.15.jar`. It is not clear what is triggering this issue. As we have changed nothing, and most likely it's the change in the GitHub runner image. I found this [StackOverflow thread](https://stackoverflow.com/questions/53108438/could-not-download-groovy-all-jar-org-codehaus-groovygroovy-all2-4-15-in-and) that recommends a few solutions.

One solution is to disable the app linter. Which will in turn should stop downloading the offending package, that for some strange reason, fails to download. I suspect that it's either very slow connection on the runner, or defender running on host that detects some false-positive in the .jar, and blocks it from being downloaded. So the "fix" is to avoid downloading it.

What it gives --> Android CI should start running tests again (fingers crossed).

@larvacea @anod 

Ad-hoc tested on Windows. Build still works fine with my change:

![image](https://user-images.githubusercontent.com/34072974/124330686-cf77ee00-db42-11eb-9385-64784a46ca85.png)
