### PR TITLE
Use Ubuntu 20.04 runner image for CI

### DIFF
--- a/.github/workflows/build-ubuntu-2004.yml
+++ b/.github/workflows/build-ubuntu-2004.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         config: [release, debug]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Other resources to learn how to setup the build system:
   | Mac OS X (latest)              | :white_check_mark: | :white_check_mark: |
   | Ubuntu 14.04.x LTS             | :white_check_mark: |                    |
   | Ubuntu 16.04.x LTS             | :white_check_mark: |                    |
-  | Ubuntu 18.04.x LTS             | :white_check_mark: | :white_check_mark: |
+  | Ubuntu 18.04.x LTS             | :white_check_mark: |                    |
+  | Ubuntu 20.04.x LTS             | :white_check_mark: | :white_check_mark: |
   | Ubuntu (latest)                | :white_check_mark: | :white_check_mark: |
   | Windows 7.1                    | :white_check_mark: |                    |
   | Windows 8.1                    | :white_check_mark: |                    |


### PR DESCRIPTION
ubunu-18.04 runner images (used in our CI) won't be supported from April 1st 2023 as mentioned here - https://github.com/actions/runner-images/issues/6002.

So changing the relevant CI pipeline to use ubuntu 20.04.
Also adding an entry for ubuntu `20.04 LS in README.md now that the ubuntu-latest refers to ubuntu-22.04 LTS.


One of the errors from pipeline - https://github.com/microsoft/cpp_client_telemetry/actions/runs/4348190703 for using deprecated image. Thanks @sid for pointing out.