### PR TITLE
Prep step for migration from master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 labels: bug
 ---
 
-**Describe your environment.** Describe any aspect of your environment relevant to the problem, including your SDK version, platform, OS version, etc. If you're reporting a problem with a specific version of a library in this repo, please check whether the problem has been fixed on master.
+**Describe your environment.** Describe any aspect of your environment relevant to the problem, including your SDK version, platform, OS version, etc. If you're reporting a problem with a specific version of a library in this repo, please check whether the problem has been fixed on main brach.
 
 **Steps to reproduce.**
 Describe exactly how to reproduce the error. Include a code sample if applicable.

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
     - dev/*
     - release/*
@@ -13,6 +14,7 @@ on:
   pull_request:
     branches:
     - master
+    - main
     - dev
 
 jobs:

--- a/.github/workflows/build-ios-latest.yml
+++ b/.github/workflows/build-ios-latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
     - dev/*
     - release/*
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches:
     - master
+    - main
     - dev
 
   schedule:

--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
     - dev/*
     - release/*
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches:
     - master
+    - main
     - dev
 
   schedule:

--- a/.github/workflows/build-windows-clang.yaml.off
+++ b/.github/workflows/build-windows-clang.yaml.off
@@ -4,11 +4,13 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
 
   pull_request:
     branches:
     - master
+    - main
     - dev
 
 jobs:

--- a/.github/workflows/build-windows-vs2017.yaml.off
+++ b/.github/workflows/build-windows-vs2017.yaml.off
@@ -4,11 +4,13 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
 
   pull_request:
     branches:
     - master
+    - main
     - dev
 
 jobs:

--- a/.github/workflows/build-windows-vs2019.yaml
+++ b/.github/workflows/build-windows-vs2019.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
 
   pull_request:
     branches:
     - master
+    - main
     - dev
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [ master, main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [ master, main ]
   schedule:
     - cron: '0 8 * * 1'
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,9 +2,9 @@ name: spellcheck
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   build:

--- a/.github/workflows/test-android-mac.yml.off
+++ b/.github/workflows/test-android-mac.yml.off
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
     - dev/*
     - release/*
@@ -13,6 +14,7 @@ on:
   pull_request:
     branches:
     - master
+    - main
     - dev
 
   schedule:

--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - main
     - dev
     - dev/*
     - release/*
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches:
     - master
+    - main
     - dev
 
   schedule:


### PR DESCRIPTION
As discussed in #924, this is the first step for migration to main - adding `main` branch to the list of branches used to trigger actions in github actions.
