### PR TITLE
Configuring option for force resetting the osx deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,17 @@ if(APPLE)
 
   # iOS build options
   option(BUILD_IOS           "Build for iOS"               NO)
+  option(FORCE_RESET_OSX_DEPLOYMENT_TARGET "Clear the OSX Deployment Target Set" ON)
 
   if(BUILD_IOS)
     set(TARGET_ARCH "APPLE")
     set(IOS True)
     set(APPLE True)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+
+    if(FORCE_RESET_OSX_DEPLOYMENT_TARGET)
+      set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
+    endif()
+    
     if((${IOS_PLAT} STREQUAL "iphonesimulator") AND (${IOS_ARCH} STREQUAL "arm64"))
       # iOS arm64 simulator is supported starting BigSur
       # Unfortunately, CMAKE produces a device binary (not simulator) when providing -miphoneos-version-min flag when building iOS arm64 simulator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(APPLE)
 
   # iOS build options
   option(BUILD_IOS           "Build for iOS"               NO)
-  option(FORCE_RESET_OSX_DEPLOYMENT_TARGET "Clear the OSX Deployment Target Set" ON)
+  option(FORCE_RESET_OSX_DEPLOYMENT_TARGET "Clear the OSX Deployment Target Set" YES)
 
   if(BUILD_IOS)
     set(TARGET_ARCH "APPLE")
@@ -35,7 +35,7 @@ if(APPLE)
     if(FORCE_RESET_OSX_DEPLOYMENT_TARGET)
       set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
     endif()
-    
+
     if((${IOS_PLAT} STREQUAL "iphonesimulator") AND (${IOS_ARCH} STREQUAL "arm64"))
       # iOS arm64 simulator is supported starting BigSur
       # Unfortunately, CMAKE produces a device binary (not simulator) when providing -miphoneos-version-min flag when building iOS arm64 simulator


### PR DESCRIPTION
**Issue**

Recently we did the integration of the 1DS library in a common xplat repo and built it for iOS. The common xplat repo contains 1DS as a submodule and adds it as a subdirectory in CMakeList. Post the integration and building it for iOS we observed that the minimum supported OS Version (LC_VERSION_MIN_IPHONEOS) is not getting set in the generated framework. Hence, the build is failing while submitting to test flight.

**RCA**

We observed that 1DS CMakeLists is forcefully setting the CMAKE_OSX_DEPLOYMENT_TARGET as an empty string which is causing the issue (`set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)`).

**Solution**

Configuring an option that gives the flexibility on whether the module building 1DS wants this behavior or not.