### PR TITLE
Update supported platforms and Build Environments

### DIFF
--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         config: [release, debug]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, ubuntu-18.04, macOS-latest]
     
     steps:
     - name: Checkout

--- a/.github/workflows/build-ubuntu-1804.yml
+++ b/.github/workflows/build-ubuntu-1804.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI on Linux and Mac
+name: C/C++ CI on Ubuntu 18:04
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         config: [release, debug]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-18.04]
     
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Other resources to learn how to setup the build system:
   | Mac OS X 10.12.6              | Clang Xcode 9.0, 9.1             |
   | Mac OS X 10.13.3              | Clang Xcode 9.2, 9.3, 10.0, 10.1 |
   | Raspbian GNU/Linux 8 (jessie) | GCC 4.9.2 (armv7l)               |
-  | Ubuntu 14.04.x LTS            | GCC 4.8.x, 4.9.4                 |
-  | Ubuntu 14.04.1 LTS            | GCC 5.x.x                        |
-  | Ubuntu 16.04 LTS              | GCC 5.x.x (armv7l)               |
+  | Ubuntu 14.04.x LTS            | GCC 5.x.x                        |
+  | Ubuntu 16.04 LTS              | GCC 5.x.x, GCC 5.x.x (armv7l)    |
+  | Ubuntu 18.04 LTS              | GCC 7.5.x                        |  
   | Windows 10                    | Android Studio/Gradle            |
   | Windows Server 2016           | Visual Studio 2017 (vc141)       |
   | Windows Server 2019           | Visual Studio 2019 (vc142)       |
@@ -63,7 +63,9 @@ Other resources to learn how to setup the build system:
   | Linux (x86, x64, arm, aarch64) | :white_check_mark: |                    |
   | Mac OS X 10.11+                | :white_check_mark: |                    |
   | Mac OS X (latest)              | :white_check_mark: | :white_check_mark: |
-  | Ubuntu 14.04.x LTS             | :white_check_mark: | :white_check_mark: |
+  | Ubuntu 14.04.x LTS             | :white_check_mark: |                    |
+  | Ubuntu 16.04.x LTS             | :white_check_mark: |                    |
+  | Ubuntu 18.04.x LTS             | :white_check_mark: | :white_check_mark: |
   | Ubuntu (latest)                | :white_check_mark: | :white_check_mark: |
   | Windows 7.1                    | :white_check_mark: |                    |
   | Windows 8.1                    | :white_check_mark: |                    |


### PR DESCRIPTION
Trying to bring clarity on build/supported matrix as mentioned in #949
 - CI coverage is only supported for ubuntu-18.04 and ubuntu-20.04 as these are the only environment available under Github. We can separately bring ubuntu-14.04 and ubuntu-16.04 under CI coverage by running under container env. 
 - 1DS SDK build breaks under ubuntu 14.04 with gcc 4.8.x ( default compiler ) and gcc 4.9.x. It is successful with gcc5.5. `Build Environments` section is updated to reflect that.
  - 1DS SDK builds successfully on ubuntu 16.04 ( with gcc 5.5.x ) and ubuntu 18.04 (with gcc 7.5.x ) and this is updated in the `Build Environments` section.