### PR TITLE
Cleaning leftover test files after test completion

### DIFF
--- a/tests/functests/LogSessionDataFuncTests.cpp
+++ b/tests/functests/LogSessionDataFuncTests.cpp
@@ -69,14 +69,14 @@ std::pair<unsigned long long, std::string> ReadPropertiesFromSessionFile(const c
     return std::make_pair(std::stoull(sessionFirstTime), skuID);
 }
 
-TEST(LogSessionDataFuncTests, Constructor_SessionFile_FileCreated)
+TEST_F(LogSessionDataFuncTests, Constructor_SessionFile_FileCreated)
 {
     auto logSessionDataProvider = LogSessionDataProvider(SessionFileArgument);
     logSessionDataProvider.CreateLogSessionData();
     ASSERT_TRUE(MAT::FileExists(SessionFile));
 }
 
-TEST(LogSessionDataFuncTests, Constructor_ValidSessionFileExists_MembersSetToExistingFile)
+TEST_F(LogSessionDataFuncTests, Constructor_ValidSessionFileExists_MembersSetToExistingFile)
 {
     const std::string validSessionFirstTime{ "123456" };
     const std::string validSkuId{ "abc123" };
@@ -90,7 +90,7 @@ TEST(LogSessionDataFuncTests, Constructor_ValidSessionFileExists_MembersSetToExi
     ASSERT_EQ(logSessionData->getSessionSDKUid(), validSkuId);
 }
 
-TEST(LogSessionDataFuncTests, Constructor_InvalidSessionFileExists_MembersRegenerated)
+TEST_F(LogSessionDataFuncTests, Constructor_InvalidSessionFileExists_MembersRegenerated)
 {
     const std::string invalidSessionFirstTime{ "not-a-number" };
     const std::string validSkuId{ "abc123" };
@@ -104,7 +104,7 @@ TEST(LogSessionDataFuncTests, Constructor_InvalidSessionFileExists_MembersRegene
     ASSERT_NE(logSessionData->getSessionSDKUid(), validSkuId);
 }
 
-TEST(LogSessionDataFuncTests, Constructor_InvalidSessionFileExists_NewFileWritten)
+TEST_F(LogSessionDataFuncTests, Constructor_InvalidSessionFileExists_NewFileWritten)
 {
     const std::string invalidSessionFirstTime{ "not-a-number" };
     const std::string validSkuId{ "abc123" };

--- a/tests/unittests/LogSessionDataTests.cpp
+++ b/tests/unittests/LogSessionDataTests.cpp
@@ -82,5 +82,8 @@ TEST(LogSessionDataTests, getLogSessionData_ValidInput_SessionDataPersists)
 
    ASSERT_EQ(logSessionData1->getSessionFirstTime(), logSessionData2->getSessionFirstTime());
    ASSERT_EQ(logSessionData1->getSessionSDKUid(), logSessionData2->getSessionSDKUid());
+
+   logSessionDataProvider1.DeleteLogSessionData();
+   logSessionDataProvider2.DeleteLogSessionData();
 }
 


### PR DESCRIPTION
Two test files were left out without cleanup after mbu test for ariasdk. Adding change to clean them up.


**Fix:**

_**test.ses:**_

reason for this being left out after mbu test is due to TEST method is being used insteasd of TEST_F which is with fixture responsible for calling the setup and tear down functions of the test class.
more info at: [link (Opens in new window or tab)](https://google.github.io/googletest/primer.html#same-data-multiple-tests)

**_sesfile.ses:_**
this is being left out since the cleanup funcitons are not being called after the setup.

