### PR TITLE
Fix linker errors on macOS sample project

### DIFF
--- a/examples/cpp/SampleCpp/CMakeLists.txt
+++ b/examples/cpp/SampleCpp/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set (PLATFORM_LIBS "")
 # Add flags for obtaining system UUID via IOKit
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set (PLATFORM_LIBS "-framework CoreFoundation -framework IOKit -framework Foundation")
+  set (PLATFORM_LIBS "-framework CoreFoundation -framework IOKit -framework Foundation -framework SystemConfiguration -framework Network")
 endif()
 
 # Raspberry Pi 4 with gcc-8 on ARMv7l requires -latomic


### PR DESCRIPTION
Resolves this issue https://github.com/microsoft/cpp_client_telemetry/issues/1140 by adding missing frameworks