### PR TITLE
Replace PAL's to_string with std::to_string.

### DIFF
--- a/lib/utils/StringUtils.cpp
+++ b/lib/utils/StringUtils.cpp
@@ -36,28 +36,19 @@ namespace MAT_NS_BEGIN
         return (stringToTest.find_first_not_of(allowlist) == string::npos);
     }
 
-    /**
-     * Convert various numeric types and bool to string in an uniform manner.
-     */
-    template<typename T>
-    static std::string to_string(T&& value)
-    {
-       return std::to_string(value);
-    }
-
     std::string toString(char const*        value) { return std::string(value); }
     std::string toString(bool               value) { return value ? "true" : "false"; }
-    std::string toString(char               value) { return to_string(static_cast<signed char>(value)); }
-    std::string toString(int                value) { return to_string(value); }
-    std::string toString(long               value) { return to_string(value); }
-    std::string toString(long long          value) { return to_string(value); }
-    std::string toString(unsigned char      value) { return to_string(value); }
-    std::string toString(unsigned int       value) { return to_string(value); }
-    std::string toString(unsigned long      value) { return to_string(value); }
-    std::string toString(unsigned long long value) { return to_string(value); }
-    std::string toString(float              value) { return to_string(value); }
-    std::string toString(double             value) { return to_string(value); }
-    std::string toString(long double        value) { return to_string(value); }
+    std::string toString(char               value) { return std::to_string(static_cast<signed char>(value)); }
+    std::string toString(int                value) { return std::to_string(value); }
+    std::string toString(long               value) { return std::to_string(value); }
+    std::string toString(long long          value) { return std::to_string(value); }
+    std::string toString(unsigned char      value) { return std::to_string(value); }
+    std::string toString(unsigned int       value) { return std::to_string(value); }
+    std::string toString(unsigned long      value) { return std::to_string(value); }
+    std::string toString(unsigned long long value) { return std::to_string(value); }
+    std::string toString(float              value) { return std::to_string(value); }
+    std::string toString(double             value) { return std::to_string(value); }
+    std::string toString(long double        value) { return std::to_string(value); }
 
     std::string toLower(const std::string& str)
     {

--- a/lib/utils/StringUtils.cpp
+++ b/lib/utils/StringUtils.cpp
@@ -36,8 +36,8 @@ namespace MAT_NS_BEGIN
         return (stringToTest.find_first_not_of(allowlist) == string::npos);
     }
 
-    std::string toString(char const*        value) { return std::string(value); }
-    std::string toString(bool               value) { return value ? "true" : "false"; }
+    std::string toString(char const*        value) { return std::string { value }; }
+    std::string toString(bool               value) { return value ? std::string { "true" } : std::string { "false" }; }
     std::string toString(char               value) { return std::to_string(static_cast<signed char>(value)); }
     std::string toString(int                value) { return std::to_string(value); }
     std::string toString(long               value) { return std::to_string(value); }

--- a/lib/utils/StringUtils.cpp
+++ b/lib/utils/StringUtils.cpp
@@ -36,42 +36,28 @@ namespace MAT_NS_BEGIN
         return (stringToTest.find_first_not_of(allowlist) == string::npos);
     }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     /**
      * Convert various numeric types and bool to string in an uniform manner.
      */
     template<typename T>
-    std::string to_string(char const* format, T value)
+    static std::string to_string(T&& value)
     {
-        static const int buf_size = 40;
-        char buf[buf_size] = { 0 };
-#ifdef _WIN32
-        ::_snprintf_s(buf, buf_size, format, value);
-#else
-        snprintf(buf, buf_size, format, value);
-#endif
-        return std::string(buf);
+       return std::to_string(value);
     }
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
     std::string toString(char const*        value) { return std::string(value); }
     std::string toString(bool               value) { return value ? "true" : "false"; }
-    std::string toString(char               value) { return to_string("%d", static_cast<signed char>(value)); }
-    std::string toString(int                value) { return to_string("%d", value); }
-    std::string toString(long               value) { return to_string("%ld", value); }
-    std::string toString(long long          value) { return to_string("%lld", value); }
-    std::string toString(unsigned char      value) { return to_string("%u", value); }
-    std::string toString(unsigned int       value) { return to_string("%u", value); }
-    std::string toString(unsigned long      value) { return to_string("%lu", value); }
-    std::string toString(unsigned long long value) { return to_string("%llu", value); }
-    std::string toString(float              value) { return to_string("%f", value); }
-    std::string toString(double             value) { return to_string("%f", value); }
-    std::string toString(long double        value) { return to_string("%Lf", value); }
+    std::string toString(char               value) { return to_string(static_cast<signed char>(value)); }
+    std::string toString(int                value) { return to_string(value); }
+    std::string toString(long               value) { return to_string(value); }
+    std::string toString(long long          value) { return to_string(value); }
+    std::string toString(unsigned char      value) { return to_string(value); }
+    std::string toString(unsigned int       value) { return to_string(value); }
+    std::string toString(unsigned long      value) { return to_string(value); }
+    std::string toString(unsigned long long value) { return to_string(value); }
+    std::string toString(float              value) { return to_string(value); }
+    std::string toString(double             value) { return to_string(value); }
+    std::string toString(long double        value) { return to_string(value); }
 
     std::string toLower(const std::string& str)
     {


### PR DESCRIPTION
Not exactly sure why this method exists. I'd like to replace the toString methods across the board (except for our own types), but that's probably a downstream change.