### PR TITLE
Suppress false positive CodeQL errors

### DIFF
--- a/lib/http/HttpClient_CAPI.cpp
+++ b/lib/http/HttpClient_CAPI.cpp
@@ -199,7 +199,7 @@ namespace MAT_NS_BEGIN {
         
         if (operation != nullptr)
         {
-            operation->Cancel();// CodeQL [cpp/uninitializedptrfield] operation is explicitly constructed with with so it will never hold garbage value
+            operation->Cancel();// CodeQL [cpp/uninitializedptrfield] operation is explicitly constructed with nullptr so it will never hold garbage value
         }
     }
 

--- a/lib/http/HttpClient_CAPI.cpp
+++ b/lib/http/HttpClient_CAPI.cpp
@@ -199,7 +199,7 @@ namespace MAT_NS_BEGIN {
         
         if (operation != nullptr)
         {
-            operation->Cancel();//lgtm [cpp/uninitializedptrfield]
+            operation->Cancel();// CodeQL [cpp/uninitializedptrfield] operation is explicitly constructed with with so it will never hold garbage value
         }
     }
 

--- a/lib/http/HttpClient_CAPI.cpp
+++ b/lib/http/HttpClient_CAPI.cpp
@@ -186,7 +186,7 @@ namespace MAT_NS_BEGIN {
     void HttpClient_CAPI::CancelRequestAsync(const std::string& id)
     {
         LOG_TRACE("Cancelling CAPI HTTP request '%s'", id.c_str());
-        std::shared_ptr<HttpClient_Operation> operation;
+        std::shared_ptr<HttpClient_Operation> operation(nullptr);
         {
             // Only lock mutex while actually reading/writing pending operations collection to prevent potential recursive deadlock
             LOCKGUARD(s_operationsLock);
@@ -199,7 +199,7 @@ namespace MAT_NS_BEGIN {
         
         if (operation != nullptr)
         {
-            operation->Cancel();
+            operation->Cancel();//lgtm [cpp/uninitializedptrfield]
         }
     }
 

--- a/lib/include/mat/json.hpp
+++ b/lib/include/mat/json.hpp
@@ -4697,7 +4697,7 @@ std::size_t hash(const BasicJsonType& j)
         }
 
         default: // LCOV_EXCL_LINE
-            JSON_ASSERT(false); //lgtm[cpp/missing-return]
+            JSON_ASSERT(false); // LCOV_EXCL_LINE
     }
 }
 
@@ -6842,7 +6842,7 @@ class lexer : public lexer_base<BasicJsonType>
           locale's decimal point is used instead of `.` to work with the
           locale-dependent converters.
     */
-    token_type scan_number()  // lgtm [cpp/reporting/alert-suppression]
+    token_type scan_number()  // CodeQL [cpp/use-of-goto] We explicitly allow the use of goto in this func
     {
         // reset token_buffer to store the number's bytes
         reset();

--- a/lib/include/mat/json.hpp
+++ b/lib/include/mat/json.hpp
@@ -4697,7 +4697,7 @@ std::size_t hash(const BasicJsonType& j)
         }
 
         default: // LCOV_EXCL_LINE
-            JSON_ASSERT(false); // LCOV_EXCL_LINE
+            JSON_ASSERT(false); //lgtm[cpp/missing-return]
     }
 }
 
@@ -6842,7 +6842,7 @@ class lexer : public lexer_base<BasicJsonType>
           locale's decimal point is used instead of `.` to work with the
           locale-dependent converters.
     */
-    token_type scan_number()  // lgtm [cpp/use-of-goto]
+    token_type scan_number()  // lgtm [cpp/reporting/alert-suppression]
     {
         // reset token_buffer to store the number's bytes
         reset();


### PR DESCRIPTION
We noticed that in our mirrored branch codeQL raises some errors and after looking into them decided they were false positives:
1. "Dereference of potentially uninitialized pointer field" in HttpClient_CAPI.cpp - the shared_ptr operation is dereferenced within an if block that checks it isn't null, in addition it is default constructed with nullptr so in the case that it isn't null, it means it was purposely assigned a non garbage value. I added the lgtm comment with justification to suppress the error and changed the initialization of operation for better clarity on its initialized value.
link to the error:

2. "Alert Suppression Without Justification" in json.hpp - The function scan_number() uses goto which raised a codeQL error which was later suppressed with the comment "lgtm [cpp/use-of-goto]", I added justification for this suppression in order to comply with the new CodeQL suppression standard: https://onees.lgtm.microsoft.com/rules/1001259/
link to the error: