### PR TITLE
Update EventPropertiesDecorator to respect the value set by SetTimestamp

### DIFF
--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -114,6 +114,9 @@ namespace MAT_NS_BEGIN {
                 record.data.push_back(data);
             }
 
+            if (eventProperties.GetTimestamp() != 0)
+                record.time = eventProperties.GetTimestamp();
+
             record.popSample = eventProperties.GetPopSample();
 
             // API surface tags('flags') are different from on-wire record.flags

--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -114,8 +114,9 @@ namespace MAT_NS_BEGIN {
                 record.data.push_back(data);
             }
 
-            if (eventProperties.GetTimestamp() != 0)
-                record.time = eventProperties.GetTimestamp();
+            auto timestamp = eventProperties.GetTimestamp();
+            if (timestamp != 0)
+                record.time = timestamp;
 
             record.popSample = eventProperties.GetPopSample();
 


### PR DESCRIPTION
EventPropertiesDecorator ignores any value specified in EventProperties::SetTimestamp and all records get the timestamp value set in BaseDecorator (PAL::getUtcSystemTimeinTicks()).  This change updates EventPropertiesDecorator::decorate to set record.time to eventProperties.GetTimestamp() if it is non-zero.