### PR TITLE
Migrate from master to main : fix master branch references

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ as the communication channel for both feature requests and issues.
 
 This project does not accept *Public* contributions at this time.
 
-**Microsoft-authorized contributors - please refer to contributing instructions [here](https://github.com/microsoft/cpp_client_telemetry_modules/blob/main/CONTRIBUTING.md).**
+**Microsoft-authorized contributors - please refer to contributing instructions [here](https://github.com/microsoft/cpp_client_telemetry_modules/blob/master/CONTRIBUTING.md).**
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ as the communication channel for both feature requests and issues.
 
 This project does not accept *Public* contributions at this time.
 
-**Microsoft-authorized contributors - please refer to contributing instructions [here](https://github.com/microsoft/cpp_client_telemetry_modules/blob/master/CONTRIBUTING.md).**
+**Microsoft-authorized contributors - please refer to contributing instructions [here](https://github.com/microsoft/cpp_client_telemetry_modules/blob/main/CONTRIBUTING.md).**
 
 ## Versioning
 

--- a/docs/Coding style.md
+++ b/docs/Coding style.md
@@ -186,5 +186,5 @@ this order:
 - Do white-space-only changes in a separate commit for clarity (null
     output for `git diff -w` etc.).
 - Squash small fixes and code-review changes into original commits.
-- Integrate changes from development branches to `master` using rebase
+- Integrate changes from development branches to `main` using rebase
     and fast-forward merge.

--- a/docs/List-of-OSS-Components.md
+++ b/docs/List-of-OSS-Components.md
@@ -6,19 +6,19 @@ These are the Open Source components used by Microsoft 1DS / C++ Client Telemetr
 
 ZLIB DATA COMPRESSION LIBRARY.
 
-SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/zlib).
+SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](../zlib).
 
 ## [SQLite](https://www.sqlite.org/index.html)
 
 SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine.
 
-SDK maintains its own snapshot of the mainline SQLite, which is used for Windows builds [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/sqlite). Other platforms use platform-provided SQLite.
+SDK maintains its own snapshot of the mainline SQLite, which is used for Windows builds [here](../sqlite). Other platforms use platform-provided SQLite.
 
 ## [nlohmann/json](https://github.com/nlohmann/json)
 
 JSON for Modern C++.
 
-SDK maintains its own snapshot of the mainline `nlohmann/json` header-only library [here](https://github.com/microsoft/cpp_client_telemetry/blob/main/lib/include/mat/json.hpp).
+SDK maintains its own snapshot of the mainline `nlohmann/json` header-only library [here](../lib/include/mat/json.hpp).
 
 ## [libcurl](https://curl.haxx.se/libcurl/)
 
@@ -37,12 +37,12 @@ Google's C++ benchmarking framework. Used only for tests and not included in pro
 ## [Tony Million Reachability Framework](https://github.com/tonymillion/Reachability)
 
 Reachability is a drop-in replacement for Apple's Reachability class. It is ARC-compatible, and it uses the new GCD methods to notify of network interface changes.
-SDK maintains its own snapshot of the mainline `tonymillion/Reachability` [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/third_party/Reachability). This code is not used nor included in the build of non-Apple OS.
+SDK maintains its own snapshot of the mainline `tonymillion/Reachability` [here](../third_party/Reachability). This code is not used nor included in the build of non-Apple OS.
 
 ## SHA-1 by Steve Reid
 
 Classic implementation of SHA-1 (Public Domain).
-SDK maintains its own snapshot of it [here](https://github.com/microsoft/cpp_client_telemetry/blob/main/third_party/sha1/sha1.c).
+SDK maintains its own snapshot of it [here](../third_party/sha1/sha1.c).
 Note that this component is not included or compiled into any of the shipable bits of SDK. It is included for internal developer debug builds only.
 For example, SHA-1 may be used to calculate destination ETW Provider GUID based on ETW Provider name on Windows OS in developer trace tooling / instrumentation.
 

--- a/docs/List-of-OSS-Components.md
+++ b/docs/List-of-OSS-Components.md
@@ -6,19 +6,19 @@ These are the Open Source components used by Microsoft 1DS / C++ Client Telemetr
 
 ZLIB DATA COMPRESSION LIBRARY.
 
-SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](https://github.com/microsoft/cpp_client_telemetry/tree/master/zlib).
+SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/zlib).
 
 ## [SQLite](https://www.sqlite.org/index.html)
 
 SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine.
 
-SDK maintains its own snapshot of the mainline SQLite, which is used for Windows builds [here](https://github.com/microsoft/cpp_client_telemetry/tree/master/sqlite). Other platforms use platform-provided SQLite.
+SDK maintains its own snapshot of the mainline SQLite, which is used for Windows builds [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/sqlite). Other platforms use platform-provided SQLite.
 
 ## [nlohmann/json](https://github.com/nlohmann/json)
 
 JSON for Modern C++.
 
-SDK maintains its own snapshot of the mainline `nlohmann/json` header-only library [here](https://github.com/microsoft/cpp_client_telemetry/blob/master/lib/include/mat/json.hpp).
+SDK maintains its own snapshot of the mainline `nlohmann/json` header-only library [here](https://github.com/microsoft/cpp_client_telemetry/blob/main/lib/include/mat/json.hpp).
 
 ## [libcurl](https://curl.haxx.se/libcurl/)
 
@@ -37,12 +37,12 @@ Google's C++ benchmarking framework. Used only for tests and not included in pro
 ## [Tony Million Reachability Framework](https://github.com/tonymillion/Reachability)
 
 Reachability is a drop-in replacement for Apple's Reachability class. It is ARC-compatible, and it uses the new GCD methods to notify of network interface changes.
-SDK maintains its own snapshot of the mainline `tonymillion/Reachability` [here](https://github.com/microsoft/cpp_client_telemetry/tree/master/third_party/Reachability). This code is not used nor included in the build of non-Apple OS.
+SDK maintains its own snapshot of the mainline `tonymillion/Reachability` [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/third_party/Reachability). This code is not used nor included in the build of non-Apple OS.
 
 ## SHA-1 by Steve Reid
 
 Classic implementation of SHA-1 (Public Domain).
-SDK maintains its own snapshot of it [here](https://github.com/microsoft/cpp_client_telemetry/blob/master/third_party/sha1/sha1.c).
+SDK maintains its own snapshot of it [here](https://github.com/microsoft/cpp_client_telemetry/blob/main/third_party/sha1/sha1.c).
 Note that this component is not included or compiled into any of the shipable bits of SDK. It is included for internal developer debug builds only.
 For example, SHA-1 may be used to calculate destination ETW Provider GUID based on ETW Provider name on Windows OS in developer trace tooling / instrumentation.
 

--- a/docs/cpp-start-android.md
+++ b/docs/cpp-start-android.md
@@ -137,9 +137,9 @@ LogManager::FlushAndTeardown();
 
 You're done! You can now compile and run your app, and it will send a telemetry event using your ingestion key to your tenant.
 
-Note that it is possible to use more than one log manager. See [examples/cpp/SampleCppLogManagers](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/SampleCppLogManagers) for a sample implementation.
+Note that it is possible to use more than one log manager. See [examples/cpp/SampleCppLogManagers](../examples/cpp/SampleCppLogManagers) for a sample implementation.
 
-Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/). The lib/android_build gradle wrappers will use the Android gradle plugin, and that in turn will use CMake/nmake to build C++ object files.
+Please refer to [EventSender](../examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](../examples/cpp/). The lib/android_build gradle wrappers will use the Android gradle plugin, and that in turn will use CMake/nmake to build C++ object files.
 
 ## 4. Device File Locations
 

--- a/docs/cpp-start-android.md
+++ b/docs/cpp-start-android.md
@@ -12,7 +12,7 @@ You will ideally build the SDK using the same versions of the Android SDK, NDK, 
 
 The Gradle wrapper in ```android_build``` builds two modules, ```app``` and ```maesdk```. The ```maesdk``` module is the SDK packaged as an AAR, with both the Java and C++ components included. The AAR includes C++ shared libraries for four ABIs (two ARM ABIs for devices and two Intel ABIs for the emulator). Android Gradle (as usual) supports debug and release builds, and the Gradle task ```maesdk:assemble``` should build both flavors of AAR.
 
-On Android, there are two database implementations to choose from. By default (the master branch on Github), the SDK will use the Android-supported androidx.Room database package. This reduces APK size because we don't need to compile and link in a copy of SQLite in native code (SQLite is hundreds of kB per ABI of APK file size). Room does have a slight CPU performance disadvantage since database transactions cross the JNI boundary when native code uses it. If you wish to change from Room to the native SQLite implementation, you should change the two module ```build.gradle``` files (app and maesdk). In those files, you will see an argument to CMake to select Room: ```"-DUSE_ROOM=1"```. Change this to ```"-DUSE_ROOM=0``` to select the native SQLite.
+On Android, there are two database implementations to choose from. By default (the main branch on Github), the SDK will use the Android-supported androidx.Room database package. This reduces APK size because we don't need to compile and link in a copy of SQLite in native code (SQLite is hundreds of kB per ABI of APK file size). Room does have a slight CPU performance disadvantage since database transactions cross the JNI boundary when native code uses it. If you wish to change from Room to the native SQLite implementation, you should change the two module ```build.gradle``` files (app and maesdk). In those files, you will see an argument to CMake to select Room: ```"-DUSE_ROOM=1"```. Change this to ```"-DUSE_ROOM=0``` to select the native SQLite.
 
 The Room database implementation adds one additional initialization requirement, since it needs a pointer to the JVM and an object reference to the application context. See below (4.5) for the required call to either ```connectContext``` (in Java) or ```ConnectJVM``` (in C++) to set this up.
 
@@ -137,9 +137,9 @@ LogManager::FlushAndTeardown();
 
 You're done! You can now compile and run your app, and it will send a telemetry event using your ingestion key to your tenant.
 
-Note that it is possible to use more than one log manager. See [examples/cpp/SampleCppLogManagers](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/SampleCppLogManagers) for a sample implementation.
+Note that it is possible to use more than one log manager. See [examples/cpp/SampleCppLogManagers](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/SampleCppLogManagers) for a sample implementation.
 
-Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/). The lib/android_build gradle wrappers will use the Android gradle plugin, and that in turn will use CMake/nmake to build C++ object files.
+Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/). The lib/android_build gradle wrappers will use the Android gradle plugin, and that in turn will use CMake/nmake to build C++ object files.
 
 ## 4. Device File Locations
 

--- a/docs/cpp-start-ios.md
+++ b/docs/cpp-start-ios.md
@@ -58,4 +58,4 @@ LogManager::FlushAndTeardown();
 
 You're done! You can now compile and run your app, and it will send a telemetry event using your ingestion key to your tenant.
 
-Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).
+Please refer to [EventSender](../examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](../examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).

--- a/docs/cpp-start-ios.md
+++ b/docs/cpp-start-ios.md
@@ -58,4 +58,4 @@ LogManager::FlushAndTeardown();
 
 You're done! You can now compile and run your app, and it will send a telemetry event using your ingestion key to your tenant.
 
-Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).
+Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).

--- a/docs/cpp-start-linux.md
+++ b/docs/cpp-start-linux.md
@@ -62,4 +62,4 @@ LogManager::FlushAndTeardown();
 
 You're done! You can now compile and run your app, and it will send a telemetry event using your ingestion key to your tenant.
 
-Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/master/examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).
+Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).

--- a/docs/cpp-start-linux.md
+++ b/docs/cpp-start-linux.md
@@ -62,4 +62,4 @@ LogManager::FlushAndTeardown();
 
 You're done! You can now compile and run your app, and it will send a telemetry event using your ingestion key to your tenant.
 
-Please refer to [EventSender](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](https://github.com/microsoft/cpp_client_telemetry/tree/main/examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).
+Please refer to [EventSender](../examples/cpp/EventSender) sample for more details. Other sample apps can be found [here](../examples/cpp/). All of our SDK samples require CMake build system, but you may consume the SDK using any other alternate build system of your choice (GNU Make, gn, etc.).

--- a/docs/cpp-start-windows.md
+++ b/docs/cpp-start-windows.md
@@ -68,7 +68,7 @@ depending on what Visual Studio version you are using.
 
 ## **Instrument your code to send a telemetry event**
 
-- Make sure you added the [public SDK headers](https://github.com/microsoft/cpp_client_telemetry/tree/master/lib/include/public) to [your project include path](https://docs.microsoft.com/en-us/cpp/build/reference/c-cpp-prop-page?view=msvc-160#additional-include-directories).
+- Make sure you added the [public SDK headers](https://github.com/microsoft/cpp_client_telemetry/tree/main/lib/include/public) to [your project include path](https://docs.microsoft.com/en-us/cpp/build/reference/c-cpp-prop-page?view=msvc-160#additional-include-directories).
 - Make sure you added the SDK that you built, e.g. `ClientTelemetry.lib` to [your project library path](https://docs.microsoft.com/en-us/cpp/build/reference/vcpp-directories-property-page).
 
 ### 1. Include the main 1DS C++ SDK header file in your main.cpp by adding the following statement to the top of your app's implementation file
@@ -113,6 +113,6 @@ More examples can be found under *examples* folder.
 - [CMake Tutorial](https://cmake.org/cmake/help/latest/guide/tutorial/index.html)
 - [Runtime Library Variants: static vs dynamic runtime](https://www.oreilly.com/library/view/c-cookbook/0596007612/ch01s24.html)
 
-If you encounter troubles building the project, please refer to our CI/Build pipeline settings [here](https://github.com/microsoft/cpp_client_telemetry/blob/master/.github/workflows/build-windows-vs2019.yaml). This pipeline runs on a standard GitHub image with a standard Visual Studio 2019 installation. If you are still stuck, please log your build question as [GitHub issue](https://github.com/microsoft/cpp_client_telemetry/issues) with labels `question` and `build infra`. We would be glad to help and adjust documentation accordingly.
+If you encounter troubles building the project, please refer to our CI/Build pipeline settings [here](https://github.com/microsoft/cpp_client_telemetry/blob/main/.github/workflows/build-windows-vs2019.yaml). This pipeline runs on a standard GitHub image with a standard Visual Studio 2019 installation. If you are still stuck, please log your build question as [GitHub issue](https://github.com/microsoft/cpp_client_telemetry/issues) with labels `question` and `build infra`. We would be glad to help and adjust documentation accordingly.
 
 If you find that some documentation is incorrect, please send a PR to fix it. We ❤️ community contributions!

--- a/docs/cpp-start-windows.md
+++ b/docs/cpp-start-windows.md
@@ -68,7 +68,7 @@ depending on what Visual Studio version you are using.
 
 ## **Instrument your code to send a telemetry event**
 
-- Make sure you added the [public SDK headers](https://github.com/microsoft/cpp_client_telemetry/tree/main/lib/include/public) to [your project include path](https://docs.microsoft.com/en-us/cpp/build/reference/c-cpp-prop-page?view=msvc-160#additional-include-directories).
+- Make sure you added the [public SDK headers](../lib/include/public) to [your project include path](https://docs.microsoft.com/en-us/cpp/build/reference/c-cpp-prop-page?view=msvc-160#additional-include-directories).
 - Make sure you added the SDK that you built, e.g. `ClientTelemetry.lib` to [your project library path](https://docs.microsoft.com/en-us/cpp/build/reference/vcpp-directories-property-page).
 
 ### 1. Include the main 1DS C++ SDK header file in your main.cpp by adding the following statement to the top of your app's implementation file
@@ -113,6 +113,6 @@ More examples can be found under *examples* folder.
 - [CMake Tutorial](https://cmake.org/cmake/help/latest/guide/tutorial/index.html)
 - [Runtime Library Variants: static vs dynamic runtime](https://www.oreilly.com/library/view/c-cookbook/0596007612/ch01s24.html)
 
-If you encounter troubles building the project, please refer to our CI/Build pipeline settings [here](https://github.com/microsoft/cpp_client_telemetry/blob/main/.github/workflows/build-windows-vs2019.yaml). This pipeline runs on a standard GitHub image with a standard Visual Studio 2019 installation. If you are still stuck, please log your build question as [GitHub issue](https://github.com/microsoft/cpp_client_telemetry/issues) with labels `question` and `build infra`. We would be glad to help and adjust documentation accordingly.
+If you encounter troubles building the project, please refer to our CI/Build pipeline settings [here](../.github/workflows/build-windows-vs2019.yaml). This pipeline runs on a standard GitHub image with a standard Visual Studio 2019 installation. If you are still stuck, please log your build question as [GitHub issue](https://github.com/microsoft/cpp_client_telemetry/issues) with labels `question` and `build infra`. We would be glad to help and adjust documentation accordingly.
 
 If you find that some documentation is incorrect, please send a PR to fix it. We ❤️ community contributions!

--- a/docs/dev-branch-process.md
+++ b/docs/dev-branch-process.md
@@ -4,25 +4,23 @@
 
 Naming convention is simple and straightforward.
 
-- **Master (master)** is the default branch available in the Git repository for the `current` release. Current SDK release is `v3.x`. This branch should be stable all the time and won’t allow any direct check-in. You can only merge it after code review. All team members are responsible for keeping the master stable and up-to-date.
+- **Main (main)** is the default branch available in the Git repository for the `current` release. Current SDK release is `v3.x`. This branch should be stable all the time and won’t allow any direct check-in. You can only merge it after code review. All team members are responsible for keeping the main stable and up-to-date.
 
-- **Development (dev)** is the main development branch for the next major release `v4.x`. The dev branch’s idea is to make changes in it and restrict the developers from making any changes in the master branch directly. Changes in the dev branch undergo reviews. When ready, the branch will be fully promoted to `master`.
+- **Development (dev)** is the main development branch for the next major release `v4.x`. The dev branch’s idea is to make changes in it and restrict the developers from making any changes in the main branch directly. Changes in the dev branch undergo reviews. When ready, the branch will be fully promoted to `main`.
 
-## `master` branch renaming to `main` would commence in 2021
-
-It is planned for `v4.x` branch to coincide with renaming of the `master` branch to `main`. Many communities, both on GitHub and in the wider Git community, are considering renaming the default branch name of their repository from `master`. We are also committed to gradually rename the default branch of our repository from `master` to `main`.
+- **Master (master)** is the copy of `main` branch created after migration of original `master` branch to `main` branch. The branch is temporarily created to ensure that builds for projects using this repo in their CI pipeline doesn't start breaking immediately after migration. This newly created copy is locked against any new commits, and would be deleted in future once all the teams hae migrated their CI pipelines to build from `main`.
 
 ## Continuous Integration on `dev` branch
 
-All of the existing tests are enabled on both `master` and `dev` branches. While implementing any refactoring changes, please adjust all tests accordingly.
+All of the existing tests are enabled on both `main` and `dev` branches. While implementing any refactoring changes, please adjust all tests accordingly.
 
 ## Documenting Feature and API changes
 
-Please use Markdown format to document any API changes from v3.x to v4.x in [docs directory](https://github.com/microsoft/cpp_client_telemetry/tree/master/docs).
+Please use Markdown format to document any API changes from v3.x to v4.x in [docs directory](https://github.com/microsoft/cpp_client_telemetry/tree/main/docs).
 
 ## Release labels for multiple versions
 
-While the `master` (`main`) branch contains linear history of all releases and associated git tags, it may be practical to branch-off specific releases for use in concrete products.
+While the `main` branch contains linear history of all releases and associated git tags, it may be practical to branch-off specific releases for use in concrete products.
 
 Sometimes a product may require a feature to be added on top of old long-term supported release.
 
@@ -38,7 +36,7 @@ All feature work made by maintainers on latest release (or `dev` branch) will no
 Commmitters use their best judgment if they'd like to backport a feature.
 
 In case of a backport of a new feature to old release, `release/$product/v3.x.y` branch would be created.
-Old release long-term support branches should never be full-promoted back into `dev` or `master` (`main`).
+Old release long-term support branches should never be full-promoted back into `dev` or `main`).
 
 Continuous Integration is enabled on `release/*` branches.
 

--- a/docs/dev-branch-process.md
+++ b/docs/dev-branch-process.md
@@ -16,7 +16,7 @@ All of the existing tests are enabled on both `main` and `dev` branches. While i
 
 ## Documenting Feature and API changes
 
-Please use Markdown format to document any API changes from v3.x to v4.x in [docs directory](https://github.com/microsoft/cpp_client_telemetry/tree/main/docs).
+Please use Markdown format to document any API changes from v3.x to v4.x in [docs directory](../docs).
 
 ## Release labels for multiple versions
 

--- a/docs/start_macOS_iOS.md
+++ b/docs/start_macOS_iOS.md
@@ -1,6 +1,6 @@
 # 1DS C++ SDK iOS/macOS Podspec Onboarding
 
-This tutorial guides you through the process of integrating the [1DS SDK](https://github.com/microsoft/cpp_client_telemetry) into your existing iOS and macOS app. Here we consume the [Msblox Podspec]() and published [Obj-C Wrappers](https://github.com/microsoft/cpp_client_telemetry/tree/master/wrappers/obj-c). If you want to consume the C++ Library directly, please follow the tutorials at [Getting started - iOS](https://github.com/microsoft/cpp_client_telemetry/blob/master/docs/cpp-start-ios.md) and [Getting Started - Mac OS X](https://github.com/microsoft/cpp_client_telemetry/blob/master/docs/cpp-start-macosx.md)
+This tutorial guides you through the process of integrating the [1DS SDK](https://github.com/microsoft/cpp_client_telemetry) into your existing iOS and macOS app. Here we consume the [Msblox Podspec]() and published [Obj-C Wrappers](https://github.com/microsoft/cpp_client_telemetry/tree/main/wrappers/obj-c). If you want to consume the C++ Library directly, please follow the tutorials at [Getting started - iOS](https://github.com/microsoft/cpp_client_telemetry/blob/main/docs/cpp-start-ios.md) and [Getting Started - Mac OS X](https://github.com/microsoft/cpp_client_telemetry/blob/main/docs/cpp-start-macosx.md)
 
 ## Add OneDsCppSdk Cocoapod to the Podfile
 

--- a/docs/start_macOS_iOS.md
+++ b/docs/start_macOS_iOS.md
@@ -1,6 +1,6 @@
 # 1DS C++ SDK iOS/macOS Podspec Onboarding
 
-This tutorial guides you through the process of integrating the [1DS SDK](https://github.com/microsoft/cpp_client_telemetry) into your existing iOS and macOS app. Here we consume the [Msblox Podspec]() and published [Obj-C Wrappers](https://github.com/microsoft/cpp_client_telemetry/tree/main/wrappers/obj-c). If you want to consume the C++ Library directly, please follow the tutorials at [Getting started - iOS](https://github.com/microsoft/cpp_client_telemetry/blob/main/docs/cpp-start-ios.md) and [Getting Started - Mac OS X](https://github.com/microsoft/cpp_client_telemetry/blob/main/docs/cpp-start-macosx.md)
+This tutorial guides you through the process of integrating the [1DS SDK](https://github.com/microsoft/cpp_client_telemetry) into your existing iOS and macOS app. Here we consume the [Msblox Podspec]() and published [Obj-C Wrappers](../wrappers/obj-c). If you want to consume the C++ Library directly, please follow the tutorials at [Getting started - iOS](./cpp-start-ios.md) and [Getting Started - Mac OS X](./cpp-start-macosx.md)
 
 ## Add OneDsCppSdk Cocoapod to the Podfile
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -7,12 +7,12 @@ If urgent critical fix is needed, then additional release could be published ahe
 
 SDK utilizes [SemVer 2.0](https://semver.org/) for its versioning.
 
-SDK version as of December 2020 is [v3.4.343](https://github.com/microsoft/cpp_client_telemetry/releases/tag/v3.4.343),
+SDK version as of September 2021 is [v3.5.200](https://github.com/microsoft/cpp_client_telemetry/releases/tag/v3.5.200),
 where:
 - `VER_MAJOR=3`
-- `VER_MINOR=4`
-- `VER_PATCH=343`
-with [Version.hpp](https://github.com/microsoft/cpp_client_telemetry/blob/master/lib/include/public/Version.hpp)
+- `VER_MINOR=5`
+- `VER_PATCH=200`
+with [Version.hpp](https://github.com/microsoft/cpp_client_telemetry/blob/main/lib/include/public/Version.hpp)
 containing runtime-accessible version information. `Version.hpp` file is auto-generated.
 
 Version details:
@@ -21,14 +21,14 @@ Version details:
 - `VER_PATCH` is a day number of the year.
 
 `Version.hpp` file is generated during Release publishing stage using cross-platform
-[gen-version](https://github.com/microsoft/cpp_client_telemetry/blob/master/tools/version.js) script written in `node.js`.
+[gen-version](https://github.com/microsoft/cpp_client_telemetry/blob/main/tools/version.js) script written in `node.js`.
 
 ## Release Process
 
 SDK maintainer preparing the release must:
 - run `tools/gen-version.cmd` on Windows (or `tools/gen-version.sh` on POSIX) to generate the `Version.hpp` file
 - commit the contents of `Version.hpp`
-- send a PR to merge it in the `master` branch
+- send a PR to merge it in the `main` branch
 - use [GitHub Release Management Tab](https://github.com/microsoft/cpp_client_telemetry/releases/new)
 to create a corresponding `v3.x.x` release tag with release notes
 
@@ -70,7 +70,7 @@ maintainers must use their best judgement to decide on where MINOR increment is 
 
 C API is designed for plugins, or "SDK in SDK" scenarios and provides ABI stability guarantee.
 
-C API is described in [mat.h](https://github.com/microsoft/cpp_client_telemetry/blob/master/lib/include/public/mat.h) C header.
+C API is described in [mat.h](https://github.com/microsoft/cpp_client_telemetry/blob/main/lib/include/public/mat.h) C header.
 
 C API is forward-compatible and backwards-compatible: unsupported API calls are ignored and
 an error returned to the caller. Current version of C API is `3.1.0` with no immediate
@@ -79,22 +79,21 @@ with various products using C API. Adding new C functions to C API should warran
 of C API to version `3.2.0`. Since C API is rather stable and does not change frequently,
 it may be missing some features recently added to C++ API.
 
-## Tentative Release schedule for 2021H1
+## Tentative Release schedule for 2021H2
 
 Release tag      | ETA Date | Branch
 -----------------|----------|--------
-v3.5.[1-31]      | Jan 2021 | master
-v3.5.[32-59]     | Feb 2021 | master
-v3.5.[60-90]     | Mar 2021 | master
-v3.6.[91-120]    | Apr 2021 | master
-v3.6.[121-151]   | May 2021 | master
-v3.6.[152-181]   | Jun 2021 | master
+v3.5.[240-270]   | Sept 2021 | main
+v3.5.[271-300]   | Oct 2021  | main
+v3.5.[301-330]   | Nov 2021  | main
+v3.6.[1-30]      | Dec 2021  | main
+
 
 NOTE: although this tentative schedule lists `v3.5` or `v3.6`, we live in agile environment.
-Due to various arising practical needs it may be necessary to update `VER_MINOR` to `6`, `7`,
-`8`, etc. in case of a need to add some new major feature or new protocol to SDK.
+Due to various arising practical needs it may be necessary to update `VER_MINOR` to `7`, `8`,
+`9`, etc. in case of a need to add some new major feature or new protocol to SDK.
 
-## Release schedule for 2021H2
+## Release schedule for 2022H1
 
 A separate feature branch may be needed to accommodate the integration with
 [OpenTelemetry C++ SDK](https://github.com/open-telemetry/opentelemetry-cpp).

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -12,7 +12,7 @@ where:
 - `VER_MAJOR=3`
 - `VER_MINOR=5`
 - `VER_PATCH=200`
-with [Version.hpp](https://github.com/microsoft/cpp_client_telemetry/blob/main/lib/include/public/Version.hpp)
+with [Version.hpp](../lib/include/public/Version.hpp)
 containing runtime-accessible version information. `Version.hpp` file is auto-generated.
 
 Version details:
@@ -21,7 +21,7 @@ Version details:
 - `VER_PATCH` is a day number of the year.
 
 `Version.hpp` file is generated during Release publishing stage using cross-platform
-[gen-version](https://github.com/microsoft/cpp_client_telemetry/blob/main/tools/version.js) script written in `node.js`.
+[gen-version](../tools/version.js) script written in `node.js`.
 
 ## Release Process
 
@@ -70,7 +70,7 @@ maintainers must use their best judgement to decide on where MINOR increment is 
 
 C API is designed for plugins, or "SDK in SDK" scenarios and provides ABI stability guarantee.
 
-C API is described in [mat.h](https://github.com/microsoft/cpp_client_telemetry/blob/main/lib/include/public/mat.h) C header.
+C API is described in [mat.h](../lib/include/public/mat.h) C header.
 
 C API is forward-compatible and backwards-compatible: unsupported API calls are ignored and
 an error returned to the caller. Current version of C API is `3.1.0` with no immediate

--- a/tools/ports/mstelemetry/portfile.cmake
+++ b/tools/ports/mstelemetry/portfile.cmake
@@ -22,13 +22,13 @@ if (DEFINED REPO_NAME)
     get_filename_component(SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
     message("Using local source snapshot from ${SOURCE_PATH}")
 else()
-    # Fetch from GitHub master
+    # Fetch from GitHub main
     message("Fetching source code from GitHub...")
     if (UNIX)
         vcpkg_from_github(
             OUT_SOURCE_PATH SOURCE_PATH
             REPO microsoft/cpp_client_telemetry
-            HEAD_REF master
+            HEAD_REF main
         )
     else()
         vcpkg_from_github(
@@ -36,7 +36,7 @@ else()
             REPO microsoft/cpp_client_telemetry
             REF 4f60dd3bca305c2c0dd5ec2ed7b91d36b4de6dcf
             SHA512 9778df5aa65d95fe1d41739753495d29b3149676e98ac2e802a103604553f4f2b43bc2eb089c2e13dc695f70279287ea79ec6e2926fad03befe8a671f91d36fb
-            HEAD_REF master
+            HEAD_REF main
             PATCHES ${CMAKE_CURRENT_LIST_DIR}/v142-build.patch
         )
     endif()


### PR DESCRIPTION
In continuation with process of migration to main branch (#924), the `master` branch has bee renamed to `main` through Github UI, a new `master` branch has been created from this renamed branch and locked ( kind-of ) for any new commits. 

This PR fixes all the references to `master` branch in this repo along with updating the current release version, and release plan.
