### PR TITLE
adding comment about using the typealised enums in swift from objc 

### DIFF
--- a/wrappers/swift/Sources/OneDSSwift/ObjCTypes.swift
+++ b/wrappers/swift/Sources/OneDSSwift/ObjCTypes.swift
@@ -6,6 +6,7 @@
 /// Contains alias for the types declared in the ObjC header files to make them available
 /// as part of the swift package module.
 /// To avoid clients not have to import ObjCModule explicitly.
+/// Important: Due to objc->swift conventions, Type name is removed, so ODWPiiKindGenericData would be accessed as .genericData in swift.
 
 /// Check corresponding header file for the doc of each type.
 


### PR DESCRIPTION
Objc enums accessed in swift have their names removed from the enum values due to convention. Adding comment about it to let the users know.