### PR TITLE
Pass CXX_FLAGS from properties to maesdk module

### DIFF
--- a/lib/android_build/gradle.properties
+++ b/lib/android_build/gradle.properties
@@ -17,4 +17,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+# Uncomment CXXFLAGS to set CXX flags
+# CXXFLAGS=-DHAVE_CS4=1
 

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -21,6 +21,7 @@ android {
                     args.add("-DBUILD_SHARED_LIBS=1")
                     args.add("-DUSE_ROOM=1")
                     String linkerFlag = project.findProperty("CMAKE_SHARED_LINKER_FLAGS") ?: ""
+                    linkerFlag = "-DCMAKE_SHARED_LINKER_FLAGS=" + linkerFlag
                     args.add(linkerFlag)
                     if (!cxxFlag.isEmpty()) {
                         args.add("-DCMAKE_CXX_FLAGS=\"" + cxxFlag + "\"")

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -15,8 +15,19 @@ android {
         if(!ext.has("build_cpp_client") || ext.build_cpp_client) {
             externalNativeBuild {
                 cmake {
+                    String cxxFlag = project.findProperty("CXXFLAGS") ?: System.getenv("CXXFLAGS") ?: ""
+                    ArrayList<String> args = new ArrayList<String>()
+                    args.add("-DANDROID_STL=c++_shared")
+                    args.add("-DBUILD_SHARED_LIBS=1")
+                    args.add("-DUSE_ROOM=1")
+                    String linkerFlag = project.findProperty("CMAKE_SHARED_LINKER_FLAGS") ?: ""
+                    args.add(linkerFlag)
+                    if (!cxxFlag.isEmpty()) {
+                        args.add("-DCMAKE_CXX_FLAGS=\"" + cxxFlag + "\"")
+                    }
                     // Passes optional arguments to CMake.
-                    arguments "-DANDROID_STL=c++_shared", "-DBUILD_SHARED_LIBS=1", "-DUSE_ROOM=1", "-DCMAKE_SHARED_LINKER_FLAGS=${project.findProperty("CMAKE_SHARED_LINKER_FLAGS") ?: ''}"
+                    arguments args.toArray(new String[args.size()])
+                    println "cmake flag: " + arguments
                 }
             }
         }


### PR DESCRIPTION
Just like what we've discussed in #1136, passing parameter to build is more explicit.

We can get the CXX_FLAGS from the following:

1. Add CXX_FLAGS in gradle.properties
2. Pass param as -PCXX_FLAGS="xxxx" in command line, for example: `./gradlew :maesdk:assemble -PCXX_FLAGS="HAVE_CS4=1"`
3. Read the CXXFLAGS env variable (This is the fallback option)

