### PR TITLE
Use msbuild from environment

### DIFF
--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -21,13 +21,13 @@ on:
 
 jobs:
   test:
-    name: Test on Windows ${{ matrix.arch }}-${{ matrix.config }}
+    name: Test on Windows ${{ matrix.arch }}-${{ matrix.build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         arch: [Win32, x64]
-        config: [Release, Debug]
-        os: [windows-2016]
+        build: [Release, Debug]
+        os: [windows-2019]
     
     steps:
 
@@ -35,6 +35,11 @@ jobs:
       uses: actions/checkout@v1
       continue-on-error: true
 
-    - name: Test ${{ matrix.arch }} ${{ matrix.config }}
+    - name: setup-msbuild
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        vs-version: '[16,)'
+
+    - name: Test ${{ matrix.arch }} ${{ matrix.build }}
       shell: cmd
-      run: build-tests.cmd ${{ matrix.arch }} ${{ matrix.config }}
+      run: build-tests.cmd ${{ matrix.arch }} ${{ matrix.build }}

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Other resources to learn how to setup the build system:
   | Windows 8.1                    | :white_check_mark: |                    |
   | Windows 10.x                   | :white_check_mark: |                    |
   | Windows Server 2012            | :white_check_mark: |                    |
-  | Windows Server 2016            | :white_check_mark: | :white_check_mark: |
-  | Windows Server 2019            | :white_check_mark: |                    |
+  | Windows Server 2016            | :white_check_mark: |                    |
+  | Windows Server 2019            | :white_check_mark: | :white_check_mark: |
   
 * **Supported** - these platforms are known to work well with the SDK in
     production.

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -22,13 +22,6 @@ echo Using custom properties file for the build:
 echo %CUSTOM_PROPS%
 :skip
 
-REM Add path to vs2017 MSBuild.exe
-set "PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\"
-
-REM Try to setup vs2017 Dev environment if possible
-echo Building using Visual Studio 2017 tools
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
-
 set MAXCPUCOUNT=%NUMBER_OF_PROCESSORS%
 set SOLUTION=Solutions\MSTelemetrySDK.sln
 


### PR DESCRIPTION
windows-2016 is deprecated (https://github.com/actions/virtual-environments/issues/4312), the build is failing when running on windows-2019