### PR TITLE
Try to fix the potential data race in Statistics

### DIFF
--- a/lib/stats/Statistics.cpp
+++ b/lib/stats/Statistics.cpp
@@ -22,7 +22,6 @@ namespace MAT_NS_BEGIN {
         m_semanticContextDecorator(m_logManager),
         m_isStarted(false)
     {
-        m_intervalMs = m_config.GetMetaStatsSendIntervalSec() * 1000;
     }
 
     Statistics::~Statistics()
@@ -35,7 +34,7 @@ namespace MAT_NS_BEGIN {
             return;
         }
 
-        m_intervalMs = m_config.GetMetaStatsSendIntervalSec() * 1000;
+        unsigned int m_intervalMs = m_config.GetMetaStatsSendIntervalSec() * 1000;
         if (m_intervalMs != 0)
         {
             if (!m_isScheduled.exchange(true))
@@ -54,7 +53,7 @@ namespace MAT_NS_BEGIN {
     {
         m_isScheduled = false;
 
-        m_intervalMs = m_config.GetMetaStatsSendIntervalSec() * 1000;
+        unsigned int m_intervalMs = m_config.GetMetaStatsSendIntervalSec() * 1000;
         if (m_intervalMs == 0)
         {
             // cancel pending stats event if timer changed at runtime
@@ -90,7 +89,7 @@ namespace MAT_NS_BEGIN {
     bool Statistics::handleOnStart()
     {
         // synchronously send stats event on SDK start, but only if stats are enabled
-        if (m_intervalMs != 0)
+        if (m_config.GetMetaStatsSendIntervalSec() * 1000 != 0)
         {
             send(ACT_STATS_ROLLUP_KIND_START);
         }
@@ -108,7 +107,7 @@ namespace MAT_NS_BEGIN {
         }
 
         // synchronously send stats event on SDK stop, but only if stats are enabled
-        if (m_intervalMs != 0)
+        if (m_config.GetMetaStatsSendIntervalSec() * 1000 != 0)
         {
             send(ACT_STATS_ROLLUP_KIND_STOP);
         }

--- a/lib/stats/Statistics.hpp
+++ b/lib/stats/Statistics.hpp
@@ -73,7 +73,6 @@ namespace MAT_NS_BEGIN {
         bool                        m_isStarted;
 
         std::int64_t                m_statEventSentTime;
-        unsigned                    m_intervalMs;
 
     public:
 


### PR DESCRIPTION
Can we remove the usage of m_intervalMs, or if this is a false alarm for the data race?

![image](https://user-images.githubusercontent.com/7663073/154955336-ede9cf3d-45b6-41b6-a41f-fac873fbf0d9.png)
