### PR TITLE
Adding sample unit tests to SamplePackage example for swift wrapper to show case the usage w.r.t unit tests

### DIFF
--- a/examples/swift/README.md
+++ b/examples/swift/README.md
@@ -10,14 +10,15 @@ Details:
     - Include module.modulemap folder in Swift compiler search path.
     - Add OneDSSwift package in build phases dependency.
 
+<a name="to-be-linked"></a>
 - Libraries/Frameworks to link to Target
     - OneDSSwift # Package
     - SystemConfiguration
     - Network
-    # /usr/local/lib
-    - libmat.a
-    - libz.tbd
-    - libsqlite3.a
+    - `/usr/local/lib`
+        - libmat.a
+        - libz.tbd
+        - libsqlite3.a
 
 
 # SamplePackage
@@ -25,8 +26,11 @@ Details:
 Contains a simple swift package importing swift wrappers package and calling 1DS API via swift wrappers.
 
 Details:
-- Package Dependencies:
+- Package Dependencies
     - OneDSSwift: Package containing swift wrappers
 
-- Modules Included:
+- Modules Included
     - ObjCModule: Module exposing ObjC headers via module.modulemap file.
+
+- Libraries and Frameworks to link to Target
+    - [Same as mentioned in the SampleXcodeApp section](#to-be-linked)

--- a/examples/swift/SamplePackage/Package.swift
+++ b/examples/swift/SamplePackage/Package.swift
@@ -23,6 +23,24 @@ let package = Package(
                 .product(name: "OneDSSwift", package: "swift"),
             ],
             swiftSettings: [
+                .unsafeFlags(["-Xcc", "-I../../../wrappers/swift/Modules/"]),
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-L/usr/local/lib"]),
+                // Libs to be linked.
+                .linkedLibrary("mat"),
+                .linkedLibrary("sqlite3"),
+                .linkedLibrary("z"),
+                // Frameworks to be linked.
+                .linkedFramework("Network"),
+                .linkedFramework("SystemConfiguration"),
+            ]),
+        .testTarget(
+            name: "SampleTests",
+            dependencies: [
+                "SamplePackage",
+            ],
+            swiftSettings: [
                 .unsafeFlags(["-Xcc", "-I../../../wrappers/swift/Modules/"])
             ]),
     ]

--- a/examples/swift/SamplePackage/Sources/SamplePackage/SamplePackage.swift
+++ b/examples/swift/SamplePackage/Sources/SamplePackage/SamplePackage.swift
@@ -5,6 +5,8 @@
 
 import OneDSSwift
 
+public var packageName = "sample swift package"
+
 private var logger:Logger?
 private var token:String = ""
 

--- a/examples/swift/SamplePackage/Tests/SampleTests/SampleTests.swift
+++ b/examples/swift/SamplePackage/Tests/SampleTests/SampleTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import SamplePackage
+
+final class SamplePackageTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(packageName, "sample swift package")
+    }
+}


### PR DESCRIPTION
Adding sample unit tests to SamplePackage example for swift wrapper to show case the usage w.r.t unit tests.

Added dependency to the objC moduel for UT target and added required libs and fwks to be linked to the build target.

Testing:
- Swift build and test passing
- Sample test is passing
