### PR TITLE
define signals module if __has_include is available

### DIFF
--- a/Solutions/build.compact-signals.props
+++ b/Solutions/build.compact-signals.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);CONFIG_CUSTOM_H="config-compact-signals.h"</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/lib/include/mat/config-compact-signals.h
+++ b/lib/include/mat/config-compact-signals.h
@@ -1,0 +1,17 @@
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#define EVTSDK_VERSION_PREFIX "EVT"
+#if defined(_WIN32)
+#  define HAVE_MAT_SIGNALS
+#endif
+#define HAVE_MAT_EXP
+#define HAVE_MAT_FIFOSTORAGE
+#define HAVE_MAT_JSONHPP
+#define HAVE_MAT_ZLIB
+#define HAVE_MAT_STORAGE
+#define HAVE_MAT_DEFAULT_HTTP_CLIENT
+#define HAVE_CS3

--- a/lib/include/mat/config-default.h
+++ b/lib/include/mat/config-default.h
@@ -13,6 +13,9 @@
 #  if __has_include ("modules/utc/UtcTelemetrySystem.hpp")
 #    define HAVE_MAT_UTC
 #  endif
+#  if __has_include("modules/signals/Signals.hpp")
+#    define HAVE_MAT_SIGNALS
+#  endif
 #endif
 #endif
 #if defined(HAVE_PRIVATE_MODULES)
@@ -29,7 +32,6 @@
 #define HAVE_MAT_DEFAULT_HTTP_CLIENT
 #define HAVE_MAT_LIVEEVENTINSPECTOR
 #define HAVE_MAT_PRIVACYGUARD
-#define HAVE_MAT_SIGNALS
 //#define HAVE_MAT_DEFAULT_FILTER
 #if defined(_WIN32) && !defined(_WINRT_DLL)
 #define HAVE_MAT_NETDETECT


### PR DESCRIPTION
This PR includes two changes:

1. move `#define HAVE_MAT_SIGNALS` to check `__has_include` before using it
2. adds `config-compact-signals` and `build.compact-signals.props`  to be used later in github workflow

