### PR TITLE
Set locale and country code only when supported by Apple OS Version

### DIFF
--- a/wrappers/obj-c/ODWLogManager.mm
+++ b/wrappers/obj-c/ODWLogManager.mm
@@ -156,8 +156,15 @@ static BOOL _initialized = false;
         // Obtain semantics values
         NSBundle* bundle = [NSBundle mainBundle];
         NSLocale* locale = [NSLocale currentLocale];
-        std::string strUserLocale = std::string([[locale languageCode] UTF8String]);
-        NSString* countryCode = [locale countryCode];
+        std::string strUserLocale;
+        NSString* countryCode = nil;
+
+        if (@available(iOS 10.0, macOS 10.12, *))
+        {
+            strUserLocale = std::string([[locale languageCode] UTF8String]);
+            countryCode = [locale countryCode];
+        }
+
         if ([countryCode length] != 0)
         {
             strUserLocale += [[NSString stringWithFormat:@"-%@", countryCode] UTF8String];


### PR DESCRIPTION
languageCode and contryCode are not supported for Mac 10.11 or earlier versions as per Apple documentation: https://developer.apple.com/documentation/foundation/nslocale/1643026-languagecode?language=objc

Added branching to only call APIs when supported

