### PR TITLE
Add target .net 6 for the 1DS Test Server

### DIFF
--- a/tools/server/run.cmd
+++ b/tools/server/run.cmd
@@ -1,1 +1,29 @@
-dotnet run
+@ECHO OFF
+set framework="netcoreapp3.1"
+
+:loop
+IF NOT "%1"=="" (
+    IF "%1"=="-f" (
+        SET framework=%2
+        SHIFT
+    )
+    IF "%1"=="--framework" (
+        SET framework=%2
+        SHIFT
+    )
+    IF "%1"=="-h" GOTO :help
+    IF "%1"=="--help" GOTO :help
+    SHIFT
+    GOTO :loop
+)
+echo "1DS test telemetry server will be run with %framework%"
+dotnet run --framework %framework%
+goto:eof
+
+:help
+   echo "Run 1DS Test Telemetry Server with specified runtime versions (.net core 3 or .net6)."
+   echo "Syntax: run.sh [-f,--framework|-h, --help]"
+   echo "options:"
+   echo "-f | --framework     Run server with specified version of runtime. Supported values: netcoreapp3.1 or net6.0. Default value is netcoreapp3.1, if option is not specified"
+   echo "-h | --help    Help."
+   goto:eof

--- a/tools/server/run.sh
+++ b/tools/server/run.sh
@@ -1,3 +1,39 @@
 #!/bin/sh
-dotnet run
+
+############################################################
+# Help                                                     #
+############################################################
+Help()
+{
+   # Display Help
+   echo "Run 1DS Test Telemetry Server with specified runtime versions (.net core 3 or .net6)."
+   echo
+   echo "Syntax: run.sh [-f,--framework|-h, --help]"
+   echo "options:"
+   echo "-f | --framework     Run server with specified version of runtime. Supported values: netcoreapp3.1 or net6.0. Default value is netcoreapp3.1, if option is not specified"
+   echo "-h | --help    Help."
+   echo
+
+   exit 0
+}
+
+framework="netcoreapp3.1"
+while test $# -gt 0;
+do
+  case "$1" in
+    -h|--help) Help;;
+    -f|--framework)       
+      shift
+      if test $# -gt 0; then
+        framework=$1
+      else
+        echo "framework is not specified. Server will be run with .netcoreapp3.1"
+      fi
+      shift
+      ;;
+    *)  break;;
+  esac
+done
+echo "1DS test telemetry server will be run with $framework"
+dotnet run -f $framework
 

--- a/tools/server/run.sh
+++ b/tools/server/run.sh
@@ -27,7 +27,7 @@ do
       if test $# -gt 0; then
         framework=$1
       else
-        echo "framework is not specified. Server will be run with .netcoreapp3.1"
+        echo "--framework option value is not specified. Server will be run with $framework"
       fi
       shift
       ;;

--- a/tools/server/server.csproj
+++ b/tools/server/server.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
-    <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+	<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+	<RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>

--- a/tools/server/server.csproj
+++ b/tools/server/server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/tools/server/server.csproj
+++ b/tools/server/server.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 	<RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+	<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 


### PR DESCRIPTION
In our e2e tests, when we are using 1DS Test Server, pipeline uses .net6 (we have been targeting custom branch with the change `user/iankudinova/update_server_to_net6`).
I want to add the support .net6 to the main branch.
In case at some other project / plcases .net core 3 is used for the Test telemetry server I kept both version.

So Users will have to specify --framework version, when they run server.
Existed scripts: 
- `run.cmd`
- `run.sh`
were updated to support --framework option and use .net core 3 as a default option