### PR TITLE
Try to fix the potential data race in InformatonProviderImpl

### DIFF
--- a/lib/pal/InformationProviderImpl.cpp
+++ b/lib/pal/InformationProviderImpl.cpp
@@ -73,22 +73,22 @@ namespace PAL_NS_BEGIN {
             // be deleted.  The current design is that IPropertyChangedCallback is
             // not refcount'ed.  Should we refcount it?
 
-            std::lock_guard<std::mutex> lock(m_lock);
-            if (m_registeredCount > 0)
+            std::vector<IPropertyChangedCallback*> local_callbacks;
             {
-                std::vector<IPropertyChangedCallback*> local_callbacks;
+                std::lock_guard<std::mutex> lock(m_lock);
+                if (m_registeredCount > 0)
                 {
                     local_callbacks.insert(local_callbacks.end(), m_callbacks.begin(), m_callbacks.end());
-                }
+                }    
+            }
 
-                size_t count = local_callbacks.size();
-                for (size_t index = 0; index < count; ++index)
+            size_t count = local_callbacks.size();
+            for (size_t index = 0; index < count; ++index)
+            {
+                IPropertyChangedCallback* cur_callback = local_callbacks[index];
+                if (cur_callback != NULL)
                 {
-                    IPropertyChangedCallback* cur_callback = local_callbacks[index];
-                    if (cur_callback != NULL)
-                    {
-                        cur_callback->OnChanged(propertyName, propertyValue);
-                    }
+                    cur_callback->OnChanged(propertyName, propertyValue);
                 }
             }
         }

--- a/lib/pal/InformationProviderImpl.cpp
+++ b/lib/pal/InformationProviderImpl.cpp
@@ -73,11 +73,11 @@ namespace PAL_NS_BEGIN {
             // be deleted.  The current design is that IPropertyChangedCallback is
             // not refcount'ed.  Should we refcount it?
 
+            std::lock_guard<std::mutex> lock(m_lock);
             if (m_registeredCount > 0)
             {
                 std::vector<IPropertyChangedCallback*> local_callbacks;
                 {
-                    std::lock_guard<std::mutex> lock(m_lock);
                     local_callbacks.insert(local_callbacks.end(), m_callbacks.begin(), m_callbacks.end());
                 }
 


### PR DESCRIPTION
I'm from Outlook iOS team. Not sure if this is a false positive, so please correct me if I'm wrong. The `Thread Sanitizer` complains the potential data race.

![Screen Shot 2021-12-07 at 5 32 54 PM](https://user-images.githubusercontent.com/7663073/145137366-ce8a9c66-ed2d-4cee-9fc4-1f0b0175c446.png)


