### PR TITLE
Add OSS usage disclaimer

### DIFF
--- a/docs/List-of-OSS-Components.md
+++ b/docs/List-of-OSS-Components.md
@@ -40,7 +40,7 @@ Google's C++ benchmarking framework. Used only for tests and not included in pro
 
 Reachability is a drop-in replacement for Apple's Reachability class. It is ARC-compatible, and it uses the new GCD methods to notify of network interface changes.
 SDK maintains its own snapshot of the mainline `tonymillion/Reachability` [here](../third_party/Reachability). This code is not used nor included in the build of non-Apple OS.
-Please note if customer product is adding dependency to this component, they should ensure it meets their product security and licesing requiremets. 
+Please note if customer product is adding dependency to this component, they should ensure it meets their product security and licensing requirements. 
 
 ## SHA-1 by Steve Reid
 

--- a/docs/List-of-OSS-Components.md
+++ b/docs/List-of-OSS-Components.md
@@ -7,7 +7,7 @@ These are the Open Source components used by Microsoft 1DS / C++ Client Telemetr
 ZLIB DATA COMPRESSION LIBRARY.
 
 SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](../zlib). 
-It is customer product responsibility to ensure that a snapshot of zlib they use - meets their product security and licensing requirements
+It is the responsibility of product teams to ensure that a snapshot of zlib they use meets their product security and licensing requirements.
 
 ## [SQLite](https://www.sqlite.org/index.html)
 

--- a/docs/List-of-OSS-Components.md
+++ b/docs/List-of-OSS-Components.md
@@ -14,7 +14,7 @@ It is the responsibility of product teams to ensure that a snapshot of zlib they
 SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine.
 
 SDK maintains its own snapshot of the mainline SQLite, which is used for Windows builds [here](../sqlite). Other platforms use platform-provided SQLite.
-It is customer product responsibility to ensure that a snapshot of SQLite they use - meets their product security and licensing requirements
+It is the responsibility of product teams to ensure that a snapshot of zlib they use meets their product security and licensing requirements.
 
 ## [nlohmann/json](https://github.com/nlohmann/json)
 

--- a/docs/List-of-OSS-Components.md
+++ b/docs/List-of-OSS-Components.md
@@ -6,13 +6,15 @@ These are the Open Source components used by Microsoft 1DS / C++ Client Telemetr
 
 ZLIB DATA COMPRESSION LIBRARY.
 
-SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](../zlib).
+SDK maintains its own snapshot of the mainline ZLib with some Intel architecture performance optimizations [here](../zlib). 
+It is customer product responsibility to ensure that a snapshot of zlib they use - meets their product security and licensing requirements
 
 ## [SQLite](https://www.sqlite.org/index.html)
 
 SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine.
 
 SDK maintains its own snapshot of the mainline SQLite, which is used for Windows builds [here](../sqlite). Other platforms use platform-provided SQLite.
+It is customer product responsibility to ensure that a snapshot of SQLite they use - meets their product security and licensing requirements
 
 ## [nlohmann/json](https://github.com/nlohmann/json)
 
@@ -38,6 +40,7 @@ Google's C++ benchmarking framework. Used only for tests and not included in pro
 
 Reachability is a drop-in replacement for Apple's Reachability class. It is ARC-compatible, and it uses the new GCD methods to notify of network interface changes.
 SDK maintains its own snapshot of the mainline `tonymillion/Reachability` [here](../third_party/Reachability). This code is not used nor included in the build of non-Apple OS.
+Please note if customer product is adding dependency to this component, they should ensure it meets their product security and licesing requiremets. 
 
 ## SHA-1 by Steve Reid
 
@@ -45,6 +48,7 @@ Classic implementation of SHA-1 (Public Domain).
 SDK maintains its own snapshot of it [here](../third_party/sha1/sha1.c).
 Note that this component is not included or compiled into any of the shipable bits of SDK. It is included for internal developer debug builds only.
 For example, SHA-1 may be used to calculate destination ETW Provider GUID based on ETW Provider name on Windows OS in developer trace tooling / instrumentation.
+Please note if customer product is adding dependency to this component, they should ensure it meets their product security and licensing requirements.
 
 ## Other components and systems
 


### PR DESCRIPTION
1DS SDK brings the snapshot of some of the OSS components ( Zlib, sqlite3, Reachability, sha1 ) for historical reasons ( custom patches, ease of build ). These components use functions that often get flagged in different security scans ([here](https://github.com/microsoft/cpp_client_telemetry_modules/issues/161) and [here](https://github.com/microsoft/cpp_client_telemetry_modules/issues/159)). Customers are not enforced to use these components for 1DS SDK build, and can also optionally use their own snapshot of these components for the build. Eg, an android app may be using room-db instead of sqlite3 DB.   This PR adds a disclaimer for customers to use these components in their build only if it meets their security and licensing requirements. 