### PR TITLE
Update before.targets to support Visual Studio 2022

### DIFF
--- a/Solutions/before.targets
+++ b/Solutions/before.targets
@@ -5,6 +5,7 @@
   <PropertyGroup Label="Globals">
     <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <!-- Fallback to Visual Studio 2017 (v141) toolset by default -->
     <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
     <PlatformToolset Condition="'$(PlatformToolset)' != ''">$(PlatformToolset)</PlatformToolset>


### PR DESCRIPTION
**Problem Description**

Common targets check for 2015 and 2017, but not for 2022. Prefer v143 toolchain if using vs2022. There is still an option to manually propagate the `PlatformToolset` parameter, so it should not break any of the existing Build pipelines.