### PR TITLE
Introduce option to checkpoint database on Flush()

### DIFF
--- a/lib/include/public/ILogConfiguration.hpp
+++ b/lib/include/public/ILogConfiguration.hpp
@@ -145,6 +145,11 @@ namespace MAT_NS_BEGIN
     static constexpr const char* const CFG_INT_RAM_QUEUE_BUFFERS = "maxDBFlushQueues";
 
     /// <summary>
+    /// SQLite DB will be checkpointed when flushing.
+    /// </summary>
+    static constexpr const char* const CFG_BOOL_CHECKPOINT_DB_ON_FLUSH = "checkpointDBOnFlush";
+
+    /// <summary>
     /// The trace level mask.
     /// </summary>
     static constexpr const char* const CFG_INT_TRACE_LEVEL_MASK = "traceLevelMask";

--- a/lib/offline/ISqlite3Proxy.hpp
+++ b/lib/offline/ISqlite3Proxy.hpp
@@ -55,6 +55,7 @@ class ISqlite3Proxy {
     virtual const void*          sqlite3_value_blob(sqlite3_value* value) = 0;
     virtual int                  sqlite3_value_bytes(sqlite3_value* value) = 0;
     virtual sqlite3_vfs*         sqlite3_vfs_find(char const* zVfsName) = 0;
+    virtual void                 sqlite3_wal_checkpoint(sqlite3* db) = 0;
 };
 
 extern ISqlite3Proxy* g_sqlite3Proxy;

--- a/lib/offline/OfflineStorageHandler.cpp
+++ b/lib/offline/OfflineStorageHandler.cpp
@@ -199,6 +199,12 @@ namespace MAT_NS_BEGIN {
             }
         }
 
+        // Checkpoint DB
+        if (m_config.HasConfig(CFG_BOOL_CHECKPOINT_DB_ON_FLUSH) && m_config[CFG_BOOL_CHECKPOINT_DB_ON_FLUSH]) 
+        {
+            m_offlineStorageDisk->Flush();
+        }
+
         m_isStorageFullNotificationSend = false;
 
         // Flush is done, notify the waiters

--- a/lib/offline/OfflineStorage_SQLite.cpp
+++ b/lib/offline/OfflineStorage_SQLite.cpp
@@ -134,6 +134,12 @@ namespace MAT_NS_BEGIN {
         }
     }
 
+    void OfflineStorage_SQLite::Flush() 
+    {
+        if (m_db)
+            m_db->flush();
+    }
+    
     void OfflineStorage_SQLite::Execute(std::string command)
     {
         if (m_db)

--- a/lib/offline/OfflineStorage_SQLite.hpp
+++ b/lib/offline/OfflineStorage_SQLite.hpp
@@ -31,7 +31,7 @@ namespace MAT_NS_BEGIN {
         virtual ~OfflineStorage_SQLite() override;
         virtual void Initialize(IOfflineStorageObserver& observer) override;
         virtual void Shutdown() override;
-        virtual void Flush() override {};
+        virtual void Flush() override;
         virtual void Execute(std::string command);
         virtual bool StoreRecord(StorageRecord const& record) override;
         virtual size_t StoreRecords(std::vector<StorageRecord> & records) override;

--- a/lib/offline/SQLiteWrapper.hpp
+++ b/lib/offline/SQLiteWrapper.hpp
@@ -184,6 +184,11 @@ namespace MAT_NS_BEGIN {
         {
             return ::sqlite3_vfs_find(zVfsName);
         }
+                
+        void sqlite3_wal_checkpoint(sqlite3* db) override 
+        {
+            ::sqlite3_wal_checkpoint_v2(db, NULL, SQLITE_CHECKPOINT_FULL, NULL, NULL);
+        }
     } g_realSqlite3Proxy;
 
     ISqlite3Proxy* g_sqlite3Proxy = &g_realSqlite3Proxy;
@@ -460,6 +465,11 @@ namespace MAT_NS_BEGIN {
             SQLRecords records;
             sqlite3_exec(sql, sqlite3_select_callback, &records);
             return records;
+        }
+
+        void flush()
+        {
+            g_sqlite3Proxy->sqlite3_wal_checkpoint(m_db);
         }
 
     protected:

--- a/wrappers/obj-c/ODWLogConfiguration.h
+++ b/wrappers/obj-c/ODWLogConfiguration.h
@@ -392,6 +392,17 @@ extern NSString * _Nonnull const ODWCFG_BOOL_SESSION_RESET_ENABLED;
 +(nullable NSString *)cacheFilePath;
 
 /*!
+@brief Controls if DB will be checkpointed when flushing
+@param enableDbCheckpointOnFlush True if DB should be checkpointed when flushing.
+*/
++(void)setEnableDbCheckpointOnFlush:(bool)enableDbCheckpointOnFlush;
+
+/*!
+@brief Returns true if DB will be checkpointed when flushing.
+*/
++(bool)enableDbCheckpointOnFlush;
+
+/*!
 @brief Sets a config key to a string value for the copied config
 @param key A key.
 @param value A value.

--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -431,6 +431,22 @@ NSString *const ODWCFG_BOOL_SESSION_RESET_ENABLED = @"sessionResetEnabled";
     return [NSString stringWithCString:strCacheFilePath.c_str() encoding:NSUTF8StringEncoding];
 }
 
++(void)setEnableDbCheckpointOnFlush:(bool)enabled
+{
+    auto& config = LogManager::GetLogConfiguration();
+    config[CFG_BOOL_CHECKPOINT_DB_ON_FLUSH] = enabled;
+}
+
++(bool)enableDbCheckpointOnFlush
+{
+    auto& config = LogManager::GetLogConfiguration();
+    if (config.HasConfig(CFG_BOOL_CHECKPOINT_DB_ON_FLUSH)) {
+        return config[CFG_BOOL_CHECKPOINT_DB_ON_FLUSH];
+    } else {
+        return false;
+    }
+}
+
 -(void)set:(nonnull NSString *)key withValue:(nonnull NSString *)value
 {
     (*_wrappedConfiguration)[[key UTF8String]] = [value UTF8String];


### PR DESCRIPTION
The way SQLite is initialized (synchronous=NORMAL config) introduces potential issues with durability of changes/updates in some corner cases (power loss, ungraceful process termination/exit, etc).

iOS Outlook logs telemetry in scenarios where if some critical validation/check failed and cannot be handled process will self-terminate. In between logging the event and terminating we call Flush() to avoid lost events. If we checkpoint the DB before returning from the Flush() call app can safely assume no events will be lost. This change introduces an option that enables such behavior.

Alternative solution would be to use the default configuration (with synchronous=FULL) which doesn't have that problem but has overhead of filesystem syncing for each transaction which makes it a bad idea from the perf point of view.