### PR TITLE
Fix unit test compilation in CI

### DIFF
--- a/tests/unittests/InformationProviderImplTests.cpp
+++ b/tests/unittests/InformationProviderImplTests.cpp
@@ -15,9 +15,11 @@ using namespace PAL;
 
 namespace
 {
+    using Callbacks = std::vector<std::pair<std::string, std::string>>;
+
     class PropertyChangedCallbackSink : public IPropertyChangedCallback
     {
-        std::vector<std::pair<std::string, std::string>> callbacks;
+        Callbacks callbacks;
 
         void OnChanged(std::string const& propertyName, std::string const& propertyValue) override
         {
@@ -27,7 +29,7 @@ namespace
     public:
         PropertyChangedCallbackSink() = default;
 
-        const auto& GetCallbacks() { return callbacks; }
+        const Callbacks& GetCallbacks() { return callbacks; }
     };
 }
 


### PR DESCRIPTION
Unit test compilation is failing with error
``
/home/runner/work/cpp_client_telemetry/cpp_client_telemetry/tests/unittests/InformationProviderImplTests.cpp:30:9: error: ‘GetCallbacks’ function uses ‘auto’ type specifier without trailing return type
   30 |         const auto& GetCallbacks() { return callbacks; }
      |         ^~~~~
/home/runner/work/cpp_client_telemetry/cpp_client_telemetry/tests/unittests/InformationProviderImplTests.cpp:30:9: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
make[2]: *** [tests/unittests/CMakeFiles/UnitTests.dir/build.make:398: tests/unittests/CMakeFiles/UnitTests.dir/InformationProviderImplTests.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:219: tests/unittests/CMakeFiles/UnitTests.dir/all] Error 2
``

1DS SDK should compile successfully with compilers with C++11 support, while the auto return type "without trailing return type" used in the unit-test is a C++14 feature.
Looks like the error surfaced out after some recent changes in the github environments.