### PR TITLE
Update .CODEOWNERS to contain 1ds-c-sdk-approver team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @1ds-c-sdk-approver
+*       @microsoft/1ds-c-sdk-approver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @kindbe @maxgolov @mkoscumb @reyang @bliptec @lalitb @ThomsonTan
+*       @1ds-c-sdk-approver


### PR DESCRIPTION
This will allow us to update the approvers without changing this file.