### PR TITLE
Remove global C++ objects

### DIFF
--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -114,8 +114,8 @@ namespace MAT_NS_BEGIN
     class ILogManagerInternal : public ILogManager
     {
        public:
-        static std::recursive_mutex managers_lock;
-        static std::set<ILogManager*> managers;
+        static std::recursive_mutex& GetManagersLock();
+        static std::set<ILogManager*>& GetManagers() noexcept;
 
         /// <summary>
         /// Optional decorator runs on event before passing it to sendEvent

--- a/lib/config/RuntimeConfig_Default.hpp
+++ b/lib/config/RuntimeConfig_Default.hpp
@@ -10,68 +10,6 @@
 
 namespace MAT_NS_BEGIN
 {
-    static ILogConfiguration defaultRuntimeConfig{
-        {CFG_INT_TRACE_LEVEL_MIN, ACTTraceLevel::ACTTraceLevel_Error},
-        {CFG_INT_SDK_MODE, SdkModeTypes::SdkModeTypes_CS},
-        {CFG_BOOL_ENABLE_ANALYTICS, false},
-        {CFG_INT_CACHE_FILE_SIZE, 3145728},
-        {CFG_INT_RAM_QUEUE_SIZE, 524288},
-        {CFG_BOOL_ENABLE_MULTITENANT, true},
-        {CFG_BOOL_ENABLE_DB_DROP_IF_FULL, false},
-        {CFG_INT_MAX_TEARDOWN_TIME, 1},
-        {CFG_INT_MAX_PENDING_REQ, 4},
-        {CFG_INT_RAM_QUEUE_BUFFERS, 3},
-        {CFG_INT_TRACE_LEVEL_MASK, 0},
-        {CFG_BOOL_ENABLE_TRACE, true},
-        {CFG_STR_COLLECTOR_URL, COLLECTOR_URL_PROD},
-        {CFG_INT_STORAGE_FULL_PCT, 75},
-        {CFG_INT_STORAGE_FULL_CHECK_TIME, 5000},
-        {CFG_INT_RAMCACHE_FULL_PCT, 75},
-        {CFG_BOOL_ENABLE_NET_DETECT, true},
-        {CFG_BOOL_SESSION_RESET_ENABLED, false},
-        {CFG_MAP_METASTATS_CONFIG,
-         {/* Parameter that allows to split stats events by tenant */
-          {"split", false},
-          {"interval", 1800},
-          {"tokenProd", STATS_TOKEN_PROD},
-          {"tokenInt", STATS_TOKEN_INT}}},
-        {"utc",
-         {
-#ifdef HAVE_MAT_UTC
-             {"providerGroupId", "780dddc8-18a1-5781-895a-a690464fa89c"},
-             {CFG_BOOL_UTC_ENABLED, true},
-             {CFG_BOOL_UTC_ACTIVE, false},
-             {CFG_BOOL_UTC_LARGE_PAYLOADS, false}
-#else
-             {CFG_BOOL_UTC_ENABLED, false}
-#endif
-         }},
-        {CFG_MAP_HTTP,
-         {
-#ifdef HAVE_MAT_ZLIB
-             {CFG_BOOL_HTTP_COMPRESSION, true}
-#else
-             {CFG_BOOL_HTTP_COMPRESSION, false}
-#endif
-             ,
-             {"contentEncoding", "deflate"},
-             /* Optional parameter to require Microsoft Root CA */
-             {CFG_BOOL_HTTP_MS_ROOT_CHECK, false}}},
-        {CFG_MAP_TPM,
-         {
-             {CFG_INT_TPM_MAX_BLOB_BYTES, 2097152},
-             {CFG_INT_TPM_MAX_RETRY, 5},
-             {CFG_BOOL_TPM_CLOCK_SKEW_ENABLED, true},
-             {CFG_STR_TPM_BACKOFF, "E,3000,300000,2,1"},
-         }},
-        {CFG_MAP_COMPAT,
-         {
-             {CFG_BOOL_COMPAT_DOTS, true}, // false: v1 backwards-compat: event.SetType("My.Custom.Type") => custom.my_custom_type
-             {CFG_STR_COMPAT_PREFIX, EVENTRECORD_TYPE_CUSTOM_EVENT} // custom type prefix for Interchange / Geneva / Cosmos flow
-         }},
-        {"sample",
-         {{"rate", 0}}}};
-
     /// <summary>
     /// This class overlays a custom configuration provided by the customer
     /// on top of default configuration above (defaultRuntimeConfig)
@@ -81,12 +19,80 @@ namespace MAT_NS_BEGIN
     {
        protected:
         ILogConfiguration& config;
+       
+       private:
+        static ILogConfiguration& GetDefaultRuntimeConfig()
+        {
+            static ILogConfiguration defaultRuntimeConfig {
+                {CFG_INT_TRACE_LEVEL_MIN, ACTTraceLevel::ACTTraceLevel_Error},
+                {CFG_INT_SDK_MODE, SdkModeTypes::SdkModeTypes_CS},
+                {CFG_BOOL_ENABLE_ANALYTICS, false},
+                {CFG_INT_CACHE_FILE_SIZE, 3145728},
+                {CFG_INT_RAM_QUEUE_SIZE, 524288},
+                {CFG_BOOL_ENABLE_MULTITENANT, true},
+                {CFG_BOOL_ENABLE_DB_DROP_IF_FULL, false},
+                {CFG_INT_MAX_TEARDOWN_TIME, 1},
+                {CFG_INT_MAX_PENDING_REQ, 4},
+                {CFG_INT_RAM_QUEUE_BUFFERS, 3},
+                {CFG_INT_TRACE_LEVEL_MASK, 0},
+                {CFG_BOOL_ENABLE_TRACE, true},
+                {CFG_STR_COLLECTOR_URL, COLLECTOR_URL_PROD},
+                {CFG_INT_STORAGE_FULL_PCT, 75},
+                {CFG_INT_STORAGE_FULL_CHECK_TIME, 5000},
+                {CFG_INT_RAMCACHE_FULL_PCT, 75},
+                {CFG_BOOL_ENABLE_NET_DETECT, true},
+                {CFG_BOOL_SESSION_RESET_ENABLED, false},
+                {CFG_MAP_METASTATS_CONFIG,
+                 {/* Parameter that allows to split stats events by tenant */
+                  {"split", false},
+                  {"interval", 1800},
+                  {"tokenProd", STATS_TOKEN_PROD},
+                  {"tokenInt", STATS_TOKEN_INT}}},
+                {"utc",
+                 {
+        #ifdef HAVE_MAT_UTC
+                     {"providerGroupId", "780dddc8-18a1-5781-895a-a690464fa89c"},
+                     {CFG_BOOL_UTC_ENABLED, true},
+                     {CFG_BOOL_UTC_ACTIVE, false},
+                     {CFG_BOOL_UTC_LARGE_PAYLOADS, false}
+        #else
+                     {CFG_BOOL_UTC_ENABLED, false}
+        #endif
+                 }},
+                {CFG_MAP_HTTP,
+                 {
+        #ifdef HAVE_MAT_ZLIB
+                     {CFG_BOOL_HTTP_COMPRESSION, true}
+        #else
+                     {CFG_BOOL_HTTP_COMPRESSION, false}
+        #endif
+                     ,
+                     {"contentEncoding", "deflate"},
+                     /* Optional parameter to require Microsoft Root CA */
+                     {CFG_BOOL_HTTP_MS_ROOT_CHECK, false}}},
+                {CFG_MAP_TPM,
+                 {
+                     {CFG_INT_TPM_MAX_BLOB_BYTES, 2097152},
+                     {CFG_INT_TPM_MAX_RETRY, 5},
+                     {CFG_BOOL_TPM_CLOCK_SKEW_ENABLED, true},
+                     {CFG_STR_TPM_BACKOFF, "E,3000,300000,2,1"},
+                 }},
+                {CFG_MAP_COMPAT,
+                 {
+                     {CFG_BOOL_COMPAT_DOTS, true}, // false: v1 backwards-compat: event.SetType("My.Custom.Type") => custom.my_custom_type
+                     {CFG_STR_COMPAT_PREFIX, EVENTRECORD_TYPE_CUSTOM_EVENT} // custom type prefix for Interchange / Geneva / Cosmos flow
+                 }},
+                {"sample",
+                 {{"rate", 0}}}};
 
+            return defaultRuntimeConfig;
+        }
+        
        public:
         RuntimeConfig_Default(ILogConfiguration& customConfig) :
             config(customConfig)
         {
-            Variant::merge_map(*customConfig, *defaultRuntimeConfig);
+            Variant::merge_map(*customConfig, *GetDefaultRuntimeConfig());
         };
 
         virtual ~RuntimeConfig_Default()

--- a/lib/include/public/TransmitProfiles.hpp
+++ b/lib/include/public/TransmitProfiles.hpp
@@ -152,7 +152,15 @@ namespace MAT_NS_BEGIN
         /// </summary>
         static bool isTimerUpdated;
 
+        /// <summary>
+        /// A map that contains all transmit profiles.
+        /// </summary>
         static std::map<std::string, TransmitProfileRules>& GetProfiles() noexcept;
+
+        /// <summary>
+        /// A string that contains the name of the currently active transmit profile.
+        /// </summary>
+        static std::string& GetCurrProfileName() noexcept;
         
         static void UpdateProfiles(const std::vector<TransmitProfileRules>& newProfiles) noexcept;
 

--- a/lib/include/public/TransmitProfiles.hpp
+++ b/lib/include/public/TransmitProfiles.hpp
@@ -131,15 +131,6 @@ namespace MAT_NS_BEGIN
     class TransmitProfiles {
 
     protected:
-        /// <summary>
-        /// A map that contains all transmit profiles.
-        /// </summary>
-        static std::map<std::string, TransmitProfileRules> profiles;
-
-        /// <summary>
-        /// A string that contains the name of the currently active transmit profile.
-        /// </summary>
-        static std::string      currProfileName;
 
         /// <summary>
         /// The size of the currently active transmit profile rule.
@@ -161,12 +152,25 @@ namespace MAT_NS_BEGIN
         /// </summary>
         static bool isTimerUpdated;
 
+        static std::map<std::string, TransmitProfileRules>& GetProfiles() noexcept;
+        
         static void UpdateProfiles(const std::vector<TransmitProfileRules>& newProfiles) noexcept;
 
         static void EnsureDefaultProfiles() noexcept;
 
-    public:
+        /// <summary>
+        /// Removes custom profiles.
+        /// This method is called from parse only, and does not require the lock.
+        /// <b>Note:</b> This function is not thread safe.
+        /// </summary>
+        static void removeCustomProfiles();
 
+        /// <summary>
+        /// A timer update event handler.
+        /// </summary>
+        static void onTimersUpdated();
+
+    public:
 
         /// <summary>
         /// The TransmitProfiles default constructor.
@@ -182,13 +186,6 @@ namespace MAT_NS_BEGIN
         /// Prints transmit profiles to the debug log.
         /// </summary>
         static void dump();
-
-        /// <summary>
-        /// Removes custom profiles.
-        /// This method is called from parse only, and does not require the lock.
-        /// <b>Note:</b> This function is not thread safe.
-        /// </summary>
-        static void removeCustomProfiles();
 
         /// <summary>
         /// Parses transmit profiles from JSON.
@@ -248,11 +245,6 @@ namespace MAT_NS_BEGIN
         /// <param name="netCost">A reference to an instance of a MAT::NetworkCost enumeration.</param>
         /// <param name="powState">A reference to an instance of a MAT::PowerSource enumeration.</param>
         static void getDeviceState(NetworkCost &netCost, PowerSource &powState);
-
-        /// <summary>
-        /// A timer update event handler.
-        /// </summary>
-        static void onTimersUpdated();
 
         /// <summary>
         /// Determines whether a timer should be updated.

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -96,9 +96,18 @@ namespace PAL_NS_BEGIN {
         bool isLoggingInited = false;
 
 #ifdef HAVE_MAT_LOGGING
-        std::recursive_mutex          debugLogMutex;
-        std::string                   debugLogPath;
-        std::unique_ptr<std::fstream> debugLogStream;
+
+        std::recursive_mutex& GetDebugLogMutex()
+        {
+            static std::recursive_mutex debugLogMutex;
+            return debugLogMutex;
+        }
+        
+        std::unique_ptr<std::fstream>& GetDebugLogStream() noexcept
+        {
+            static std::unique_ptr<std::fstream> debugLogStream;
+            return debugLogStream;
+        }
 
         bool log_init(bool isTraceEnabled, const std::string& traceFolderPath)
         {
@@ -108,17 +117,18 @@ namespace PAL_NS_BEGIN {
             }
 
             bool result = true;
-            if (debugLogStream != nullptr)
+            if (GetDebugLogStream() != nullptr)
             {
                 return result;
             }
 
-            debugLogMutex.lock();
-            debugLogPath = traceFolderPath;
+            std::lock_guard<std::recursive_mutex> lockguard(GetDebugLogMutex());
+            std::string debugLogPath = traceFolderPath;
             debugLogPath += "mat-debug-";
             debugLogPath += std::to_string(MAT::GetCurrentProcessId());
             debugLogPath += ".log";
 
+            std::unique_ptr<std::fstream>& debugLogStream = GetDebugLogStream();
             debugLogStream = std::unique_ptr<std::fstream>(new std::fstream());
             debugLogStream->open(debugLogPath, std::fstream::out);
             if (!debugLogStream->is_open())
@@ -127,19 +137,18 @@ namespace PAL_NS_BEGIN {
                 debugLogStream->open(DEBUG_LOG_NULL);
                 result = false;
             }
-            debugLogMutex.unlock();
             return result;
         }
 
         void log_done()
         {
-            debugLogMutex.lock();
-            if (debugLogStream)
+            std::lock_guard<std::recursive_mutex> lockguard(GetDebugLogMutex());
+            std::unique_ptr<std::fstream>& debugLogStream = GetDebugLogStream();
+            if (debugLogStream != nullptr)
             {
                 debugLogStream = nullptr;
                 isLoggingInited = false;
             }
-            debugLogMutex.unlock();
         }
 #else
         bool log_init(bool /*isTraceEnabled*/, const std::string& /*traceFolderPath*/)
@@ -258,14 +267,14 @@ namespace PAL_NS_BEGIN {
                 // Make sure all of our debug strings contain EOL
                 buffer[len] = '\n';
                 // Log to debug log file if enabled
-                debugLogMutex.lock();
+                std::lock_guard<std::recursive_mutex> lockguard(GetDebugLogMutex());
+                std::unique_ptr<std::fstream>& debugLogStream = GetDebugLogStream();
                 if (debugLogStream->good())
                 {
                     (*debugLogStream) << buffer;
                     // flush is not very efficient, but needed to get realtime file updates
                     debugLogStream->flush();
                 }
-                debugLogMutex.unlock();
             }
             va_end(ap);
 #endif

--- a/lib/tpm/TransmitProfiles.cpp
+++ b/lib/tpm/TransmitProfiles.cpp
@@ -71,15 +71,6 @@ namespace MAT_NS_BEGIN {
         return profiles_mtx;
     }
 
-    /// <summary>
-    /// A string that contains the name of the currently active transmit profile.
-    /// </summary>
-    std::string& GetCurrProfileName()
-    {
-        static std::string currProfileName = DEFAULT_PROFILE;
-        return currProfileName;
-    }
-
     size_t      TransmitProfiles::currRule = 0;
     NetworkCost TransmitProfiles::currNetCost = NetworkCost::NetworkCost_Any;
     PowerSource TransmitProfiles::currPowState = PowerSource::PowerSource_Any;
@@ -92,6 +83,15 @@ namespace MAT_NS_BEGIN {
     {
         static std::map<std::string, TransmitProfileRules> profiles;
         return profiles;
+    }
+
+    /// <summary>
+    /// A string that contains the name of the currently active transmit profile.
+    /// </summary>
+    std::string& TransmitProfiles::GetCurrProfileName() noexcept
+    {
+        static std::string currProfileName = DEFAULT_PROFILE;
+        return currProfileName;
     }
 
     /// <summary>

--- a/tests/unittests/TransmitProfilesTests.cpp
+++ b/tests/unittests/TransmitProfilesTests.cpp
@@ -13,12 +13,12 @@ class TransmitProfilesTests : public TransmitProfiles, public ::testing::Test
 protected:
     virtual void SetUp() override
     {
-        TransmitProfiles::profiles.clear();
+        TransmitProfiles::GetProfiles().clear();
     }
 
     virtual void TearDown() override
     {
-        TransmitProfiles::profiles.clear();
+        TransmitProfiles::GetProfiles().clear();
     }
 };
 
@@ -58,224 +58,224 @@ protected:
 
 TEST_F(TransmitProfilesTests, EnsureDefaultProfiles_NeverCalledBefore_ProfilesSizeIsThree)
 {
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t{0});
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t{0});
     TransmitProfiles::EnsureDefaultProfiles();
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t{3});
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t{3});
 }
 
 TEST_F(TransmitProfilesTests, EnsureDefaultProfiles_CalledTwice_ProfilesSizeIsThree)
 {
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t{0});
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t{0});
     TransmitProfiles::EnsureDefaultProfiles();
     TransmitProfiles::EnsureDefaultProfiles();
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t{3});
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t{3});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeProfileEntryMatchesKey)
 {
-    ASSERT_EQ(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].name, defaultRealTimeProfileName);
+    ASSERT_EQ(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].name, defaultRealTimeProfileName);
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeProfileHasElevenRules)
 {
-    const auto& profile = TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}];
+    const auto& profile = TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}];
     ASSERT_EQ(profile.rules.size(), size_t{11});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleZeroIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleOneIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {16, 8, 4});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {16, 8, 4});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleTwoIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {16, 8, 4});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {16, 8, 4});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleThreeIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {12, 6, 3});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {12, 6, 3});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleFourIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {8, 4, 2});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {8, 4, 2});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleFiveIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {8, 4, 2});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {8, 4, 2});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleSixIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {4, 2, 1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {4, 2, 1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleSevenIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {8, 4, 2});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {8, 4, 2});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleEightIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {8, 4, 2});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {8, 4, 2});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleNineIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {4, 2, 1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {4, 2, 1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_RealTimeRuleTenIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultRealTimeProfileName}].rules[10], {-1, -1, -1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultRealTimeProfileName}].rules[10], {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeProfileEntryMatchesKey)
 {
-    ASSERT_EQ(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].name, defaultNearRealTimeProfileName);
+    ASSERT_EQ(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].name, defaultNearRealTimeProfileName);
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeProfileHasElevenRules)
 {
-    const auto& profile = TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}];
+    const auto& profile = TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}];
     ASSERT_EQ(profile.rules.size(), size_t{11});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleZeroIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleOneIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 24, 12});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 24, 12});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleTwoIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 24, 12});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 24, 12});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleThreeIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 18, 9});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 18, 9});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleFourIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {24, 12, 6});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {24, 12, 6});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleFiveIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {24, 12, 6});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {24, 12, 6});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleSixIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {12, 6, 3});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {12, 6, 3});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleSevenIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {24, 12, 6});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {24, 12, 6});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleEightIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {24, 12, 6});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {24, 12, 6});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleNineIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {12, 6, 3});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {12, 6, 3});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_NearRealTimeRuleTenIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultNearRealTimeProfileName}].rules[10], {-1, -1, -1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultNearRealTimeProfileName}].rules[10], {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortProfileEntryMatchesKey)
 {
-    ASSERT_EQ(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].name, defaultBestEffortProfileName);
+    ASSERT_EQ(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].name, defaultBestEffortProfileName);
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortProfileHasElevenRules)
 {
-    const auto& profile = TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}];
+    const auto& profile = TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}];
     ASSERT_EQ(profile.rules.size(), size_t{11});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleZeroIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[0], NetworkCost::NetworkCost_Roaming, {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleOneIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 72, 36});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[1], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Unknown, {-1, 72, 36});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleTwoIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 72, 36});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[2], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Battery, {-1, 72, 36});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleThreeIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 54, 27});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[3], NetworkCost::NetworkCost_Metered, PowerSource::PowerSource_Charging, {-1, 54, 27});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleFourIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {72, 36, 18});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[4], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Unknown, {72, 36, 18});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleFiveIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {72, 36, 18});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[5], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Battery, {72, 36, 18});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleSixIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {36, 18, 9});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[6], NetworkCost::NetworkCost_Unmetered, PowerSource::PowerSource_Charging, {36, 18, 9});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleSevenIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {72, 36, 18});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[7], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Unknown, {72, 36, 18});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleEightIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {72, 36, 18});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[8], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Battery, {72, 36, 18});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleNineIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {36, 18, 9});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[9], NetworkCost::NetworkCost_Unknown, PowerSource::PowerSource_Charging, {36, 18, 9});
 }
 
 TEST_F(TransmitProfilesTests_EnsureDefaultProfiles, Pinning_BestEffortRuleTenIsCorrect)
 {
-    ValidateTransmitProfileRule(TransmitProfiles::profiles[std::string{defaultBestEffortProfileName}].rules[10], {-1, -1, -1});
+    ValidateTransmitProfileRule(TransmitProfiles::GetProfiles()[std::string{defaultBestEffortProfileName}].rules[10], {-1, -1, -1});
 }
 
 TEST_F(TransmitProfilesTests, UpdateProfiles_ProfileAlreadyAddedAndNotInNewProfiles_PreviousCustomProfilesRemoved)
 {
     const std::string previousRuleName = "previousRule";
     TransmitProfileRules previousRule{previousRuleName, {}};
-    TransmitProfiles::profiles[previousRuleName] = previousRule;
+    TransmitProfiles::GetProfiles()[previousRuleName] = previousRule;
     TransmitProfiles::UpdateProfiles(std::vector<TransmitProfileRules>{});
-    ASSERT_TRUE(TransmitProfiles::profiles.find(previousRuleName) == TransmitProfiles::profiles.end());
+    ASSERT_TRUE(TransmitProfiles::GetProfiles().find(previousRuleName) == TransmitProfiles::GetProfiles().end());
 }
 
 TEST_F(TransmitProfilesTests, UpdateProfiles_NewRule_NewRuleAddedToProfiles)
@@ -283,32 +283,32 @@ TEST_F(TransmitProfilesTests, UpdateProfiles_NewRule_NewRuleAddedToProfiles)
     const std::string newRuleName = "newRule";
     TransmitProfileRules newRule{newRuleName, {}};
     TransmitProfiles::UpdateProfiles(std::vector<TransmitProfileRules>{newRule});
-    ASSERT_TRUE(TransmitProfiles::profiles.find(newRuleName) != TransmitProfiles::profiles.end());
+    ASSERT_TRUE(TransmitProfiles::GetProfiles().find(newRuleName) != TransmitProfiles::GetProfiles().end());
 }
 
 TEST_F(TransmitProfilesTests, UpdateProfiles_OldCurrentProfileDoesntExistInNewRules_SetCurrentProfileToDefault)
 {
-    TransmitProfiles::currProfileName = std::string{"newRule"};
+    TransmitProfiles::GetCurrProfileName() = std::string{"newRule"};
     TransmitProfiles::UpdateProfiles(std::vector<TransmitProfileRules>{});
-    ASSERT_EQ(TransmitProfiles::currProfileName, std::string{"REAL_TIME"});
+    ASSERT_EQ(TransmitProfiles::GetCurrProfileName(), std::string{"REAL_TIME"});
 }
 
 TEST_F(TransmitProfilesTests, UpdateProfiles_OldCurrentProfileExistsInNewRules_CurrentProfileNotChanged)
 {
     const std::string newRuleName = "newRule";
-    TransmitProfiles::currProfileName = newRuleName;
+    TransmitProfiles::GetCurrProfileName() = newRuleName;
     TransmitProfileRule rule;
     rule.timers = {1, 2, 3};
     TransmitProfileRules newRule{newRuleName, {rule}};
     TransmitProfiles::UpdateProfiles(std::vector<TransmitProfileRules>{newRule});
-    ASSERT_EQ(TransmitProfiles::currProfileName, newRuleName);
+    ASSERT_EQ(TransmitProfiles::GetCurrProfileName(), newRuleName);
 }
 
 TEST_F(TransmitProfilesTests, load_VectorIsLargerThanMaxTransmitProfiles_ReturnsFalseAndSizeThree)
 {
     std::vector<TransmitProfileRules> newProfiles{MAX_TRANSMIT_PROFILES + 1};
     ASSERT_FALSE(TransmitProfiles::load(newProfiles));
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t { 3 });
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t { 3 });
 }
 
 TEST_F(TransmitProfilesTests, load_OneProfileTooManyRules_ReturnsFalseAndSizeThree)
@@ -317,7 +317,7 @@ TEST_F(TransmitProfilesTests, load_OneProfileTooManyRules_ReturnsFalseAndSizeThr
     profile.rules = std::vector<TransmitProfileRule>{MAX_TRANSMIT_RULES + 1};
     std::vector<TransmitProfileRules> newProfiles{profile};
     ASSERT_FALSE(TransmitProfiles::load(newProfiles));
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t { 3 });
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t { 3 });
 }
 
 TEST_F(TransmitProfilesTests, load_OneProfileNoRules_ReturnsFalseAndSizeThree)
@@ -325,7 +325,7 @@ TEST_F(TransmitProfilesTests, load_OneProfileNoRules_ReturnsFalseAndSizeThree)
     TransmitProfileRules profile{"testProfile", { }};
     std::vector<TransmitProfileRules> newProfiles{profile};
     ASSERT_FALSE(TransmitProfiles::load(newProfiles));
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t { 3 });
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t { 3 });
 }
 
 TEST_F(TransmitProfilesTests, load_OneProfileOneRuleNoTimers_ReturnsFalseAndSizeThree)
@@ -334,7 +334,7 @@ TEST_F(TransmitProfilesTests, load_OneProfileOneRuleNoTimers_ReturnsFalseAndSize
     TransmitProfileRules profile{"testProfile", { rule }};
     std::vector<TransmitProfileRules> newProfiles{profile};
     ASSERT_FALSE(TransmitProfiles::load(newProfiles));
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t { 3 });
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t { 3 });
 }
 
 TEST_F(TransmitProfilesTests, load_OneRule_ReturnsTrueAndSizeFour)
@@ -344,7 +344,7 @@ TEST_F(TransmitProfilesTests, load_OneRule_ReturnsTrueAndSizeFour)
     TransmitProfileRules profile{"testProfile", { rule }};
     std::vector<TransmitProfileRules> newProfiles{profile};
     ASSERT_TRUE(TransmitProfiles::load(newProfiles));
-    ASSERT_EQ(TransmitProfiles::profiles.size(), size_t { 4 });
+    ASSERT_EQ(TransmitProfiles::GetProfiles().size(), size_t { 4 });
 }
 
 #ifdef HAVE_MAT_JSONHPP


### PR DESCRIPTION
Telemetry API should be accessible before global C++ objects (with non-trivial constructors) are constructed. This may happen when executing code in +load in Obj-C runtime, which starts before C++ globals construction, or in case of global C++ constructors race, where the order of constructors is not guaranteed in some runtimes.
The replacements for such problematic globals are accessor functions with local static objects created on demand.
