### PR TITLE
add custom root cert pinning support

### DIFF
--- a/lib/http/HttpClient_WinInet.hpp
+++ b/lib/http/HttpClient_WinInet.hpp
@@ -17,6 +17,7 @@ namespace MAT_NS_BEGIN {
 #ifndef _WININET_
 typedef void* HINTERNET;
 #endif
+#define CERTIFICATE_THUMBPRINT_SHA256_SIZE 32
 
 class WinInetRequestWrapper;
 
@@ -34,7 +35,14 @@ class HttpClient_WinInet : public IHttpClient {
     void SetMsRootCheck(bool enforceMsRoot);
     bool IsMsRootCheckRequired();
 
-  protected:
+    void SetCustomRootCheck(bool enforceCustomRoot);
+    bool IsCustomRootCheckRequired();
+    bool AddCustomRootCertSHA256Thumbprint(std::array<std::byte, CERTIFICATE_THUMBPRINT_SHA256_SIZE>& aCertThumbprint);
+    bool IsTrustedRootCert(std::array<std::byte, CERTIFICATE_THUMBPRINT_SHA256_SIZE>& aCertThumbprint);
+    bool AddCustomTrustedSubjectOrg(std::string& aTrustedOrg);
+    bool IsTrustedSubjectOrg(char* aTrustedOrg);
+
+   protected:
     void erase(std::string const& id);
 
   protected:
@@ -43,6 +51,9 @@ class HttpClient_WinInet : public IHttpClient {
     std::map<std::string, WinInetRequestWrapper*>                    m_requests;
     static unsigned                                                  s_nextRequestId;
     bool                                                             m_msRootCheck;
+    bool                                                             m_fcustomRootCheck;
+    std::vector<std::array<std::byte, CERTIFICATE_THUMBPRINT_SHA256_SIZE>> m_customRootCerts;
+    std::vector<std::string>                                         m_customTrustedSubjectOrgs;
     friend class WinInetRequestWrapper;
 };
 


### PR DESCRIPTION
This changes adds support to custom trusted root certificate pinning support for HTTP Wininet library. Consumers will be able to ping root CA certificate based on certificate thumbprint and leaf and intermediate certificate can be validated based on subject metadata.

Following 6APIs are added to HttpClient_WinInet.
SetCustomRootCheck ==> SDK consumers need to set call this api to set or un set custom root certificate validation.
IsCustomRootCheckRequired ==> Return current state of custom root check validation.
AddCustomRootCertSHA256Thumbprint ==> Adds one trusted root certificate SHA256 thumbprint. Consumers can add multiple trusted root certificates.
AddCustomTrustedSubjectOrg == > Adds one trusted subject organization. This is only used to validate leaf and intermediary CA certificates. As these can rotate often consumers can leverage subject metadata based pinning.

IsTrustedSubjectOrg ==> Used internally by WinInetRequestWrapper to validate the ongoing http request certificate chain.
IsTrustedRootCert==> Used internally by WinInetRequestWrapper to validate the ongoing http request certificate chain.

