### PR TITLE
[Fix: 1081] upgrade googletest to v1.12.1

### DIFF
--- a/build-all.bat
+++ b/build-all.bat
@@ -14,7 +14,7 @@ if DEFINED GIT_PULL_TOKEN (
 
 set GTEST_PATH=third_party\googletest
 if NOT EXIST %GTEST_PATH%\CMakeLists.txt (
- git clone --depth 1 --branch release-1.11.0 https://github.com/google/googletest %GTEST_PATH%
+ git clone --depth 1 --branch release-1.12.1 https://github.com/google/googletest %GTEST_PATH%
 )
 
 set CUSTOM_PROPS=

--- a/build-gtest.sh
+++ b/build-gtest.sh
@@ -19,7 +19,7 @@ GTEST_PATH=third_party/googletest
 if [ ! "$(ls -A $GTEST_PATH/CMakeLists.txt)" ]; then 
   echo Clone googletest from google/googletest:master ...
   rm -rf ${GTEST_PATH} #delete just if empty directory exists
-  git clone --depth 1 --branch release-1.11.0 https://github.com/google/googletest $GTEST_PATH
+  git clone --depth 1 --branch release-1.12.1 https://github.com/google/googletest $GTEST_PATH
 else
   echo "Using existing googletest from thirdparty/"
 fi

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -10,7 +10,7 @@ if DEFINED GIT_PULL_TOKEN (
 
 set GTEST_PATH=third_party\googletest
 if NOT EXIST %GTEST_PATH%\CMakeLists.txt (
-  git clone --depth 1 --branch release-1.12.0 https://github.com/google/googletest %GTEST_PATH%
+  git clone --depth 1 --branch release-1.12.1 https://github.com/google/googletest %GTEST_PATH%
 )
 
 set PLATFORM=

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -10,7 +10,7 @@ if DEFINED GIT_PULL_TOKEN (
 
 set GTEST_PATH=third_party\googletest
 if NOT EXIST %GTEST_PATH%\CMakeLists.txt (
-  git clone --depth 1 --branch release-1.11.0 https://github.com/google/googletest %GTEST_PATH%
+  git clone --depth 1 --branch release-1.12.0 https://github.com/google/googletest %GTEST_PATH%
 )
 
 set PLATFORM=

--- a/lib/android_build/gradlew.bat
+++ b/lib/android_build/gradlew.bat
@@ -17,7 +17,7 @@ set APP_HOME=%DIRNAME%
 set GTEST_PATH=..\..\third_party\googletest
 if NOT EXIST %GTEST_PATH%\CMakeLists.txt (
   rd /S /Q %GTEST_PATH%
-  git clone --depth 1 --branch release-1.11.0 https://github.com/google/googletest %GTEST_PATH%
+  git clone --depth 1 --branch release-1.12.1 https://github.com/google/googletest %GTEST_PATH%
   dir %GTEST_PATH%\googletest\src\gtest-all.cc
 )
 


### PR DESCRIPTION
Fixes: #1081 

The `ubuntu-latest` virtual environment for GitHub is upgraded to `ubuntu-22.04`, which brings `g++-11.0` as default compiler. And the version of googletest using by 1ds-sdk (`v1.11.1`) doesn't build successfully with new compiler. Refer - https://github.com/google/googletest/pull/3797 and https://github.com/google/googletest/issues/3219. The fix is to upgrade the googletest to latest version `v1.12.1`.
