### PR TITLE
Allow Kestrel webserver to use synchronous IO

### DIFF
--- a/tools/server/Program.cs
+++ b/tools/server/Program.cs
@@ -26,7 +26,10 @@ namespace CommonSchema.Server
         public static void Main(string[] args)
         {
             CreateWebHostBuilder(args)
-            .UseKestrel()
+            .UseKestrel(options =>
+            {
+                options.AllowSynchronousIO = true;
+            })
             .UseContentRoot(Directory.GetCurrentDirectory())
             .UseWebRoot(Path.Combine(Directory.GetCurrentDirectory(), "wwwroot"))
             .ConfigureAppConfiguration((hostingContext, config) =>


### PR DESCRIPTION
By default, Kestrel webserver doesn't allow to accept sync request. See more details [here](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#synchronous-io).

However, when .net 1DS SDK is used with default configuration it sends sync request to 1DS test server and as a result request is processed with error:
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/1.1 POST http://localhost:63980/OneCollector/ application/bond-compact-binary 494
info: REQ-1[0]
      Connection: keep-alive
Content-Type: application/bond-compact-binary
Content-Encoding: gzip
Host: localhost:63980
User-Agent: OneCollectorSDK server
Content-Length: 494
Client-Version: AST-windows-C#-no-1.1.3.308-no
Upload-Time: 1667921679807
client-time-epoch-millis: 1667921679807
Client-Id: NO_AUTH

fail: REQ-1[0]
      Exception: System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead.
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestStream.Read(Byte[] buffer, Int32 offset, Int32 count)
         at System.IO.BinaryReader.ReadBytes(Int32 count)
         at CommonSchema.Server.Startup.<>c__DisplayClass2_0.<<Configure>b__0>d.MoveNext() in 
```

Because this server is intended to be used for the test purpose only, it is reasonable to allow to use synchronous IO