### PR TITLE
Try to fix the data race in DeviceStateHandler

### DIFF
--- a/lib/tpm/DeviceStateHandler.cpp
+++ b/lib/tpm/DeviceStateHandler.cpp
@@ -26,6 +26,7 @@ using namespace PAL;
 void DeviceStateHandler::Start()
 {
 	// TRACE("_RetrieveAndRegisterForDeviceConditionChange");
+	LOCKGUARD(m_lock);
 
 	m_networkInformation = PAL::GetNetworkInformation();
 	if (m_networkInformation)
@@ -63,6 +64,7 @@ void DeviceStateHandler::Start()
 void DeviceStateHandler::Stop()
 {
 	// TRACE("Enter stop transmission policy manager");
+	LOCKGUARD(m_lock);
 
 	// 4. Stop listening to platform network, power and device info changes
 	if (m_networkInformation)
@@ -91,7 +93,7 @@ void DeviceStateHandler::OnChanged(
 {
     // TRACE("OnChanged: Platform network callback with Name=%s, Val=%s",
  //       propertyName.c_str(), propertyValue.c_str());
-
+    LOCKGUARD(m_lock);
 
     if (propertyName.compare(NETWORK_TYPE) == 0)
     {
@@ -117,6 +119,8 @@ void DeviceStateHandler::OnChanged(
  ******************************************************************************/
  void DeviceStateHandler::_UpdateDeviceCondition()
 {
+     LOCKGUARD(m_lock);
+	 
 #ifdef _WIN32
      if (m_networkInformation)
      {

--- a/lib/tpm/DeviceStateHandler.cpp
+++ b/lib/tpm/DeviceStateHandler.cpp
@@ -26,7 +26,7 @@ using namespace PAL;
 void DeviceStateHandler::Start()
 {
 	// TRACE("_RetrieveAndRegisterForDeviceConditionChange");
-	LOCKGUARD(m_lock);
+	std::lock_guard<std::mutex> lock(m_lock);
 
 	m_networkInformation = PAL::GetNetworkInformation();
 	if (m_networkInformation)
@@ -64,7 +64,7 @@ void DeviceStateHandler::Start()
 void DeviceStateHandler::Stop()
 {
 	// TRACE("Enter stop transmission policy manager");
-	LOCKGUARD(m_lock);
+	std::lock_guard<std::mutex> lock(m_lock);
 
 	// 4. Stop listening to platform network, power and device info changes
 	if (m_networkInformation)
@@ -93,7 +93,7 @@ void DeviceStateHandler::OnChanged(
 {
     // TRACE("OnChanged: Platform network callback with Name=%s, Val=%s",
  //       propertyName.c_str(), propertyValue.c_str());
-    LOCKGUARD(m_lock);
+    std::lock_guard<std::mutex> lock(m_lock);
 
     if (propertyName.compare(NETWORK_TYPE) == 0)
     {
@@ -119,7 +119,7 @@ void DeviceStateHandler::OnChanged(
  ******************************************************************************/
  void DeviceStateHandler::_UpdateDeviceCondition()
 {
-     LOCKGUARD(m_lock);
+     std::lock_guard<std::mutex> lock(m_lock);
 	 
 #ifdef _WIN32
      if (m_networkInformation)

--- a/lib/tpm/DeviceStateHandler.hpp
+++ b/lib/tpm/DeviceStateHandler.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <mutex>
 #include <string>
 
 namespace MAT_NS_BEGIN {
@@ -44,6 +45,7 @@ private:
     std::shared_ptr<PAL::IDeviceInformation> m_deviceInformation;
     int m_deviceInformationToken;
 
+    std::mutex m_lock;
 };
 
 } MAT_NS_END


### PR DESCRIPTION
I'm from Outlook Mobile iOS team, found another data race: 

SUMMARY: ThreadSanitizer: data race (OLMAnalyticsKit:x86_64+0xa90565) in `Microsoft::Applications::Events::DeviceStateHandler::_UpdateDeviceCondition()+0x65`