### PR TITLE
Fix the data race in DispatchEvent

### DIFF
--- a/lib/callbacks/DebugSource.cpp
+++ b/lib/callbacks/DebugSource.cpp
@@ -35,13 +35,15 @@ namespace MAT_NS_BEGIN {
     /// <summary>Microsoft Telemetry SDK invokes this method to dispatch event to client callback</summary>
     bool DebugEventSource::DispatchEvent(DebugEvent evt)
     {
-        seq++;
-        evt.seq = seq;
-        evt.ts = PAL::getUtcSystemTime();
+        int64_t timestamp = PAL::getUtcSystemTime();
         bool dispatched = false;
-
+                
         {
             DE_LOCKGUARD(stateLock());
+            seq++;
+            evt.seq = seq;
+            evt.ts = timestamp;
+
             if (listeners.size()) {
                 // Events filter handlers list
                 auto &v = listeners[evt.type];

--- a/lib/callbacks/DebugSource.cpp
+++ b/lib/callbacks/DebugSource.cpp
@@ -35,14 +35,13 @@ namespace MAT_NS_BEGIN {
     /// <summary>Microsoft Telemetry SDK invokes this method to dispatch event to client callback</summary>
     bool DebugEventSource::DispatchEvent(DebugEvent evt)
     {
-        int64_t timestamp = PAL::getUtcSystemTime();
+        evt.ts = PAL::getUtcSystemTime();
         bool dispatched = false;
                 
         {
             DE_LOCKGUARD(stateLock());
             seq++;
             evt.seq = seq;
-            evt.ts = timestamp;
 
             if (listeners.size()) {
                 // Events filter handlers list


### PR DESCRIPTION
I'm from Outlook Mobile iOS team. While debugging with ThreadSanitizer, found another possible data race. 

![Screen Shot 2022-01-10 at 1 09 45 PM](https://user-images.githubusercontent.com/7663073/148721276-75e8166f-730d-4517-a32c-68f642bfbcb7.png)

