### PR TITLE
Add Distributed Tracing semantics

### DIFF
--- a/lib/include/public/CommonFields.h
+++ b/lib/include/public/CommonFields.h
@@ -24,6 +24,15 @@
 #define COMMONFIELDS_DEVICE_CLASS                            "DeviceInfo.Class"
 #define COMMONFIELDS_DEVICE_ORGID                            "DeviceInfo.OrgId"
 
+/* Ref. https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+ - ParentId  - parent of the current span received via remote context propagation.
+ - SpanId    - current SpanId sent in 'traceparent' to remote service.
+ */
+#define COMMONFIELDS_DT_TRACEID                              "env_dt_traceId"
+#define COMMONFIELDS_DT_SPANID                               "env_dt_spanId"
+#define COMMONFIELDS_DT_TRACEFLAGS                           "env_dt_traceFlags"
+#define COMMONFIELDS_DT_PARENTID                             "parentId"
+
 #define COMMONFIELDS_NETWORK_PROVIDER                        "DeviceInfo.NetworkProvider"
 #define COMMONFIELDS_NETWORK_TYPE                            "DeviceInfo.NetworkType"
 #define COMMONFIELDS_NETWORK_COST                            "DeviceInfo.NetworkCost"

--- a/lib/include/public/ISemanticContext.hpp
+++ b/lib/include/public/ISemanticContext.hpp
@@ -109,11 +109,38 @@ namespace MAT_NS_BEGIN
         /// <param name="deviceClass">Device class.</param>
         DECLARE_COMMONFIELD(DeviceClass, COMMONFIELDS_DEVICE_CLASS);
 
-          /// <summary>
+        /// <summary>
         /// Set the device orgId context information of telemetry event.
         /// </summary>
         /// <param name="deviceClass">Device orgId</param>
         DECLARE_COMMONFIELD(DeviceOrgId, COMMONFIELDS_DEVICE_ORGID);
+
+        /// <summary>
+        /// Set the W3C TraceContext TraceId information of telemetry event.
+        /// </summary>
+        /// <param name="traceId">TraceContext TraceId</param>
+        DECLARE_COMMONFIELD(TraceId, COMMONFIELDS_DT_TRACEID);
+
+        /// <summary>
+        /// Set the W3C TraceContext SpanId information of telemetry event.
+        /// </summary>
+        /// <param name="spanId">TraceContext SpanId</param>
+        DECLARE_COMMONFIELD(SpanId, COMMONFIELDS_DT_SPANID);
+
+        /// <summary>
+        /// Set the W3C TraceContext TraceFlags information of telemetry event.
+        /// </summary>
+        /// <param name="TraceFlags">TraceContext TraceFlags</param>
+        virtual void SetTraceFlags(uint8_t traceFlags)
+        {
+            SetCommonField(COMMONFIELDS_DT_TRACEFLAGS, traceFlags);
+        }
+
+        /// <summary>
+        /// Set the remote context (parent) SpanId information of telemetry event.
+        /// </summary>
+        /// <param name="ParentId">ParentId</param>
+        DECLARE_COMMONFIELD(ParentId, COMMONFIELDS_DT_PARENTID);
 
         /// <summary>
         /// Set the network cost context information of telemetry event.

--- a/lib/shared/SemanticContextCX.cpp
+++ b/lib/shared/SemanticContextCX.cpp
@@ -117,6 +117,27 @@ namespace Microsoft {
                 {
                     m_semanticContextCore->SetUserTimeZone(FromPlatformString(userTimeZone));
                 }
+
+                void SemanticContextImpl::TraceId::set(String^ traceId)
+                {
+                    m_semanticContextCore->SetTraceId(FromPlatformString(traceId));
+                }
+
+                void SemanticContextImpl::SpanId::set(String ^ spanId)
+                {
+                    m_semanticContextCore->SetSpanId(FromPlatformString(spanId));
+                }
+
+                void SemanticContextImpl::ParentId::set(String ^ parentId)
+                {
+                    m_semanticContextCore->SetParentId(FromPlatformString(parentId));
+                }
+
+                void SemanticContextImpl::TraceFlags::set(unsigned char traceFlags)
+                {
+                    m_semanticContextCore->SetTraceFlags(static_cast<uint8_t>(traceFlags));
+                }
+
             }
         }
     }

--- a/lib/shared/SemanticContextCX.hpp
+++ b/lib/shared/SemanticContextCX.hpp
@@ -100,6 +100,23 @@ namespace Microsoft {
                     }
 
                     virtual void SetUserId(String^ userId, PiiKind piiKind) = 0;
+
+                    property String^ TraceId {
+                        virtual void set(String^ traceId) = 0;
+                    }
+
+                    property String^ SpanId {
+                        virtual void set(String^ spanId) = 0;
+                    }
+
+                    property unsigned char TraceFlags
+                    {
+                        virtual void set(unsigned char traceFlags) = 0;
+                    }
+
+                    property String^ ParentId {
+                        virtual void set(String^ parentId) = 0;
+                    }
                 };
 
                 /// @cond INTERNAL_DOCS
@@ -206,8 +223,25 @@ namespace Microsoft {
                     {
                         virtual void set(String^ appExperimentIds);
                     }
-                                        
-                    virtual void SetEventExperimentIds(String^ eventName, String^ experimentIds);					
+
+                    virtual void SetEventExperimentIds(String^ eventName, String^ experimentIds);
+
+                    property String^ TraceId {
+                        virtual void set(String^ traceId);
+                    }
+
+                    property String^ SpanId {
+                        virtual void set(String ^ spanId);
+                    }
+
+                    property unsigned char TraceFlags
+                    {
+                        virtual void set(unsigned char traceFlags);
+                    }
+
+                    property String^ ParentId {
+                        virtual void set(String ^ parentId);
+                    }
 
                 internal:
                     SemanticContextImpl(MAT::ISemanticContext* semanticContextCore);


### PR DESCRIPTION
Add Distributed Tracing semantics to the following APIs:
- `ISemanticContext` - allows to set context on all events emitted by `ILogger`
- ability to use `env_dt` aliases to customize TraceContext of individual events running in a given scope
- semantic context projection for C++/CL/CX apps on Windows
- add test that emits two events with DT semantics

PR adds "common" fields:
- `env_dt_traceId`
- `env_dt_spanId`
- `env_dt_traceFlags`
- Part B `parentId`

And the set of corresponding high-level API setters at context-level:
- SetTraceId
- SetSpanId
- SetTraceFlags
- SetParentId
which is styled in the same way as other common context variables.

How to use it:
- events land in Aria-Kusto or Kusto and could be subsequently routed to Geneva via 1DS-Interchange.
- events landing in Geneva have the required `ext.dt` extension semantics, just enough for the Trace Explorer view to work.. Less duration semantics: since 1DS in principle does not require client events to have "duration", start / end / scope. Events are timepoints that carry `timestamp` and `name`. How exactly to remap these, i.e. what would/could/should be considered duration - is out-of-scope of this PR.

How this could be improved further:
- There's no helper for formatting TraceContext. Users may use whatever formatter of their choice, e.g. taking a dependency on OpenTelemetry API for well-formed context of [trace parent header values](https://www.w3.org/TR/trace-context/). In our org scenario we are utilizing existing .NET APIs that already give us the access to values in the right format, so calling into 1DS C++ SDK via projection is trivial. We do not require manual formatting of these values in C++ land.
- Should someone need to learn how to do this formatting in C++ - please refer to the [OpenTelemetry C++ code here](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api/include/opentelemetry/trace), that illustrates how to format TraceId and SpanId to hexadecimal string values.

Example showing how events look when traced from client to service in one Kusto table:
![image](https://user-images.githubusercontent.com/34072974/199130746-a1e88a73-c928-4c2f-8c78-e34bf4cf1c7b.png)

Disregard the column names in the above screenshot, the proper long-term names compatible with our current Distributed Tracing explorer are those mentioned above (`env_dt_*` and Part B `parentId`).

`APITest` verifies the basic functionality. More complex usage examples are not presently a priority for our team, since in our case we use the higher-level .NET `StartActivity` API while interacting with remote service instrumented with OpenTelemetry, and supplement the existing client telemetry events with correlation identifiers that follow Common Schema naming, specifically Common Schema -to- Geneva mapping.