### PR TITLE
Fix deprecated CURL API usage.

### DIFF
--- a/lib/http/HttpClient_Curl.hpp
+++ b/lib/http/HttpClient_Curl.hpp
@@ -208,7 +208,13 @@ public:
          * Note that this API takes a pointer to a 'long' while we use
          * curl_socket_t for sockets otherwise.
          */
+
+#if LIBCURL_VERSION_NUM >= 0x072D00 // Version 7.45.00
+        res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockextr);
+#else
         res = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &sockextr);
+#endif
+
         if(CURLE_OK != res)
         {
             DispatchEvent(OnConnectFailed);     // couldn't connect - stage 2


### PR DESCRIPTION
```
lib/./http/HttpClient_Curl.hpp: In member function ‘long int Microsoft::Applications::Events::CurlHttpOperation::Send()’:
lib/./http/HttpClient_Curl.hpp:211:39: error: ‘CURLINFO_LASTSOCKET’ is deprecated: since 7.45.0. Use CURLINFO_ACTIVESOCKET [-Werror=deprecated-declarations]
  211 |         res = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &sockextr);
```