### PR TITLE
Fix Mac Memory leak issue

### DIFF
--- a/lib/pal/WorkerThread.cpp
+++ b/lib/pal/WorkerThread.cpp
@@ -182,7 +182,7 @@ namespace PAL_NS_BEGIN {
             LOG_INFO("Running thread %u", std::this_thread::get_id());
 
             for (;;) {
-                #ifdef MacOS
+                #ifdef __APPLE__
                 @autoreleasepool
                 #endif
                 {

--- a/lib/pal/WorkerThread.cpp
+++ b/lib/pal/WorkerThread.cpp
@@ -182,69 +182,74 @@ namespace PAL_NS_BEGIN {
             LOG_INFO("Running thread %u", std::this_thread::get_id());
 
             for (;;) {
-                std::unique_ptr<MAT::Task> item = nullptr;
-                wakeupCount++;
-                unsigned nextTimerInMs = MAX_FUTURE_DELTA_MS;
+                #ifdef MacOS
+                @autoreleasepool
+                #endif
                 {
-                    LOCKGUARD(self->m_lock);
+                    std::unique_ptr<MAT::Task> item = nullptr;
+                    wakeupCount++;
+                    unsigned nextTimerInMs = MAX_FUTURE_DELTA_MS;
+                    {
+                        LOCKGUARD(self->m_lock);
 
-                    auto now = getMonotonicTimeMs();
-                    if (!self->m_timerQueue.empty()) {
-                        const auto currTargetTime = self->m_timerQueue.front()->TargetTime;
-                        if (currTargetTime <= now) {
-                            // process the item at the front immediately
-                            item = std::unique_ptr<MAT::Task>(self->m_timerQueue.front());
-                            self->m_timerQueue.pop_front();
-                        } else {
-                           // timed call in future, we need to resort the items in the queue
-                           const auto delta = currTargetTime - now;
-                           if (delta > MAX_FUTURE_DELTA_MS) {
-                               const auto itemPtr = self->m_timerQueue.front();
-                               self->m_timerQueue.pop_front();
-                               itemPtr->TargetTime = now + MAX_FUTURE_DELTA_MS;
-                               self->Queue(itemPtr);
-                               continue;
-                           }
-                           // value used for sleep in case if m_queue ends up being empty
-                           nextTimerInMs = static_cast<unsigned>(delta);
+                        auto now = getMonotonicTimeMs();
+                        if (!self->m_timerQueue.empty()) {
+                            const auto currTargetTime = self->m_timerQueue.front()->TargetTime;
+                            if (currTargetTime <= now) {
+                                // process the item at the front immediately
+                                item = std::unique_ptr<MAT::Task>(self->m_timerQueue.front());
+                                self->m_timerQueue.pop_front();
+                            } else {
+                               // timed call in future, we need to resort the items in the queue
+                               const auto delta = currTargetTime - now;
+                               if (delta > MAX_FUTURE_DELTA_MS) {
+                                   const auto itemPtr = self->m_timerQueue.front();
+                                   self->m_timerQueue.pop_front();
+                                   itemPtr->TargetTime = now + MAX_FUTURE_DELTA_MS;
+                                   self->Queue(itemPtr);
+                                   continue;
+                               }
+                               // value used for sleep in case if m_queue ends up being empty
+                               nextTimerInMs = static_cast<unsigned>(delta);
+                            }
+                        }
+
+                        if (!self->m_queue.empty() && !item) {
+                            item = std::unique_ptr<MAT::Task>(self->m_queue.front());
+                            self->m_queue.pop_front();
+                        }
+
+                        if (item) {
+                            self->m_itemInProgress = item.get();
                         }
                     }
 
-                    if (!self->m_queue.empty() && !item) {
-                        item = std::unique_ptr<MAT::Task>(self->m_queue.front());
-                        self->m_queue.pop_front();
+                    if (!item) {
+                        if (!self->m_event.Reset())
+                            self->m_event.wait(nextTimerInMs);
+                        continue;
                     }
 
-                    if (item) {
-                        self->m_itemInProgress = item.get();
-                    }
-                }
-
-                if (!item) {
-                    if (!self->m_event.Reset())
-                        self->m_event.wait(nextTimerInMs);
-                    continue;
-                }
-
-                if (item->Type == MAT::Task::Shutdown) {
-                    item.reset();
-                    self->m_itemInProgress = nullptr;
-                    break;
-                }
-
-                {
-                    std::lock_guard<std::timed_mutex> lock(self->m_execution_mutex);
-
-                    // Item wasn't cancelled before it could be executed
-                    if (self->m_itemInProgress != nullptr) {
-                        LOG_TRACE("%10llu Execute item=%p type=%s\n", wakeupCount, item.get(), item.get()->TypeName.c_str() );
-                        (*item)();
+                    if (item->Type == MAT::Task::Shutdown) {
+                        item.reset();
                         self->m_itemInProgress = nullptr;
+                        break;
                     }
 
-                    if (item) {
-                        item->Type = MAT::Task::Done;
-                        item = nullptr;
+                    {
+                        std::lock_guard<std::timed_mutex> lock(self->m_execution_mutex);
+
+                        // Item wasn't cancelled before it could be executed
+                        if (self->m_itemInProgress != nullptr) {
+                            LOG_TRACE("%10llu Execute item=%p type=%s\n", wakeupCount, item.get(), item.get()->TypeName.c_str() );
+                            (*item)();
+                            self->m_itemInProgress = nullptr;
+                        }
+
+                        if (item) {
+                            item->Type = MAT::Task::Done;
+                            item = nullptr;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://github.com/microsoft/cpp_client_telemetry_modules/issues/176

Multiple users are reporting high memory usage, especially on M1 Macs. We've made some significant gains in the last few months, but we are still running into users seeing 12+GB of usage. I've been in a thread with one such user who has provided leak traces

 The "with aria" traces were collected first, in OneDrive's default configuration. The user enabled malloc_history and let the product run until it reached around 1GB usage, at which point it is my understanding that we crashed (this has to do with malloc tracing and not another bug). After that, I had the user disable Aria, and run the same trace again (the "without aria" trace). No crash this time.

From a comparison of the traces, it is obvious that Aria is responsible for significant memory consumption.  What seems to be happening here (and this is consistent with when Apple looked at it) is that Aria is allocating objects inside an autoreleasepool that is never released. 

What changes:
Just added autorelease pool to functions that were not releasing memory.