### PR TITLE
Hide misleading exception

### DIFF
--- a/tools/decoder/Decoder.cs
+++ b/tools/decoder/Decoder.cs
@@ -26,6 +26,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using CsProtocol;
 using System.Linq;
+using Fiddler;
 
 namespace CommonSchema
 {
@@ -324,6 +325,10 @@ namespace CommonSchema
                         jsonList.Add(j);
                         outputBuffer.SetLength(0);
                     } while (true);
+                }
+                catch (EndOfStreamException)
+                {
+                    Logger.LogDebug("End of Binary Stream");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
At the moment test server produces
```
Exception: System.IO.EndOfStreamException: Unexpected end of stream reached.
         at Bond.Protocols.Throw.EndOfStreamException()
         at Bond.IO.Safe.InputBuffer.EndOfStream(Int32 count)
         at Bond.IO.Safe.InputBuffer.ReadUInt8()
         at lambda_method(Closure , CompactBinaryReader`1 )
         at Bond.Deserializer`1.Deserialize[T](R reader)
         at Bond.Deserialize`1.From[R](R reader)
         at CommonSchema.Decoder.FromBondToJSONList(Boolean outputCompactJson, Boolean flatExt)
```

Even though [Decoder.cs](https://github.com/microsoft/cpp_client_telemetry/blob/7f36d8933e621f90513f69d78a40529fcc47a088/tools/decoder/Decoder.cs#L33) successfully read data and send successful response.

As I don't know better way to handle / detect that end of stream is reached and it seems that 1DS Test Server can keep processing request successfully, let's handle and log message for this exception (not stack trace). Then user won't see stacktrace and won't think that there is any error problem with Request or 1DS Test Server
