### PR TITLE
Fixing URLs for Collector

### DIFF
--- a/Solutions/win32-cs/Program.cs
+++ b/Solutions/win32-cs/Program.cs
@@ -54,7 +54,7 @@ namespace CLI
                 AutoLogAppSuspend = false,
                 AutoLogUnhandledException = false,
                 OfflineStorage = "offline.storage",
-                // CollectorURL = "https://pipe.int.trafficmanager.net/Collector/3.0/",	// INT collector example
+                // CollectorURL = "https://mobile.events-sandbox.data.microsoft.com/Collector/3.0/",	// INT collector example
                 MinTraceLevel = ACTTraceLevel.ACTTraceLevel_Trace,
                 TraceLevelMask = 0xFFFFFFFF, // API calls + Global mask for general messages                
                 MaxTeardownUploadTimeInSec = 5

--- a/examples/cpp/EventSender/EventSender.cpp
+++ b/examples/cpp/EventSender/EventSender.cpp
@@ -35,7 +35,7 @@ const char* defaultConfig = static_cast<const char *> JSON_CONFIG
             "dotType": true
         },
         "enableLifecycleSession" : false,
-        "eventCollectorUri" : "https://self.events.data.microsoft.com/OneCollector/1.0/",
+        "eventCollectorUri" : "https://mobile.events.data.microsoft.com/OneCollector/1.0/",
         "forcedTenantToken" : null,
         "hostMode" : true,
         "http" : {

--- a/examples/cpp/EventSender/direct.config
+++ b/examples/cpp/EventSender/direct.config
@@ -8,7 +8,7 @@
 		"dotType": true
 	},
 	"enableLifecycleSession": false,
-	"eventCollectorUri": "https://self.events.data.microsoft.com/OneCollector/1.0/",
+	"eventCollectorUri": "https://mobile.events.data.microsoft.com/OneCollector/1.0/",
 	"forcedTenantToken": null,
 	"hostMode": true,
 	"http": {

--- a/lib/android_build/app/src/androidTest/java/com/microsoft/applications/events/maesdktest/LogManagerDDVUnitTest.java
+++ b/lib/android_build/app/src/androidTest/java/com/microsoft/applications/events/maesdktest/LogManagerDDVUnitTest.java
@@ -538,7 +538,7 @@ public class LogManagerDDVUnitTest extends MaeUnitLogger {
   @Test
   public void getDefaultConfig() {
     ILogConfiguration defaultConfig = ILogConfiguration.getDefaultConfiguration();
-    final String COLLECTOR_URL_PROD = "https://self.events.data.microsoft.com/OneCollector/1.0/";
+    final String COLLECTOR_URL_PROD = "https://mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     assertThat(defaultConfig.getBoolean(LogConfigurationKey.CFG_BOOL_ENABLE_ANALYTICS), is(false));
     assertThat(defaultConfig.getLong(LogConfigurationKey.CFG_INT_CACHE_FILE_SIZE), is(3145728L));

--- a/lib/include/public/ILogConfiguration.hpp
+++ b/lib/include/public/ILogConfiguration.hpp
@@ -22,32 +22,32 @@ namespace MAT_NS_BEGIN
     class IHttpClient;
 
     /// Default collector url to send events to
-    static constexpr const char* COLLECTOR_URL_PROD = "https://self.events.data.microsoft.com/OneCollector/1.0/";
+    static constexpr const char* COLLECTOR_URL_PROD = "https://mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     /// <summary>
     /// The URI of the United States collector.
     /// </summary>
-    static constexpr const char* COLLECTOR_URL_UNITED_STATES = "https://noam.events.data.microsoft.com/OneCollector/1.0/";
+    static constexpr const char* COLLECTOR_URL_UNITED_STATES = "https://us-mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     /// <summary>
     /// The URI of the German collector.
     /// </summary>
-    static constexpr const char* COLLECTOR_URL_GERMANY = "https://emea.events.data.microsoft.com/OneCollector/1.0/";
+    static constexpr const char* COLLECTOR_URL_GERMANY = "https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     /// <summary>
     /// The URI of the Australian collector.
     /// </summary>
-    static constexpr const char* COLLECTOR_URL_AUSTRALIA = "https://apac.events.data.microsoft.com/OneCollector/1.0/";
+    static constexpr const char* COLLECTOR_URL_AUSTRALIA = "https://au-mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     /// <summary>
     /// The URI of the Japanese collector.
     /// </summary>
-    static constexpr const char* COLLECTOR_URL_JAPAN = "https://apac.events.data.microsoft.com/OneCollector/1.0/";
+    static constexpr const char* COLLECTOR_URL_JAPAN = "https://jp-mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     /// <summary>
     /// The URI of the European collector.
     /// </summary>
-    static constexpr const char* COLLECTOR_URL_EUROPE = "https://emea.events.data.microsoft.com/OneCollector/1.0/";
+    static constexpr const char* COLLECTOR_URL_EUROPE = "https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/";
 
     /// <summary>
     /// The real-time transmit profile.

--- a/lib/shared/LogConfigurationCX.hpp
+++ b/lib/shared/LogConfigurationCX.hpp
@@ -43,19 +43,19 @@ namespace Microsoft {
                 {
                 public:
 #ifndef _WINRT_DLL  /* C# .NET implementation */
-                    static String^ CollectorUrlDefault      = L"https://self.events.data.microsoft.com/OneCollector/1.0/";
-                    static String^ CollectorUrlUnitedStates = L"https://noam.events.data.microsoft.com/OneCollector/1.0/";
-                    static String^ CollectorUrlGermany      = L"https://emea.events.data.microsoft.com/OneCollector/1.0/";
-                    static String^ CollectorUrlAustralia    = L"https://apac.events.data.microsoft.com/OneCollector/1.0/";
-                    static String^ CollectorUrlJapan        = L"https://apac.events.data.microsoft.com/OneCollector/1.0/";
-                    static String^ CollectorUrlEurope       = L"https://emea.events.data.microsoft.com/OneCollector/1.0/";
+                    static String^ CollectorUrlDefault      = L"https://mobile.events.data.microsoft.com/OneCollector/1.0/";
+                    static String^ CollectorUrlUnitedStates = L"https://us-mobile.events.data.microsoft.com/OneCollector/1.0/";
+                    static String^ CollectorUrlGermany      = L"https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/";
+                    static String^ CollectorUrlAustralia    = L"https://au-mobile.events.data.microsoft.com/OneCollector/1.0/";
+                    static String^ CollectorUrlJapan        = L"https://jp-mobile.events.data.microsoft.com/OneCollector/1.0/";
+                    static String^ CollectorUrlEurope       = L"https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/";
 #else               /* WinRT .winmd linkage implementation*/
-                    static property String^ CollectorUrlDefault      { String ^get() { return L"https://self.events.data.microsoft.com/OneCollector/1.0/"; } }
-                    static property String^ CollectorUrlUnitedStates { String ^get() { return L"https://noam.events.data.microsoft.com/OneCollector/1.0/"; } }
-                    static property String^ CollectorUrlGermany      { String ^get() { return L"https://emea.events.data.microsoft.com/OneCollector/1.0/"; } }
-                    static property String^ CollectorUrlAustralia    { String ^get() { return L"https://apac.events.data.microsoft.com/OneCollector/1.0/"; } }
-                    static property String^ CollectorUrlJapan        { String ^get() { return L"https://apac.events.data.microsoft.com/OneCollector/1.0/"; } }
-                    static property String^ CollectorUrlEurope       { String ^get() { return L"https://emea.events.data.microsoft.com/OneCollector/1.0/"; } }
+                    static property String^ CollectorUrlDefault      { String ^get() { return L"https://mobile.events.data.microsoft.com/OneCollector/1.0/"; } }
+                    static property String^ CollectorUrlUnitedStates { String ^get() { return L"https://us-mobile.events.data.microsoft.com/OneCollector/1.0/"; } }
+                    static property String^ CollectorUrlGermany      { String ^get() { return L"https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/"; } }
+                    static property String^ CollectorUrlAustralia    { String ^get() { return L"https://au-mobile.events.data.microsoft.com/OneCollector/1.0/"; } }
+                    static property String^ CollectorUrlJapan        { String ^get() { return L"https://jp-mobile.events.data.microsoft.com/OneCollector/1.0/"; } }
+                    static property String^ CollectorUrlEurope       { String ^get() { return L"https://eu-mobile.events.data.microsoft.com/OneCollector/1.0/"; } }
 #endif
                     LogConfiguration()
                     {

--- a/tests/functests/APITest.cpp
+++ b/tests/functests/APITest.cpp
@@ -1144,8 +1144,8 @@ TEST(APITest, LogConfiguration_MsRoot_Check)
         {
             {"https://v10.events.data.microsoft.com/OneCollector/1.0/", false, 1},   // MS-Rooted, no MS-Root check:     post succeeds
             {"https://v10.events.data.microsoft.com/OneCollector/1.0/", true, 1},    // MS-Rooted, MS-Root check:        post succeeds
-            {"https://self.events.data.microsoft.com/OneCollector/1.0/", false, 1},  // Non-MS rooted, no MS-Root check: post succeeds
-            {"https://self.events.data.microsoft.com/OneCollector/1.0/", true, 0}    // Non-MS rooted, MS-Root check:    post fails
+            {"https://mobile.events.data.microsoft.com/OneCollector/1.0/", false, 1},  // Non-MS rooted, no MS-Root check: post succeeds
+            {"https://mobile.events.data.microsoft.com/OneCollector/1.0/", true, 0}    // Non-MS rooted, MS-Root check:    post fails
         };
 
     // 4 test runs
@@ -1193,7 +1193,7 @@ TEST(APITest, LogManager_BadNetwork_Test)
         "https://0.0.0.0/",
         "https://127.0.0.1/",
 #endif
-        "https://1ds.pipe.int.trafficmanager.net/OneCollector/1.0/",
+        "https://mobile.events-sandbox.data.microsoft.com/OneCollector/1.0/",
         "https://invalid.host.name.microsoft.com/"
         })
     {

--- a/tests/unittests/HttpRequestEncoderTests.cpp
+++ b/tests/unittests/HttpRequestEncoderTests.cpp
@@ -65,7 +65,7 @@ TEST_F(HttpRequestEncoderTests, SetsAllParameters)
 
     EXPECT_THAT(req->m_id, Eq("HttpRequestEncoderTests"));
     EXPECT_THAT(req->m_method, Eq("POST"));
-    EXPECT_THAT(req->m_url, Eq("https://self.events.data.microsoft.com/OneCollector/1.0/"));
+    EXPECT_THAT(req->m_url, Eq("https://mobile.events.data.microsoft.com/OneCollector/1.0/"));
     EXPECT_THAT(req->m_headers, Contains(Pair("Expect", "100-continue")));
     EXPECT_THAT(req->m_headers, Contains(Pair("SDK-Version", PAL::getSdkVersion())));
     EXPECT_THAT(req->m_headers, Contains(Pair("Client-Id", "NO_AUTH")));


### PR DESCRIPTION
The current default URLs for Collector the SDK is using are not the preferred URLs. We no longer want teams to use EMEA, NOAM or APAC URLs, because those are geographic boundaries and not data boundaries. We also don't want the "self" URL to be used, since that was never intended to be public. That was intended for internal use. 

The preferred URLs are:

mobile.events.data.microsoft.com
eu-mobile.events.data.microsoft.com
us-mobile.events.data.microsoft.com
au-mobile.events.data.microsoft.com
jp-mobile.events.data.microsoft.com

..

All future geo URLs will follow this same pattern.