### PR TITLE
Fix inefficient range-based for loop identified by static analysis.

### DIFF
--- a/tests/unittests/StringUtilsTests.cpp
+++ b/tests/unittests/StringUtilsTests.cpp
@@ -155,7 +155,7 @@ TEST(StringUtilsTests, Utf8Utf16Conversion)
         "!@#$%^&*()-=_+[]\\{}|;':\",./<>?",
     };
 
-    for (std::string str : test_strings) {
+    for (const auto& str : test_strings) {
       EXPECT_EQ(str, to_utf8_string(to_utf16_string(str)));
     }
 }


### PR DESCRIPTION
Existing code performed a by-value copy of the std::string into the range declarator. Replace with a const&