### PR TITLE
[WIP] Fix Android test loop failure on Mac

### DIFF
--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2.19.0
+      uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: ${{ matrix.api-level }}
         ndk: 21.1.6352462
@@ -65,7 +65,7 @@ jobs:
         script: echo "Generated AVD snapshot for caching."
 
     - name: Build and Test
-      uses: reactivecircus/android-emulator-runner@v2.19.0
+      uses: reactivecircus/android-emulator-runner@v2
       with:
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
 
     - name: Build and Test
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@v2.19.0
       with:
         api-level: 29
         ndk: 21.1.6352462

--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         api-level: [29]

--- a/.github/workflows/test-android-mac.yml
+++ b/.github/workflows/test-android-mac.yml
@@ -17,9 +17,14 @@ on:
 
   schedule:
     - cron: '17 */4 * * *'
+
 jobs:
   build:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [29]
+
     name: Android Unit Tests (Mac)
     steps:
 
@@ -29,14 +34,48 @@ jobs:
         submodules: 'true'
       continue-on-error: true
 
+    - name: Gradle cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+
+    - name: AVD cache
+      uses: actions/cache@v2
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.api-level }}
+
+    - name: Create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2.19.0
+      with:
+        api-level: ${{ matrix.api-level }}
+        ndk: 21.1.6352462
+        cmake: 3.10.2.4988404
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        working-directory: ./lib/android_build
+        script: echo "Generated AVD snapshot for caching."
+
     - name: Build and Test
       uses: reactivecircus/android-emulator-runner@v2.19.0
       with:
-        api-level: 29
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        api-level: ${{ matrix.api-level }}
         ndk: 21.1.6352462
         cmake: 3.10.2.4988404
         working-directory: ./lib/android_build
         script: ./testandlog
+
     - name: Upload
       if: ${{ always() }}
       uses: actions/upload-artifact@v2

--- a/lib/android_build/app/build.gradle
+++ b/lib/android_build/app/build.gradle
@@ -3,12 +3,6 @@ apply plugin: 'com.android.application'
 apply from: "$rootProject.projectDir/tools.gradle"
 
 android {
-
-    lintOptions {
-        checkReleaseBuilds false
-        abortOnError false
-    }
-
     defaultConfig {
         applicationId "com.microsoft.applications.events.maesdktest"
         versionCode 1

--- a/lib/android_build/app/build.gradle
+++ b/lib/android_build/app/build.gradle
@@ -3,6 +3,12 @@ apply plugin: 'com.android.application'
 apply from: "$rootProject.projectDir/tools.gradle"
 
 android {
+
+    lintOptions {
+        checkReleaseBuilds false
+        abortOnError false
+    }
+
     defaultConfig {
         applicationId "com.microsoft.applications.events.maesdktest"
         versionCode 1

--- a/lib/android_build/build.gradle
+++ b/lib/android_build/build.gradle
@@ -4,9 +4,8 @@ ext {
 
 buildscript {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
-        
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
@@ -18,8 +17,8 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
-        jcenter()        
     }
 }
 

--- a/lib/android_build/build.gradle
+++ b/lib/android_build/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lib/android_build/build.gradle
+++ b/lib/android_build/build.gradle
@@ -4,8 +4,9 @@ ext {
 
 buildscript {
     repositories {
-        mavenCentral()
         google()
+        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
@@ -17,8 +18,9 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
         google()
+        mavenCentral()
+        jcenter()
     }
 }
 

--- a/lib/android_build/gradle/wrapper/gradle-wrapper.properties
+++ b/lib/android_build/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/lib/android_build/testandlog
+++ b/lib/android_build/testandlog
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-./gradlew app:connectedDebugAndroidTest
+./gradlew app:connectedDebugAndroidTest --refresh-dependencies
 RC=$?
 adb logcat -t 2000 MAE:D '*:E' > ./logcat.txt
 exit $RC

--- a/lib/android_build/testandlog.cmd
+++ b/lib/android_build/testandlog.cmd
@@ -1,0 +1,2 @@
+call .\gradlew.bat app:connectedDebugAndroidTest --refresh-dependencies
+adb.exe logcat -t 2000 MAE:D '*:E' > logcat.txt

--- a/lib/android_build/tools.gradle
+++ b/lib/android_build/tools.gradle
@@ -2,7 +2,7 @@ android {
 
     compileSdkVersion    = 29
 
-    buildToolsVersion    = "29.0.3"
+    buildToolsVersion    = "30.0.2"
 
     ndkVersion           = System.getenv("ANDROID_NDK_VERSION") ?: "21.1.6352462"
 


### PR DESCRIPTION
Fixes #901

JCenter shutdown: https://docs.microsoft.com/en-us/appcenter/build/android/jcentershut caused our build loops to fail.

**Changes**

Merit of all these changes is to ensure that we no longer attempt to pull anything from jcenter anymore. Thus, resolving the issue that this old artifacts repo was shutdown in May. There is no change to SDK nor NDK versions, only build tools have been upgraded.

- switch to `mavenCentral` binary artifacts repo before `jcenter` (eventually need to remove `jcenter`)
- ~~update `reactivecircus/android-emulator-runner` to latest presently available version~~
- use latest gradle tools `com.android.tools.build:gradle:4.2.0`
- use latest `gradle-6.7.1`
- use `--refresh-dependencies` flag to refetch latest versions, ignoring cache
- add equivalent to Unix test script for a Windows runner (just a dev-focused script, not used in CI)
- upgrade `buildToolsVersion` to **30.0.2**

UPDATE: the build is getting stuck due to so many things to be downloaded. I'm adding GitHub cache Action here to try speed it up.