### PR TITLE
Fix: Issue 1185 - make HttpClient_Android singleton

### DIFF
--- a/lib/http/HttpClient_Android.cpp
+++ b/lib/http/HttpClient_Android.cpp
@@ -12,6 +12,7 @@
 namespace MAT_NS_BEGIN
 {
     constexpr static auto Tag = "HttpClient_Android";
+    std::once_flag flagClient;
 
     HttpClient_Android::HttpRequest::~HttpRequest() noexcept
     {
@@ -439,13 +440,17 @@ namespace MAT_NS_BEGIN
         return std::string(buffer);
     }
 
+    void HttpClient_Android::createInstance()
+    {
+        s_client = std::make_shared<HttpClient_Android>();
+    }
+
     void HttpClient_Android::CreateClientInstance(JNIEnv* env,
                                                   jobject java_client)
     {
-        auto client = std::make_shared<HttpClient_Android>();
-        s_client = client;
+        std::call_once(flagClient, createInstance);
 
-        client->SetClient(env, java_client);
+        s_client->SetClient(env, java_client);
     }
 
     void HttpClient_Android::SetJavaVM(JavaVM* vm)

--- a/lib/http/HttpClient_Android.hpp
+++ b/lib/http/HttpClient_Android.hpp
@@ -208,6 +208,11 @@ namespace MAT_NS_BEGIN
         static std::string s_cache_file_path;
 
         bool CheckException(JNIEnv* env, HttpRequest* request);
+
+        private:
+        static void createInstance();
+        HttpClient_Android(const HttpClient_Android&) = delete;
+        HttpClient_Android& operator=(const HttpClient_Android&) = delete;
     };
 
 }


### PR DESCRIPTION
Make HttpClient_Android a singleton object so that multiple instances are not created.

Two HttpClient_Android objects are created (one is created by 1DS SDK and another by UTel SDK using HttpClient.java’s native/JNI createClientInstance() function in constructor). The Android Designer app immediately sends an event ‘Boot’ upon start that is probably causing the race condition and hence these two objects. The events are forwarded from HttpClient_Android to HttpClient.java to send to collector, then using JNI dispatchCallback() function is called of HttpClient_Android (the right object is not called and hence the debug message ‘Maximum number of HTTP requests reached’).
Making the HttpClient_Android class a singleton object fixes this issue (my change is to make it singleton only). 
