### PR TITLE
Mark PauseGuard::isPaused as const noexcept.

### DIFF
--- a/lib/tpm/TransmissionPolicyManager.cpp
+++ b/lib/tpm/TransmissionPolicyManager.cpp
@@ -26,7 +26,7 @@ namespace MAT_NS_BEGIN {
             }
         }
 
-        bool isPaused()
+        bool isPaused() const noexcept
         {
             return !m_unpaused;
         }


### PR DESCRIPTION
The method doesn't mutate any members and can't throw exceptions.