### PR TITLE
Fix PAL unit test to validate sdk-version

### DIFF
--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -122,7 +122,7 @@ TEST_F(PalTests, SdkVersion)
     EXPECT_THAT(std::count(v.cbegin(), v.cend(), '-'), Eq(4));
     EXPECT_THAT(v, StartsWith(EVTSDK_VERSION_PREFIX "-"));
     EXPECT_THAT(v.at(v.find('-', 0) + 1), Ne('-'));
-    EXPECT_THAT(v, HasSubstr("-C++-No-"));
+    EXPECT_THAT(v, HasSubstr(std::string("-C++-" ECS_SUPP "-")));
     EXPECT_THAT(v, EndsWith(BUILD_VERSION_STR));
 
     EXPECT_THAT(PAL::getSdkVersion(), Eq(v));


### PR DESCRIPTION
Fix [PalTests::SdkVersion](https://github.com/microsoft/cpp_client_telemetry/blob/f4fce8ffe6c75736c84b61b9597b3987125d3228/tests/unittests/PalTests.cpp#L465) test while running in private(modules) repo. This test was enabled as part of #1009, and the unit-test is failing in the modules repo after merging this PR. The `<Projection>` field value of sdk-version depends on whether the ECS module is enabled or not as defined here - 

https://github.com/microsoft/cpp_client_telemetry/blob/f198a547e54cbc7a5349bc956ee39f90eaf2f472/lib/pal/PAL.hpp#L12-L16
