### PR TITLE
Fix a syntax error in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ if [[ $1 == CUSTOM_BUILD_FLAGS* ]] || [[ $2 == CUSTOM_BUILD_FLAGS* ]] || [[ $3 =
 fi
 
 LINK_TYPE=
-CMAKE_OPTS="${CMAKE_OPTS:-DBUILD_SHARED_LIBS=OFF}"
+CMAKE_OPTS="${CMAKE_OPTS:--DBUILD_SHARED_LIBS=OFF}"
 while getopts "h?vl:D:" opt; do
     case "$opt" in
     h|\?)


### PR DESCRIPTION
The correct syntax here is `${VARIABLE:-REPLACEMENT}`. The dash is part of the operator.

Since the replacement also needs to start with a dash, two dashes are required.

For instance:

```bash
CMAKE_OPTS="${CMAKE_OPTS:-DBUILD_SHARED_LIBS=OFF}"
echo $CMAKE_OPTS
```

Will output

```
DBUILD_SHARED_LIBS=OFF
```

And

```bash
CMAKE_OPTS="${CMAKE_OPTS:--DBUILD_SHARED_LIBS=OFF}"
echo $CMAKE_OPTS
```

Will output


```
-DBUILD_SHARED_LIBS=OFF
```

This issue was causing the -DBUILD_SHARED_LIBS=OFF default to be ignored if a user did not set CMAKE_OPTS:

```
2023-09-06T22:39:53.3228622Z cmake -DMAC_ARCH=x86_64 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PACKAGE_TYPE=deb -DCMAKE_CXX_FLAGS="-DHAVE_MAT_EVT_TRACEID=1" DBUILD_SHARED_LIBS=OFF ..

CMake Warning:
  Ignoring extra path from command line:

   "/mnt/s/out/DBUILD_SHARED_LIBS=OFF"
```