### PR TITLE
Adding Config Option to Disable Zombie Logger Logic

### DIFF
--- a/lib/include/public/ILogConfiguration.hpp
+++ b/lib/include/public/ILogConfiguration.hpp
@@ -185,6 +185,11 @@ namespace MAT_NS_BEGIN
     static constexpr const char* const CFG_INT_MAX_TEARDOWN_TIME = "maxTeardownUploadTimeInSec";
 
     /// <summary>
+    /// Disable zombie logger logic.
+    /// </summary>
+    static constexpr const char* const CFG_BOOL_DISABLE_ZOMBIE_LOGGERS = "disableZombieLoggers";
+
+    /// <summary>
     /// The maximum number of pending HTTP requests.
     /// </summary>
     static constexpr const char* const CFG_INT_MAX_PENDING_REQ = "maxPendingHTTPRequests";


### PR DESCRIPTION
We want to add the ability to disable deferred cleanup of the loggers, so that XAL's cleanup properly cleans up, and our clients can test for memory leaks correctly. 

Happy to change flag name if it's not inline with your style guide.

@lubeltra for vis 