### PR TITLE
Fix HttpClient SendRequestAsync bugs

### DIFF
--- a/lib/http/HttpClient_WinInet.cpp
+++ b/lib/http/HttpClient_WinInet.cpp
@@ -34,7 +34,7 @@ class WinInetRequestWrapper
     BYTE                   m_buffer[1024] {0};
     DWORD                  m_bufferUsed {0};
     std::vector<uint8_t>   m_bodyBuffer;
-    bool                   m_responsePending {false};
+    bool                   m_readingData {false};
     bool                   isCallbackCalled {false};
     bool                   isAborted {false};
   public:
@@ -325,12 +325,12 @@ class WinInetRequestWrapper
             // trigger INTERNET_STATUS_REQUEST_COMPLETE again.
 
             m_bodyBuffer.insert(m_bodyBuffer.end(), m_buffer, m_buffer + m_bufferUsed);
-            while (!m_responsePending || m_bufferUsed != 0) {
+            while (!m_readingData || m_bufferUsed != 0) {
                 BOOL bResult = ::InternetReadFile(m_hWinInetRequest, m_buffer, sizeof(m_buffer), &m_bufferUsed);
+                m_readingData = true;
                 if (!bResult) {
                     dwError = GetLastError();
                     if (dwError == ERROR_IO_PENDING) {
-                        m_responsePending = true;
                         // Do not touch anything from this thread anymore.
                         // The buffer passed to InternetReadFile() and the
                         // read count will be filled asynchronously, so they

--- a/lib/http/HttpClient_WinInet.cpp
+++ b/lib/http/HttpClient_WinInet.cpp
@@ -33,7 +33,7 @@ class WinInetRequestWrapper
     SimpleHttpRequest*     m_request;
     BYTE                   m_buffer[1024] {0};
     DWORD                  m_bufferUsed {0};
-    std::vector<uint8_t>   m_bodyBuffer {};
+    std::vector<uint8_t>   m_bodyBuffer;
     bool                   m_responsePending {false};
     bool                   isCallbackCalled {false};
     bool                   isAborted {false};

--- a/lib/http/HttpClient_WinInet.cpp
+++ b/lib/http/HttpClient_WinInet.cpp
@@ -325,11 +325,7 @@ class WinInetRequestWrapper
             // trigger INTERNET_STATUS_REQUEST_COMPLETE again.
 
             m_bodyBuffer.insert(m_bodyBuffer.end(), m_buffer, m_buffer + m_bufferUsed);
-            do {
-                if (m_responsePending && m_bufferUsed == 0) {
-                    LOG_TRACE("InternetReadFile finished async");
-                    break;
-                }
+            while (!m_responsePending || m_bufferUsed != 0) {
                 BOOL bResult = ::InternetReadFile(m_hWinInetRequest, m_buffer, sizeof(m_buffer), &m_bufferUsed);
                 if (!bResult) {
                     dwError = GetLastError();
@@ -349,7 +345,7 @@ class WinInetRequestWrapper
                 }
 
                 m_bodyBuffer.insert(m_bodyBuffer.end(), m_buffer, m_buffer + m_bufferUsed);
-            } while (m_bufferUsed != 0);
+            }
         }
 
         std::unique_ptr<SimpleHttpResponse> response(new SimpleHttpResponse(m_id));


### PR DESCRIPTION
#973 

- "To ensure all data is retrieved, an application must continue to call the InternetReadFile function until the function returns TRUE and the lpdwNumberOfBytesRead parameter equals zero." [InternetReadFile](https://docs.microsoft.com/en-us/windows/win32/api/wininet/nf-wininet-internetreadfile) Updating the while condition to match API documentation
- "The lpdwNumberOfBytesRead parameter will be populated on async completion, so it must exist until INTERNET_STATUS_REQUEST_COMPLETE. The same is true of lpBuffer parameter.." [Async InternetReadFile](https://docs.microsoft.com/en-us/windows/win32/wininet/asynchronous-example-application) Ensuring the byte count & buffer stays valid by making them member variables.

The bug is reproducible with slower network condition. Tested by enabling Fiddler -> Rules -> Performance -> Simulate Modem Speeds
Before: Consistently hit responses that were missing chunks
After: Response body now contains full response