### PR TITLE
Remove privacy guard from obj-c wrapper

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -172,8 +172,6 @@ if(PAL_IMPLEMENTATION STREQUAL "CPP11")
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/modules/privacyguard/ AND BUILD_PRIVACYGUARD)
           list(APPEND SRCS
           ../wrappers/obj-c/ODWCommonDataContext.mm
-          ../wrappers/obj-c/ODWPrivacyGuard.mm
-          ../wrappers/obj-c/ODWPrivacyGuardInitConfig.mm
           )
     endif()
   endif()

--- a/wrappers/obj-c/ODWLogger.h
+++ b/wrappers/obj-c/ODWLogger.h
@@ -4,7 +4,6 @@
 //
 #include "objc_begin.h"
 #import "ODWEventProperties.h"
-#import "ODWPrivacyGuardInitConfig.h"
 #import "ODWSemanticContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -122,10 +121,6 @@ typedef NS_ENUM(NSInteger, ODWSessionState)
 -(void)logSessionWithState:(enum ODWSessionState)state
             eventProperties:(ODWEventProperties *)properties;
 
-/*!
- @brief Initialize and get an instance of Privacy Guard.
- */
--(void)initializePrivacyGuardWithODWPrivacyGuardInitConfig:(ODWPrivacyGuardInitConfig *)initConfigObject;
 
 #pragma mark Set Context methods
 

--- a/wrappers/obj-c/ODWLogger.mm
+++ b/wrappers/obj-c/ODWLogger.mm
@@ -8,7 +8,6 @@
 #import "ODWLogConfiguration.h"
 #import "ODWSemanticContext.h"
 #import "ODWSemanticContext_private.h"
-#import "ODWPrivacyGuard_private.h"
 
 #include "EventProperties.hpp"
 
@@ -408,8 +407,4 @@ void PerformActionWithCppExceptionsCatch(void (^block)())
     }
 }
 
--(void)initializePrivacyGuardWithODWPrivacyGuardInitConfig:(ODWPrivacyGuardInitConfig *)initConfigObject
-{    
-    [ODWPrivacyGuard initializePrivacyGuard:_wrappedLogger withODWPrivacyGuardInitConfig:initConfigObject];
-}
 @end

--- a/wrappers/obj-c/OneDsCppSdk.h
+++ b/wrappers/obj-c/OneDsCppSdk.h
@@ -11,7 +11,6 @@
 #import "ODWLogConfiguration.h"
 #import "ODWLogger.h"
 #import "ODWLogManager.h"
-#import "ODWPrivacyGuard.h"
 #import "ODWSemanticContext.h"
 
 #endif


### PR DESCRIPTION
It's a cleaner experience to be able to the repo with only the contents of the repo. Remove privacy guard from obj-c wrapper.