### PR TITLE
Fixed the issue of configuration being shared between multiple loggers

### DIFF
--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -311,8 +311,8 @@ NSString *const ODWCFG_BOOL_SESSION_RESET_ENABLED = @"sessionResetEnabled";
 +(nullable ODWLogConfiguration *)getLogConfigurationCopy
 {
     auto& config = LogManager::GetLogConfiguration();
-    static ILogConfiguration configCopy(config);
-    return [[ODWLogConfiguration alloc] initWithILogConfiguration: &configCopy];
+    auto configCopy = new ILogConfiguration(config);
+    return [[ODWLogConfiguration alloc] initWithILogConfiguration: configCopy];
 }
 
 +(void)setEventCollectorUri:(nonnull NSString *)eventCollectorUri


### PR DESCRIPTION
**Bug:**
The `ODWLogManager :+(nullable ODWLogger *)loggerWithTenant:(nonnull NSString *)tenantToken source:(nonnull NSString *)source withConfig:(nonnull ODWLogConfiguration *)config 
` always picks the most recent collector URI for all the loggers that have been created using this API.

****Issue Raised with all the details:**** - https://github.com/microsoft/cpp_client_telemetry/issues/991

**Reason:**
`static` configuration object was being used that was being shared between all the loggers created using the above API.

**Fix:** 
Removed the `static` and created an independent configuration instance.
Now the events are going through correct collector URL.
<img width="795" alt="Screenshot 2022-06-06 at 1 35 28 PM" src="https://user-images.githubusercontent.com/85876413/172765254-ae1ed8ea-9081-449c-9890-ff56395bee57.png">
  