### PR TITLE
[Maglev Teams 2.1] ECS Proxy Support

### DIFF
--- a/lib/http/HttpResponseDecoder.cpp
+++ b/lib/http/HttpResponseDecoder.cpp
@@ -56,7 +56,7 @@ namespace MAT_NS_BEGIN {
             {
                 outcome = Accepted;
             }
-            else if (response.GetStatusCode() >= 500 || response.GetStatusCode() == 408 || response.GetStatusCode() == 429)
+            else if (response.GetStatusCode() >= 500 || response.GetStatusCode() == 408 || response.GetStatusCode() == 429 || response.GetStatusCode() == 407)
             {
                 outcome = RetryServer;
             }


### PR DESCRIPTION
This is a patch that we are applying onto Teams 2.1's version of cpp_client_telemetry repo. It enables proxy support for the WinInet stack.