### PR TITLE
Fix #1078 : Fix ARM build warning on Linux with gcc compiler

### DIFF
--- a/lib/include/public/VariantType.hpp
+++ b/lib/include/public/VariantType.hpp
@@ -396,7 +396,7 @@ public:
             case '\r': o << "\\r"; break;
             case '\t': o << "\\t"; break;
             default:
-                if ('\x00' <= *c && *c <= '\x1f') {
+                if ('\x00' <= static_cast<signed char>(*c) && *c <= '\x1f') {
                     o << "\\u"
                         << std::hex << std::setw(4) << std::setfill('0') << (int)*c;
                 }


### PR DESCRIPTION
Fix: #1078

`char` type is `unsigned char` by default in ARM processor (https://developer.arm.com/documentation/dui0472/k/C-and-C---Implementation-Details/Basic-data-types-in-ARM-C-and-C--), and `signed char` in x86 processor. This causes the comparison `'\x00' <= *c` as always true in ARM, and hence gcc compiler throws the warning "comparison is always true due to limited range" which is treated as error, and fails. Typecasting the char value to signed before comparison fixes the issue. This conversion is safe to do as it will typecast - 
 - signed char to signed char in x86 processor
 - unsigned char to signed char in ARM processor
 
 and both are type safe conversions.
