### PR TITLE
Android, upgrade room and test deps, cleanup not required

### DIFF
--- a/lib/android_build/app/build.gradle
+++ b/lib/android_build/app/build.gradle
@@ -39,9 +39,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':maesdk')
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    testImplementation 'junit:junit:4.13.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/lib/android_build/app/src/main/cpp/native-lib.cpp
+++ b/lib/android_build/app/src/main/cpp/native-lib.cpp
@@ -124,17 +124,6 @@ int RunTests::run_all_tests(JNIEnv* env, jobject java_logger)
     return RUN_ALL_TESTS();
 }
 
-extern "C" JNIEXPORT jstring JNICALL
-Java_com_microsoft_applications_events_maesdktest_MainActivity_stringFromJNI(
-    JNIEnv* env,
-    jobject /* this */,
-    jstring path)
-{
-    auto result = RunTests::run_all_tests(env, path);
-    std::string hello = std::to_string(result);
-    return env->NewStringUTF(hello.c_str());
-}
-
 extern "C" JNIEXPORT jint JNICALL
 
 Java_com_microsoft_applications_events_maesdktest_TestStub_runNativeTests(

--- a/lib/android_build/app/src/main/java/com/microsoft/applications/events/maesdktest/MaeUnitLogger.java
+++ b/lib/android_build/app/src/main/java/com/microsoft/applications/events/maesdktest/MaeUnitLogger.java
@@ -4,9 +4,6 @@
 //
 package com.microsoft.applications.events.maesdktest;
 
-import androidx.annotation.Keep;
-
-@Keep
 public abstract class MaeUnitLogger {
     abstract void log_failure(String filename, int line, String summary);
 }

--- a/lib/android_build/app/src/main/java/com/microsoft/applications/events/maesdktest/MainActivity.java
+++ b/lib/android_build/app/src/main/java/com/microsoft/applications/events/maesdktest/MainActivity.java
@@ -4,58 +4,54 @@
 //
 package com.microsoft.applications.events.maesdktest;
 
+import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
-import androidx.appcompat.app.AppCompatActivity;
+
 import com.microsoft.applications.events.HttpClient;
 import com.microsoft.applications.events.OfflineRoom;
+
+import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
-public class MainActivity extends AppCompatActivity {
-  class DummyLogger extends MaeUnitLogger {
+public class MainActivity extends Activity {
+    static class DummyLogger extends MaeUnitLogger {
+        @Override
+        void log_failure(String filename, int line, String summary) {
+            Log.e("MAE", String.format("Uh oh %s: %s", filename, summary));
+        }
+    }
 
+    // Used to load the 'native-lib' library on application startup.
+    static {
+        System.loadLibrary("native-lib");
+        System.loadLibrary("maesdk");
+    }
+
+    HttpClient m_client;
+
+    @SuppressLint("SetTextI18n")
     @Override
-    void log_failure(String filename, int line, String summary) {
-      Log.e("MAE", String.format("Uh oh %s: %s", filename, summary));
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        m_client = new HttpClient(getApplicationContext());
+        OfflineRoom.connectContext(getApplicationContext());
+        TestStub testStub = new TestStub();
+        DummyLogger dummyLogger = new DummyLogger();
+        // Example of a call to a native method
+        TextView tv = findViewById(R.id.sample_text);
+        try {
+            Integer result = testStub.executorRun(dummyLogger);
+            tv.setText(String.format(Locale.ROOT, "Tests returned %d", result));
+        } catch (ExecutionException e) {
+            tv.setText("Woopsy");
+        } catch (InterruptedException e) {
+            tv.setText("Interrupted!");
+        }
     }
-  }
-
-  // Used to load the 'native-lib' library on application startup.
-  static {
-    System.loadLibrary("native-lib");
-    System.loadLibrary("maesdk");
-  }
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_main);
-
-    m_client = new HttpClient(getApplicationContext());
-    OfflineRoom.connectContext(getApplicationContext());
-    TestStub testStub = new TestStub();
-    DummyLogger dummyLogger = new DummyLogger();
-    // Example of a call to a native method
-    TextView tv = findViewById(R.id.sample_text);
-    try {
-    Integer result = testStub.executorRun(dummyLogger);
-    tv.setText(String.format("Tests returned %d", result));
-      }
-    catch(ExecutionException e) {
-      tv.setText("Woopsy");
-    }
-    catch(InterruptedException e) {
-      tv.setText("Interrupted!");
-    }
-  }
-
-  /**
-   * A native method that is implemented by the 'native-lib' native library, which is packaged with
-   * this application.
-   */
-  public native String stringFromJNI(String path);
-
-  HttpClient m_client;
 }
 

--- a/lib/android_build/app/src/main/res/layout/activity_main.xml
+++ b/lib/android_build/app/src/main/res/layout/activity_main.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
     <TextView
+        android:layout_gravity="center"
         android:id="@+id/sample_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:text="Hello World!"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/lib/android_build/app/src/main/res/values/colors.xml
+++ b/lib/android_build/app/src/main/res/values/colors.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="colorPrimary">#008577</color>
-    <color name="colorPrimaryDark">#00574B</color>
-    <color name="colorAccent">#D81B60</color>
-</resources>

--- a/lib/android_build/app/src/main/res/values/styles.xml
+++ b/lib/android_build/app/src/main/res/values/styles.xml
@@ -1,11 +1,6 @@
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+    <style name="AppTheme" parent="android:Theme.Black">
     </style>
 
 </resources>

--- a/lib/android_build/build.gradle
+++ b/lib/android_build/build.gradle
@@ -5,11 +5,6 @@ buildscript {
     repositories {
         google() // to fetch com.android.tools.build:gradle
         mavenCentral()
-        maven { url 'https://maven.google.com' }
-        jcenter()
-        maven { url "https://jitpack.io" }
-        maven { url "https://jcenter.bintray.com" }
-        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
@@ -21,11 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google() // to fetch com.android.tools.build:gradle
-        mavenCentral()
-        maven { url 'https://maven.google.com' }
-        jcenter()
-        maven { url "https://jitpack.io" }
-        maven { url "https://jcenter.bintray.com" }
         mavenCentral()
     }
 }

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -58,7 +58,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    def room_version = '2.4.3'
+    def room_version = '2.2.6'
 
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -5,12 +5,10 @@ plugins {
 
 apply plugin: 'com.android.library'
 
-apply from: "$rootProject.projectDir/tools.gradle"
+apply from: "$projectDir/../tools.gradle"
 
 android {
     defaultConfig {
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -60,14 +58,14 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    def room_version = '2.2.6'
+    def room_version = '2.4.3'
 
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:3.2.4'
     testImplementation "androidx.room:room-testing:$room_version"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/lib/android_build/maesdk/src/test/java/com/microsoft/applications/events/HttpClientRequestTest.java
+++ b/lib/android_build/maesdk/src/test/java/com/microsoft/applications/events/HttpClientRequestTest.java
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-package com.microsoft.applications.events.maesdktest;
+package com.microsoft.applications.events;
 
 import com.microsoft.applications.events.HttpClientRequest;
 


### PR DESCRIPTION
Subset of #1103

~Upgrade room 2.2.6 -> 2.4.3 (latest 2.5.1)~ (requires java upgrade)
Upgrade espresso-core
Clean not needed libraries
Move HttpClientRequestTest to the library project, so it will run during build