### PR TITLE
honor no-rtti setting

### DIFF
--- a/lib/pal/typename.hpp
+++ b/lib/pal/typename.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <typeinfo>
 
-#ifdef __GNUG__
+#if defined(_CPPRTTI) && defined(__GNUG__)
 #include <cstdlib>
 #include <memory>
 #include <cxxabi.h>
@@ -35,4 +35,3 @@ __inline static std::string demangle(const char* name) {
 #endif
 
 #endif
-


### PR DESCRIPTION
The `TYPENAME` method should honor the `no-rtti` build flag when using GCC building, just like win32 does.