### PR TITLE
Maxgolov/shared library

### DIFF
--- a/lib/include/public/ctmacros.hpp
+++ b/lib/include/public/ctmacros.hpp
@@ -127,4 +127,24 @@
 #define EVTSDK_LIBABI_CDECL MATSDK_LIBABI_CDECL
 #define EVTSDK_SPEC         MATSDK_SPEC
 
+/* Implement struct packing for stable FFI C API */
+#ifdef __clang__
+# define MATSDK_PACKED_STRUCT __attribute__((packed))
+# define MATSDK_PACK_PUSH
+# define MATSDK_PACK_POP
+#elif __GNUC__
+# define MATSDK_PACKED_STRUCT __attribute__((packed))
+# define MATSDK_PACK_PUSH
+# define MATSDK_PACK_POP
+#elif _MSC_VER
+# define MATSDK_PACKED_STRUCT
+# define MATSDK_PACK_PUSH     __pragma(pack(push, 1))
+# define MATSDK_PACK_POP      __pragma(pack(pop))
+#else
+/* No packing behavior on unknown compilers */
+# define MATSDK_PACKED_STRUCT
+# define MATSDK_PACK_PUSH
+# define MATSDK_PACK_POP
+#endif
+
 #endif

--- a/lib/include/public/mat.h
+++ b/lib/include/public/mat.h
@@ -9,12 +9,26 @@
  * For version handshake check there is no mandatory requirement to update the $PATCH level.
  * Ref. https://semver.org/ for Semantic Versioning documentation.
  */
-#define TELEMETRY_EVENTS_VERSION	"3.1.0"
+#define TELEMETRY_EVENTS_VERSION "3.4.0"
 
 #include "ctmacros.hpp"
 
 #ifdef _WIN32
 #include <Windows.h>
+#endif
+
+#ifdef __clang__
+#define PACKED_STRUCT __attribute__((packed))
+#define PACK_PUSH
+#define PACK_POP
+#elif __GNUC__
+#define PACKED_STRUCT __attribute__((packed))
+#define PACK_PUSH
+#define PACK_POP
+#else
+#define PACKED_STRUCT
+#define PACK_PUSH     __pragma(pack(push, 1))
+#define PACK_POP      __pragma(pack(pop))
 #endif
 
 #if (_MSC_VER == 1500) || (_MSC_VER == 1600)
@@ -45,7 +59,7 @@ typedef int                 bool;
 extern "C" {
 #endif
 
-    typedef enum evt_call_t
+    typedef enum evt_call_t /* 32-bit */
     {
         EVT_OP_LOAD = 0x00000001,
         EVT_OP_UNLOAD = 0x00000002,
@@ -59,10 +73,11 @@ extern "C" {
         EVT_OP_FLUSH = 0x0000000A,
         EVT_OP_VERSION = 0x0000000B,
         EVT_OP_OPEN_WITH_PARAMS = 0x0000000C,
-        EVT_OP_MAX = EVT_OP_OPEN_WITH_PARAMS + 1
+        EVT_OP_MAX = EVT_OP_OPEN_WITH_PARAMS + 1,
+        EVT_OP_MAXINT = 0xFFFFFFFF
     } evt_call_t;
 
-    typedef enum evt_prop_t
+    typedef enum evt_prop_t /* 32-bit */
     {
         /* Basic types */
         TYPE_STRING,
@@ -79,11 +94,13 @@ extern "C" {
         TYPE_BOOL_ARRAY,
         TYPE_GUID_ARRAY,
         /* NULL-type */
-        TYPE_NULL
+        TYPE_NULL,
+        TYPE_MAXINT = 0xFFFFFFFF
     } evt_prop_t;
 
-    typedef struct evt_guid_t
+    typedef struct PACKED_STRUCT evt_guid_t
     {
+PACK_PUSH
         /**
          * <summary>
          * Specifies the first eight hexadecimal digits of the GUID.
@@ -111,19 +128,22 @@ extern "C" {
          * </summary>
          */
         uint8_t  Data4[8];
+PACK_POP
     } evt_guid_t;
 
     typedef int64_t  evt_handle_t;
     typedef int32_t  evt_status_t;
     typedef struct   evt_event evt_event;
 
-    typedef struct evt_context_t
+    typedef struct PACKED_STRUCT evt_context_t
     {
+PACK_PUSH
         evt_call_t      call;       /* In       */
         evt_handle_t    handle;     /* In / Out */
         void*           data;       /* In / Out */
         evt_status_t    result;     /* Out      */
         uint32_t        size;       /* In / Out */
+PACK_POP
     } evt_context_t;
 
     /**
@@ -183,12 +203,14 @@ extern "C" {
         uint64_t**          as_arr_time;
     } evt_prop_v;
 
-    typedef struct evt_prop
+    typedef struct PACKED_STRUCT evt_prop
     {
+PACK_PUSH
         const char*             name;
         evt_prop_t              type;
         evt_prop_v              value;
         uint32_t                piiKind;
+PACK_POP
     } evt_prop;
     
     /**

--- a/lib/include/public/mat.h
+++ b/lib/include/public/mat.h
@@ -17,20 +17,6 @@
 #include <Windows.h>
 #endif
 
-#ifdef __clang__
-#define PACKED_STRUCT __attribute__((packed))
-#define PACK_PUSH
-#define PACK_POP
-#elif __GNUC__
-#define PACKED_STRUCT __attribute__((packed))
-#define PACK_PUSH
-#define PACK_POP
-#else
-#define PACKED_STRUCT
-#define PACK_PUSH     __pragma(pack(push, 1))
-#define PACK_POP      __pragma(pack(pop))
-#endif
-
 #if (_MSC_VER == 1500) || (_MSC_VER == 1600)
 /* Visual Studio 2010 */
 typedef	__int64				int64_t;
@@ -59,7 +45,7 @@ typedef int                 bool;
 extern "C" {
 #endif
 
-    typedef enum evt_call_t /* 32-bit */
+    typedef enum evt_call_t
     {
         EVT_OP_LOAD = 0x00000001,
         EVT_OP_UNLOAD = 0x00000002,
@@ -77,7 +63,7 @@ extern "C" {
         EVT_OP_MAXINT = 0xFFFFFFFF
     } evt_call_t;
 
-    typedef enum evt_prop_t /* 32-bit */
+    typedef enum evt_prop_t
     {
         /* Basic types */
         TYPE_STRING,
@@ -98,9 +84,9 @@ extern "C" {
         TYPE_MAXINT = 0xFFFFFFFF
     } evt_prop_t;
 
-    typedef struct PACKED_STRUCT evt_guid_t
+    typedef struct MATSDK_PACKED_STRUCT evt_guid_t
     {
-PACK_PUSH
+MATSDK_PACK_PUSH
         /**
          * <summary>
          * Specifies the first eight hexadecimal digits of the GUID.
@@ -128,22 +114,22 @@ PACK_PUSH
          * </summary>
          */
         uint8_t  Data4[8];
-PACK_POP
+MATSDK_PACK_POP
     } evt_guid_t;
 
     typedef int64_t  evt_handle_t;
     typedef int32_t  evt_status_t;
     typedef struct   evt_event evt_event;
 
-    typedef struct PACKED_STRUCT evt_context_t
+    typedef struct MATSDK_PACKED_STRUCT evt_context_t
     {
-PACK_PUSH
+MATSDK_PACK_PUSH
         evt_call_t      call;       /* In       */
         evt_handle_t    handle;     /* In / Out */
         void*           data;       /* In / Out */
         evt_status_t    result;     /* Out      */
         uint32_t        size;       /* In / Out */
-PACK_POP
+MATSDK_PACK_POP
     } evt_context_t;
 
     /**
@@ -203,14 +189,14 @@ PACK_POP
         uint64_t**          as_arr_time;
     } evt_prop_v;
 
-    typedef struct PACKED_STRUCT evt_prop
+    typedef struct MATSDK_PACKED_STRUCT evt_prop
     {
-PACK_PUSH
+MATSDK_PACK_PUSH
         const char*             name;
         evt_prop_t              type;
         evt_prop_v              value;
         uint32_t                piiKind;
-PACK_POP
+MATSDK_PACK_POP
     } evt_prop;
     
     /**

--- a/wrappers/netcore/EventNativeAPI.cs
+++ b/wrappers/netcore/EventNativeAPI.cs
@@ -1,0 +1,549 @@
+#pragma warning disable IDE1006 // ignore naming rule violations: we preserve original C API naming for clarity here
+#pragma warning disable IDE0044 // ignore readonly suggestion for field passed over P/Invoke
+#undef TRACE
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.IO;
+using System.Json;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections;
+
+namespace Microsoft
+{
+    namespace Telemetry
+    {
+        namespace Core
+        {
+            public class Constants
+            {
+                public const string LIBRARY_NAME = "ClientTelemetry";
+                public const string VERSION = "3.4.0-netcore";
+            }
+
+            public enum EventCallType : UInt32
+            {
+                EVT_OP_LOAD = 0x00000001,
+                EVT_OP_UNLOAD = 0x00000002,
+                EVT_OP_OPEN = 0x00000003,
+                EVT_OP_CLOSE = 0x00000004,
+                EVT_OP_CONFIG = 0x00000005,
+                EVT_OP_LOG = 0x00000006,
+                EVT_OP_PAUSE = 0x00000007,
+                EVT_OP_RESUME = 0x00000008,
+                EVT_OP_UPLOAD = 0x00000009,
+                EVT_OP_FLUSH = 0x0000000A,
+                EVT_OP_VERSION = 0x0000000B,
+                EVT_OP_OPEN_WITH_PARAMS = 0x0000000C,
+                EVT_OP_MAX = EVT_OP_OPEN_WITH_PARAMS + 1
+            }
+
+            public enum EventPropertyType : UInt32
+            {
+                /* Basic types */
+                TYPE_STRING = 0,
+                TYPE_INT64 = 1,
+                TYPE_DOUBLE = 2,
+                TYPE_TIME = 3,
+                TYPE_BOOLEAN = 4,
+                TYPE_GUID = 5,
+                /* Arrays of basic types */
+                TYPE_STRING_ARRAY = 6,
+                TYPE_INT64_ARRAY = 7,
+                TYPE_DOUBLE_ARRAY = 8,
+                TYPE_TIME_ARRAY = 9,
+                TYPE_BOOL_ARRAY = 10,
+                TYPE_GUID_ARRAY = 11,
+                /* NULL-type */
+                TYPE_NULL = 12
+            }
+
+            public struct PiiKind
+            {
+                /// <summary>No PII kind.</summary>
+                public const int None = 0;
+                /// <summary>An LDAP distinguished name.</summary>
+                public const int DistinguishedName = 1;
+                /// <summary>Generic data.</summary>
+                public const int GenericData = 2;
+                /// <summary>An IPV4 Internet address.</summary>
+                public const int IPv4Address = 3;
+                /// <summary>An IPV6 Internet address.</summary>
+                public const int IPv6Address = 4;
+                /// <summary>An e-mail subject.</summary>
+                public const int MailSubject = 5;
+                /// <summary>A telephone number.</summary>
+                public const int PhoneNumber = 6;
+                /// <summary>A query string.</summary>
+                public const int QueryString = 7;
+                /// <summary>A SIP address</summary>
+                public const int SipAddress = 8;
+                /// <summary>An e-mail address.</summary>
+                public const int SmtpAddress = 9;
+                /// <summary>An identity.</summary>
+                public const int Identity = 10;
+                /// <summary>A uniform resource indicator.</summary>
+                public const int Uri = 11;
+                /// <summary>A fully-qualified domain name.</summary>
+                public const int Fqdn = 12;
+                /// <summary>A legacy IPV4 Internet address.</summary>
+                public const int IPv4AddressLegacy = 13;
+                public const int CustomerData = 32;
+            }
+
+            [StructLayout(LayoutKind.Explicit, Size = 16, CharSet = CharSet.Ansi)]
+            public unsafe struct EventGUIDType
+            {
+                /**
+                 * <summary>
+                 * Specifies the first eight hexadecimal digits of the GUID.
+                 * </summary>
+                 */
+                [FieldOffset(0)] UInt32 Data1;
+
+                /* <summary>
+                 * Specifies the first group of four hexadecimal digits.
+                 * </summary>
+                 */
+                [FieldOffset(4)] UInt16 Data2;
+
+                /**
+                 * <summary>
+                 * Specifies the second group of four hexadecimal digits.
+                 * </summary>
+                 */
+                [FieldOffset(6)] UInt16 Data3;
+
+                /** <summary>
+                 * An array of eight bytes.
+                 * The first two bytes contain the third group of four hexadecimal digits.
+                 * The remaining six bytes contain the final 12 hexadecimal digits.
+                 * </summary>
+                 */
+                [FieldOffset(8)]
+                fixed byte Data4[8];
+            }
+
+            [StructLayout(LayoutKind.Explicit, Size = 28, CharSet = CharSet.Ansi)]
+            public unsafe struct EventContextType
+            {
+                [FieldOffset(0)] public UInt32 call;
+                [FieldOffset(4)] public ulong handle;
+                [FieldOffset(12)] public IntPtr data;
+                [FieldOffset(20)] public UInt32 result;
+                [FieldOffset(24)] public UInt32 size;
+            }
+
+            public enum EventOpenParamType
+            {
+                OPEN_PARAM_TYPE_HTTP_HANDLER_SEND = 0,
+                OPEN_PARAM_TYPE_HTTP_HANDLER_CANCEL = 1,
+                OPEN_PARAM_TYPE_TASK_DISPATCHER_QUEUE = 2,
+                OPEN_PARAM_TYPE_TASK_DISPATCHER_CANCEL = 3,
+                OPEN_PARAM_TYPE_TASK_DISPATCHER_JOIN = 4
+            }
+
+            [StructLayout(LayoutKind.Explicit, Size = 12, CharSet = CharSet.Ansi)]
+            public unsafe struct EventOpenParam
+            {
+                [FieldOffset(0)] public UInt32 type;
+                [FieldOffset(4)] public IntPtr data;
+            };
+
+            [StructLayout(LayoutKind.Explicit, Size = 8, CharSet = CharSet.Ansi)]
+            public unsafe struct EventPropertyValue
+            {
+                /* Basic types */
+                [FieldOffset(0)] public UInt64 as_uint64;
+                [FieldOffset(0)] public IntPtr as_string;
+                [FieldOffset(0)] public Int64  as_int64;
+                [FieldOffset(0)] public double as_double;
+                [FieldOffset(0)] public bool   as_bool;
+                [FieldOffset(0)] public IntPtr as_guid;
+                [FieldOffset(0)] public UInt64 as_time;
+#if FALSE
+                /* We don't support passing arrays yet. Code below needs to be ported from C++ to C# */
+                /* Array types are nullptr-terminated array of pointers */
+                char**              as_arr_string;
+                int64_t**           as_arr_int64;
+                bool**              as_arr_bool;
+                double**            as_arr_double;
+                evt_guid_t**        as_arr_guid;
+                uint64_t**          as_arr_time;
+#endif
+            };
+
+            /**
+             * <summary>
+             * Wraps logger configuration string and all input parameters to 'evt_open_with_params'
+             * </summary>
+             */
+            // TODO: this structure size depends on architecture - 32-bit or 64-bit..
+            // Since all Mac OS X and Linux are mostly 64-bit by now, as well as
+            // most Windows - we should assume that the struct layout is optimized
+            // for 64-bit. From a practical standpoint - somebody building .NET Core
+            // app would likely consider running it on a platform that is modern
+            // enough. One way to solve this issue for 32-bit machines is to add a
+            // custom SDK build flag that enforces certain struct layout. i.e.
+            // positioning the two pointers below as 64-bit integers instead of 32-bit.
+            [StructLayout(LayoutKind.Explicit, Size = 20, CharSet = CharSet.Ansi)]
+            public unsafe struct EventOpenWithParamsDataType
+            {
+                [FieldOffset(0)] public IntPtr config;
+                [FieldOffset(8)] public IntPtr parameters; /* pointer to array of EventOpenParam */
+                [FieldOffset(8)] public UInt32 paramsCount;
+            }
+
+            [StructLayout(LayoutKind.Explicit, Size = 24, CharSet = CharSet.Ansi)]
+            public unsafe struct EventPropertyKeyValue
+            {
+                [FieldOffset(0)] public IntPtr name;
+                [FieldOffset(8)] public EventPropertyType type;
+                [FieldOffset(12)] public EventPropertyValue value;
+                [FieldOffset(20)] public UInt32 piiKind;
+            }
+
+            /**
+             * <summary>
+             * Identifies HTTP request method type
+             * </summary>
+             */
+            public enum HttpRequestType
+            {
+                HTTP_REQUEST_TYPE_GET = 0,
+                HTTP_REQUEST_TYPE_POST = 1,
+            }
+
+            public class EventProperties : Dictionary<string, EventProperty>
+            {
+
+                public IntPtr nativeBuffer = IntPtr.Zero;
+                public int nativeSize = 0;
+                public int szEvtPropKV = Marshal.SizeOf(typeof(EventPropertyKeyValue));
+
+                public EventProperties()
+                {
+                }
+                internal unsafe void AllocNative()
+                {
+                    nativeSize = (Count+1) * szEvtPropKV;
+                    nativeBuffer = Marshal.AllocHGlobal(nativeSize);// sizeof(EventPropertyKeyValue));
+                    int i = 0;
+                    EventPropertyKeyValue* propPtr = (EventPropertyKeyValue*)(IntPtr.Zero);
+                    foreach (KeyValuePair<string, EventProperty> item in this)
+                    {
+                        propPtr = (EventPropertyKeyValue*)(nativeBuffer) + i;
+                        (*propPtr).name = Marshal.StringToHGlobalAnsi(item.Key);
+                        (*propPtr).piiKind = 0; // TODO: add Pii Kind support
+                        (*propPtr).type = item.Value.type;
+#if (TRACE)
+                        Console.Write("0x{0:X} ", (long)propPtr);
+#endif
+                        switch (item.Value.type)
+                        {
+                            case EventPropertyType.TYPE_BOOLEAN:
+                                (*propPtr).value.as_bool = item.Value.value.as_bool;
+#if (TRACE)
+                                Console.WriteLine("boolean {0}={1}", item.Key, (*propPtr).value.as_bool);
+#endif
+                                break;
+                            case EventPropertyType.TYPE_DOUBLE:
+                                (*propPtr).value.as_double = item.Value.value.as_double;
+#if (TRACE)
+                                Console.WriteLine("double {0}={1}", item.Key, (*propPtr).value.as_double);
+#endif
+                                break;
+                            case EventPropertyType.TYPE_GUID:
+                                // TODO: not implemented
+#if (TRACE)
+                                Console.WriteLine("guid    {0}={1}", item.Key, (*propPtr).value.as_guid);
+#endif
+                                break;
+                            case EventPropertyType.TYPE_INT64:
+                                (*propPtr).value.as_int64 = item.Value.value.as_int64;
+#if (TRACE)
+                                Console.WriteLine("int64  {0}={1}", item.Key, (*propPtr).value.as_int64);
+#endif
+                                break;
+                            case EventPropertyType.TYPE_STRING:
+                                {
+                                    string s = (string)(item.Value.objValue);
+                                    (*propPtr).value.as_string = Marshal.StringToHGlobalAnsi(s);
+                                    (*propPtr).piiKind = item.Value.piiKind;
+#if (TRACE)
+                                    Console.WriteLine("string {0}={1} (piiKind={2})", item.Key, s, item.Value.piiKind);
+#endif
+                                    break;
+                                }
+                            default:
+                                break;
+                        }
+                        i++;
+                    }
+                    /* NULL terminator property at the end of property list */
+                    propPtr = (EventPropertyKeyValue*)(nativeBuffer) + i;
+                    (*propPtr).name = IntPtr.Zero;
+                    (*propPtr).type = EventPropertyType.TYPE_NULL;
+                }
+
+                internal unsafe void FreeNative()
+                {
+                    if (nativeBuffer==IntPtr.Zero)
+                    {
+                        throw new Exception("Memory not allocated!");
+                    }
+                    // TODO: assert count==Count
+                    int count = nativeSize / szEvtPropKV;
+                    for (int i = 0; i < count; i++)
+                    {
+                        EventPropertyKeyValue* propPtr = (EventPropertyKeyValue*)(nativeBuffer) + i;
+                        EventPropertyType type = (EventPropertyType)((*propPtr).type);
+                        switch (type)
+                        {
+                            case EventPropertyType.TYPE_GUID:
+                                // TODO: not implemented
+                                break;
+                            case EventPropertyType.TYPE_STRING:
+                                {
+                                    IntPtr strPtr = (*propPtr).value.as_string;
+                                    if (strPtr != IntPtr.Zero)
+                                    {
+                                        Marshal.FreeHGlobal(strPtr);
+                                    }
+                                    break;
+                                }
+                            default:
+                                break;
+                        }
+                        if ((*propPtr).name != IntPtr.Zero)
+                        {
+                            Marshal.FreeHGlobal((*propPtr).name);
+                        }
+                    }
+                    Marshal.FreeHGlobal(nativeBuffer);
+                    nativeBuffer = IntPtr.Zero;
+                    nativeSize = 0;
+                }
+            }
+
+            public class EventProperty
+            {
+                public EventPropertyType type;
+                public EventPropertyValue value;
+                public object objValue = null;
+                public UInt32 piiKind = 0;
+
+                public EventProperty(string strValue)
+                {
+                    type = EventPropertyType.TYPE_STRING;
+                    objValue = strValue;
+                }
+
+                public EventProperty(string strValue, UInt32 piiKind)
+                {
+                    type = EventPropertyType.TYPE_STRING;
+                    objValue = strValue;
+                    this.piiKind = piiKind;
+                }
+
+                public EventProperty(Guid guidValue)
+                {
+                    // TODO: compact GUID on wire is not implemented!
+                    // Currently we flatten it to string.
+                    // type = EventPropertyType.TYPE_GUID;
+                    type = EventPropertyType.TYPE_STRING;
+                    objValue = guidValue.ToString();
+                }
+
+                public EventProperty(Int64 intValue)
+                {
+                    type = EventPropertyType.TYPE_INT64;
+                    value.as_int64 = intValue;
+                }
+
+                public EventProperty(int intValue)
+                {
+                    type = EventPropertyType.TYPE_INT64;
+                    value.as_int64 = intValue;
+                }
+
+                public EventProperty(double doubleValue)
+                {
+                    type = EventPropertyType.TYPE_DOUBLE;
+                    value.as_double = doubleValue;
+                }
+
+                public EventProperty(bool boolValue)
+                {
+                    type = EventPropertyType.TYPE_BOOLEAN;
+                    value.as_bool = boolValue;
+                }
+
+                public static implicit operator EventProperty(string v) => new EventProperty(v);
+                public static implicit operator EventProperty(int v) => new EventProperty(v);
+                public static implicit operator EventProperty(double v) => new EventProperty(v);
+                public static implicit operator EventProperty(Guid v) => new EventProperty(v);
+            };
+
+            public static class EventNativeAPI
+            {
+                // Conditional compilation: pass different library name depending on target OS
+
+                [DllImport(Constants.LIBRARY_NAME, EntryPoint = "evt_api_call_default")]
+                internal static extern UInt32 evt_api_call([In, Out] ref EventContextType context);
+
+                /**
+                 * <summary>
+                 * Create or open existing SDK instance.
+                 * </summary>
+                 * <param name="config">SDK configuration.</param>
+                 * <returns>SDK instance handle.</returns>
+                 */
+                public static ulong evt_open(string cfg)
+                {
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_OPEN,
+                        data = Marshal.StringToHGlobalAnsi(cfg)
+                    };
+                    evt_api_call(ref context);
+                    Marshal.FreeHGlobal(context.data);
+                    return context.handle;
+                }
+
+                /**
+                 * <summary>
+                 * Destroy or close SDK instance by handle
+                 * </summary>
+                 * <param name="handle">SDK instance handle.</param>
+                 * <returns>Status code.</returns>
+                 */
+                public static ulong evt_close(ulong inHandle)
+                {
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_CLOSE,
+                        handle = inHandle
+                    };
+                    return evt_api_call(ref context);
+                }
+
+                public static ulong evt_log(ulong inHandle, ref EventProperties properties)
+                {
+                    ulong result = 0;
+                    unsafe
+                    {
+                        properties.AllocNative();
+                        EventContextType context = new EventContextType
+                        {
+                            call = (Byte)EventCallType.EVT_OP_LOG,
+                            handle = inHandle,
+                            data = properties.nativeBuffer,
+                            size = 0 /* (uint)(properties.Count) */
+                        };
+                        result = evt_api_call(ref context);
+                        properties.FreeNative();
+                    };
+                    return result;
+                }
+
+                /**
+                 * <summary>
+                 * Pauses transmission. In that mode events stay in ram or saved to disk, not sent.
+                 * </summary>
+                 * <param name="handle">SDK handle.</param>
+                 * <returns>Status code.</returns>
+                 */
+                public static ulong evt_pause(ulong inHandle)
+                {
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_PAUSE,
+                        handle = inHandle
+                    };
+                    return evt_api_call(ref context);
+                }
+
+                /**
+                 * <summary>
+                 * Resumes transmission. Pending telemetry events should be attempted to be sent.
+                 * </summary>
+                 * <param name="handle">SDK handle.</param>
+                 * <returns>Status code.</returns>
+                 */
+                public static ulong evt_resume(ulong inHandle)
+                {
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_RESUME,
+                        handle = inHandle
+                    };
+                    return evt_api_call(ref context);
+                }
+
+                /** <summary>
+                 * Provide a hint to telemetry system to attempt force-upload of events
+                 * without waiting for the next batch timer interval. This API does not
+                 * guarantee the upload.
+                 * </summary>
+                 * <param name="handle">SDK handle.</param>
+                 * <returns>Status code.</returns>
+                 */
+                public static ulong evt_upload(ulong inHandle)
+                {
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_RESUME,
+                        handle = inHandle
+                    };
+                    return evt_api_call(ref context);
+                }
+
+                /** <summary>
+                 * Save pending telemetry events to offline storage on disk.
+                 * </summary>
+                 * <param name="handle">SDK handle.</param>
+                 * <returns>Status code.</returns>
+                 */
+                public static ulong evt_flush(ulong inHandle)
+                {
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_FLUSH,
+                        handle = inHandle
+                    };
+                    return evt_api_call(ref context);
+                }
+
+                /** <summary>
+                 * Pass down SDK header version to SDK library. Needed for late binding version checking.
+                 * This method provides means of a handshake between library header and a library impl.
+                 * It is up to app dev to verify the value returned, making a decision whether some SDK
+                 * features are implemented/supported by particular SDK version or not.
+                 * </summary>
+                 * <param name="libSemver">SDK header semver.</param>
+                 * <returns>SDK library semver</returns>
+                 */
+                public static string evt_version()
+                {
+                    byte[] data = Encoding.ASCII.GetBytes(Constants.VERSION);
+                    var nativeDataPtr = Marshal.AllocHGlobal(data.Length + 1);
+                    Marshal.Copy(data, 0, nativeDataPtr, data.Length);
+                    Marshal.WriteByte(nativeDataPtr + data.Length, 0);
+                    EventContextType context = new EventContextType
+                    {
+                        call = (Byte)EventCallType.EVT_OP_VERSION,
+                        data = nativeDataPtr
+                    };
+                    evt_api_call(ref context);
+                    string result = Marshal.PtrToStringAnsi(context.data);
+                    Marshal.FreeHGlobal(nativeDataPtr);
+                    return result;
+                }
+            }
+
+        }
+    }
+}

--- a/wrappers/netcore/EventSender.csproj
+++ b/wrappers/netcore/EventSender.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="sdk-config.json" CopyToOutputDirectory="Always" />
+    <None Include="EventSender.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Json" Version="4.7.0" />
+  </ItemGroup>
+</Project>

--- a/wrappers/netcore/EventSender.xml
+++ b/wrappers/netcore/EventSender.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <dllmap dll="ClientTelemetry" target="libmat"/>
+</configuration>

--- a/wrappers/netcore/Program.cs
+++ b/wrappers/netcore/Program.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.IO;
+using System.Json;
+using System.Diagnostics;
+
+using Microsoft.Telemetry.Core;
+
+namespace EventSender
+{
+
+    class Program
+    {
+        static string ReadConfiguration(string filename)
+        {
+            string result = "";
+            using (StreamReader sr = new StreamReader(filename))
+            {
+                result = sr.ReadToEnd();
+            }
+            return result;
+        }
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Reading configuration...");
+            string cfg = ReadConfiguration("sdk-config.json");
+
+            // Parse to verify it is valid and print it out..
+            // Parser should throw if config is invalid.
+            JsonObject jsonDoc = (JsonObject)JsonObject.Parse(cfg);
+            Console.WriteLine("SDK configuration:\n{0}", jsonDoc.ToString());
+
+            // Obtain SDK version from native library
+            Console.WriteLine("SDK version: {0}", EventNativeAPI.evt_version());
+
+            // Initialize
+            Console.WriteLine(">>> evt_open...");
+            var handle = EventNativeAPI.evt_open(cfg);
+            Console.WriteLine("handle={0}", handle);
+
+            // Initialize
+            Console.WriteLine(">>> evt_pause...");
+            EventNativeAPI.evt_pause(handle);
+
+            Console.WriteLine(">>> evt_log...");
+
+            long total0 = GC.GetTotalMemory(true);
+            long frag0  = GC.GetGCMemoryInfo().FragmentedBytes;
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
+            const int MAX_ITERATIONS = 100000;
+            for (int i = 0; i < MAX_ITERATIONS; i++)
+            {
+                var props = new EventProperties() {
+                    { "strKey", "value1" },
+                    { "intKey", 12345 },
+                    { "dblKey", 0.12345 } ,
+                    { "guidKey", new Guid("73e21739-9d4e-497d-9c66-8e399a532ec9") }
+                };
+                EventNativeAPI.evt_log(handle, ref props);
+            }
+            sw.Stop();
+            long total1 = GC.GetTotalMemory(true);
+            long frag1  = GC.GetGCMemoryInfo().FragmentedBytes;
+            // Print some benchmarking results for offline storage + serialization
+            TimeSpan ts = sw.Elapsed;
+            Console.WriteLine("Elapsed    = {0}", ts);
+            Console.WriteLine("Event rate = {0} eps", (MAX_ITERATIONS/ts.TotalSeconds) );
+            Console.WriteLine("Latency    = {0} ms", (ts.TotalMilliseconds/MAX_ITERATIONS) );
+            Console.WriteLine("Mem used   = {0} bytes", total1-total0);
+            // Console.WriteLine("Fragmented = {0} bytes", frag1-frag0);
+
+            // FlushAndTeardown
+            Console.WriteLine(">>> evt_close...");
+            var result = EventNativeAPI.evt_close(handle);
+            Console.WriteLine("result={0}", result);
+        }
+    }
+}

--- a/wrappers/netcore/README.md
+++ b/wrappers/netcore/README.md
@@ -1,0 +1,19 @@
+# .NET Core wrapper example for 1DS C/C++ SDK
+
+Note that this wrapper is incomplete simple reference implementation that illustrates how to use 1DS C API from cross-platform .NET Core application.
+
+## POSIX instructions (Linux, Mac)
+
+1. Install latest .NET Core for your platform.
+
+2. Make sure you compile and install shared library build of SDK (`build.sh -l shared`).
+
+3. `run.sh` to compile and run the sample wrapper.
+
+## Windows instructions
+
+1. Install latest .NET Core for your platform.
+
+2. Open `Solutions\MSTelemetry.sln` and compile `win32-dll` project, producing `ClientTelemetry.dll`
+
+3. `run.cmd` to compile and run the sample wrapper.

--- a/wrappers/netcore/appsettings.json
+++ b/wrappers/netcore/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "Logging": {
+    "IncludeScopes": true,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Debug",
+        "System": "Information",
+        "Microsoft": "Information"
+      }
+    }
+  }
+}
+

--- a/wrappers/netcore/run.cmd
+++ b/wrappers/netcore/run.cmd
@@ -1,0 +1,2 @@
+set "PATH=%CD%\..\..\Solutions\out\Release\x64\win32-dll;%PATH%"
+dotnet run -c Release

--- a/wrappers/netcore/run.sh
+++ b/wrappers/netcore/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Mac OS X:
+# brew cask install dotnet-sdk
+
+#export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+#export DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib:$DYLD_FALLBACK_LIBRARY_PATH
+
+#dotnet run -c Debug -v diag
+dotnet run -c Debug
+
+
+

--- a/wrappers/netcore/sdk-config.json
+++ b/wrappers/netcore/sdk-config.json
@@ -1,0 +1,46 @@
+{
+	"config": {"host": "*"},
+	"name": "C-API-Client-0",
+	"version": "1.0.0",
+	"cacheFileFullNotificationPercentage": 75,
+	"cacheFilePath": "/tmp/storage.db",
+	"cacheFileSizeLimitInBytes": 13145728,
+	"cacheMemoryFullNotificationPercentage": 75,
+	"cacheMemorySizeLimitInBytes": 32768000,
+	"compat": {
+		"dotType": true
+	},
+	"enableLifecycleSession": false,
+	"eventCollectorUri": "https://self.events.data.microsoft.com/OneCollector/1.0/",
+	"hostMode": true,
+	"http": {
+		"compress": true
+	},
+	"maxDBFlushQueues": 3,
+	"maxPendingHTTPRequests": 4,
+	"maxTeardownUploadTimeInSec": 1,
+	"minimumTraceLevel": 5,
+	"multiTenantEnabled": true,
+	"primaryToken": "6d084bbf6a9644ef83f40a77c9e34580-c2d379e0-4408-4325-9b4d-2a7d78131e14-7322",
+	"sample": {
+		"rate": 0
+	},
+	"sdkmode": 0,
+	"skipSqliteInitAndShutdown": null,
+	"stats": {
+		"interval": 5,
+		"split": false,
+		"tokenInt": "8130ef8ff472405d89d6f420038927ea-0c0d561e-cca5-4c81-90ed-0aa9ad786a03-7166",
+		"tokenProd": "4bb4d6f7cafc4e9292f972dca2dcde42-bd019ee8-e59c-4b0f-a02c-84e72157a3ef-7485"
+	},
+	"tpm": {
+		"backoffConfig": "E,3000,300000,2,1",
+		"clockSkewEnabled": true,
+		"maxBlobSize": 2097152,
+		"maxRetryCount": 5
+	},
+	"traceLevelMask": 0,
+	"utc": {
+		"providerGroupId": "780dddc8-18a1-5781-895a-a690464fa89c"
+	}
+}


### PR DESCRIPTION
C# projection layer - old work item #4 

It took us a few years to realize that we finally need 1DS C++ SDK bindings for Unity C# code.

Implementation should work well under the following environments:
- Unity WebAssembly IL2CPP (Unity transpiles C# to C++ to WebAssembly)
- Unity Editor with Mono 2.x
- Unity based on NETStandard 2.x+

List of changes:
- allow **build.sh** to accept parameters and cmake options
- clean-up CMakeLists.txt to allow building a shared library (tested on Mac only, need to test on Linux)
- update corresponding packaging scripts to include the shared library output
- update package versions from v3.2 to v3.3
- mod mat.h to pack structure
- draft example that shows how to P/Invoke from .NET Core 3.x into shared library (tested on Mac OS X and Windows). This is a DRAFT, not final. But it is a working draft to upload events to Collector.

Practical reasons for this implementation:

**Reason 1. New ways to express an event for Geneva IFx SDK without using Bond. Main intent is to move IFx customers away from Bond in their code to 1DS-style EventProperties.**

A concept of strongly-typed variant dictionary that can be used to express an event in a very user-friendly, intuitive manner. This is C# code that is pretty much identical to API surface we have in C++11 land and other 1DS SDKs:
```
                var props = new EventProperties() {
                    { "strKey", "value1" },
                    { "intKey", 12345 },
                    { "dblKey", 0.12345 } ,
                    { "guidKey", new Guid("73e21739-9d4e-497d-9c66-8e399a532ec9") }
                };
```

This managed object is implemented as "variant dictionary":
```
Dictionary<string, EventProperty>
```

where _EventProperty_ - allows to contain the standard supported by collector strong types, plus optional Pii Kind tag. That managed container object then gets converted to native structure passed down to 1DS C++ SDK via "ABI stable" C API. The marshaling is not ideal at the moment. I believe we can make it x2 times faster by avoiding memcpy in a few spots.

**Reason 2. Prove that it's a viable approach from performance standpoint that can be used in system services written in C#.**

Benchmarking how fast we can go -- measuring combined time of the following steps:
- emit an event in managed code
- translate it from managed into native representation, including string translations from UTF-16
- serialize it with native code Common Schema 4.x Bond serializer
- save it to disk storage in SQLite DB

Preliminary results of early implementation:
- 9 seconds to process 100,000 managed code events (string, integer, double and guid, I'm a bit cheating with GUID as I've been processing it as string... final properly packed GUID would be much faster)
- Note that every event also gets decorated with all possible CS4.x Part A properties, like system state, device id, timestamps, etc... many others. So it's a "bulky" event, not just 4 raw fields.
- 10,000 events per second can be achieved on an oldish 2015 Macbook Pro with one thread (not a server machine)
- 50,000 events per second on more modern i7-9750H at 2.6GHz with one thread (gaming laptop, lol)
- no memory leaks (ahem).
- no memory fragmentation (ahem-ahem...).

**Reason 3. We can do the rest of "incremental" work to provide a compat layer for Aria C# Server customers on top of our 1DS C++ SDK**. 

We can also deprecate our C++/CX and C++/CLI projection layers. Those two other technologies to generate Windows C# wrapper are "legacy" and "deprecated", we should switch to netcore P/Invoke instead.

**Reason 4. I wanted to learn more about data marshaling from managed to native via P/Invoke** 😄(out of curiosity ... to learn something new)

Perf numbers for a quick test to emit 100000 events in ONE thread in a loop (not multi-threaded, just 1 core, 1 background disk flush thread):
```
...
SDK version: 3.3.0
>>> evt_open...
handle=2933216226
>>> evt_pause...
>>> evt_log...
Elapsed    = 00:00:09.3721759
Event rate = 10669.880833115818 eps
Latency    = 0.093721759 ms
Mem used   = 6208 bytes
Fragmented = -37536 bytes
>>> evt_close...
result=0
```

Usage instructions for building shared library instead of static:

```
bash-3.2$ ./build.sh -h
Usage: build.sh [clean] [noroot] [release] [-h|-?] [-l (static|shared)] [-D CMAKE_OPTION]

options:

 -h | -?             - this help.
 -l [static|shared]  - build static (default) or shared library.
 -D [CMAKE_OPTION]   - additional option to pass to cmake.

cmake options can be passed using CMAKE_OPTS environment variable.
```

To build shared library:
```
./build.sh -l shared
```

or - new way of passing options from script to cmake:
```
CMAKE_OPTS=-DBUILD_SHARED_LIBS=ON ./build.sh
```

Unity wrapper will be maintained elsewhere outside of this repo.