### PR TITLE
Finish DLL Build Fix

### DIFF
--- a/Solutions/win32-dll/win32-dll.vcxproj
+++ b/Solutions/win32-dll/win32-dll.vcxproj
@@ -328,9 +328,6 @@
     <ProjectReference Include="..\..\zlib\contrib\vstudio\vc14\zlibvc.vcxproj">
       <Project>{8fd826f8-3739-44e6-8cc8-997122e53b8d}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\win32-lib\win32-lib.vcxproj">
-      <Project>{1dc6b38a-b390-34ce-907f-4958807a3d42}</Project>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(NoSqlite)'!='TRUE'">
     <ProjectReference Include="..\..\sqlite\sqlite.vcxproj">


### PR DESCRIPTION
This is an update to PR #980, which fixes the win32-dll build. In [this comment](https://github.com/microsoft/cpp_client_telemetry/pull/980#pullrequestreview-843123385) @lalitb correctly pointed out that there was an additional win32-lib reference that was now not necessary. It also breaks the build via multiple definitions and therefore must be removed. Thanks for pointing that out! This change will resolve the issue.

Local testing: build-x64Debug.bat script now correctly builds the dll