### PR TITLE
Handle exception thrown PlatformEventHandler deconstructor

### DIFF
--- a/lib/shared/WindowsRTPlatformEventHandler.cpp
+++ b/lib/shared/WindowsRTPlatformEventHandler.cpp
@@ -63,19 +63,26 @@ namespace Microsoft {
 
                 PlatformEventHandler::~PlatformEventHandler()
                 {
-                    if (this->m_suspendToken.Value != 0)
+                    try
                     {
-                        Application::Current->Suspending -= this->m_suspendToken;
-                    }
+                        if (this->m_suspendToken.Value != 0)
+                        {
+                            Application::Current->Suspending -= this->m_suspendToken;
+                        }
 
-                    if (this->m_resumeToken.Value != 0)
-                    {
-                        Application::Current->Resuming -= this->m_resumeToken;
-                    }
+                        if (this->m_resumeToken.Value != 0)
+                        {
+                            Application::Current->Resuming -= this->m_resumeToken;
+                        }
 
-                    if (this->m_unhandledExceptionToken.Value != 0)
+                        if (this->m_unhandledExceptionToken.Value != 0)
+                        {
+                            Application::Current->UnhandledException -= this->m_unhandledExceptionToken;
+                        }
+                    }
+                    catch (Exception^ e)
                     {
-                        Application::Current->UnhandledException -= this->m_unhandledExceptionToken;
+                        // Access to Application::Current can generate COM exceptions.
                     }
                 }
 


### PR DESCRIPTION
Catch exception when accessing Application::Current in WindowsRTPlatformEventHandler deconstructor like in the constructor as both have the same risk of throwing the exception.

Manually tested that it fixes the issue where the exception was thrown on the first deconstruction of a PlatformEventHandler on Windows.