### PR TITLE
Use correct `const` modifier in `EventProperties::unpack`

### DIFF
--- a/lib/include/public/EventProperties.hpp
+++ b/lib/include/public/EventProperties.hpp
@@ -363,7 +363,7 @@ namespace MAT_NS_BEGIN
 #ifdef MAT_C_API
         /// Implementation of ABI-safe packing of EventProperties object
         evt_prop* pack();
-        bool unpack(evt_prop* packed, size_t size);
+        bool unpack(const evt_prop* packed, size_t size);
 #endif
 
        private:

--- a/lib/system/EventProperties.cpp
+++ b/lib/system/EventProperties.cpp
@@ -485,9 +485,9 @@ namespace MAT_NS_BEGIN {
     static const std::string KEY_PRSIST    = COMMONFIELDS_EVENT_PERSISTENCE;
     static const std::string KEY_POLICY    = COMMONFIELDS_EVENT_POLICYFLAGS;
 
-    bool EventProperties::unpack(evt_prop *packed, size_t size)
+    bool EventProperties::unpack(const evt_prop *packed, size_t size)
     {
-        evt_prop *curr = packed;
+        const evt_prop *curr = packed;
         if (packed==nullptr)
         {
             // Invalid input (nullptr) from C API results in an empty property bag


### PR DESCRIPTION
The method does not modify the vt_prop so it should take a const object