### PR TITLE
Add noexcept annotation where applicable

### DIFF
--- a/lib/pal/desktop/NetworkDetector.cpp
+++ b/lib/pal/desktop/NetworkDetector.cpp
@@ -330,7 +330,7 @@ namespace MAT_NS_BEGIN
             return true;
         }
 
-        bool NetworkDetector::RegisterAndListen()
+        bool NetworkDetector::RegisterAndListen() noexcept
         {
             // ???
             HRESULT hr = pNlm->QueryInterface(IID_IUnknown, (void**)&pSink);

--- a/lib/pal/desktop/NetworkDetector.hpp
+++ b/lib/pal/desktop/NetworkDetector.hpp
@@ -153,7 +153,7 @@ namespace MAT_NS_BEGIN
                     /// Register and listen to network state notifications
                     /// </summary>
                     /// <returns></returns>
-                    bool RegisterAndListen();
+                    bool RegisterAndListen() noexcept;
 
                     /// <summary>
                     /// Reset network state listener to uninitialized state

--- a/tests/functests/MultipleLogManagersTests.cpp
+++ b/tests/functests/MultipleLogManagersTests.cpp
@@ -39,7 +39,7 @@ using namespace MAT;
 class RequestHandler : public HttpServer::Callback 
 {
    public:
-    RequestHandler(int id) noexcept : m_count(0), m_id(id){}
+    RequestHandler(int id) noexcept : m_id(id){}
 
     int onHttpRequest(HttpServer::Request const& request, HttpServer::Response& /*response*/) override
     {
@@ -54,7 +54,7 @@ class RequestHandler : public HttpServer::Callback
     }
 
    private:
-    size_t m_count;
+    size_t m_count {};
     int m_id ;
 };
 

--- a/tests/functests/MultipleLogManagersTests.cpp
+++ b/tests/functests/MultipleLogManagersTests.cpp
@@ -39,7 +39,7 @@ using namespace MAT;
 class RequestHandler : public HttpServer::Callback 
 {
    public:
-    RequestHandler(int id) : m_count(0), m_id(id){}
+    RequestHandler(int id) noexcept : m_count(0), m_id(id){}
 
     int onHttpRequest(HttpServer::Request const& request, HttpServer::Response& /*response*/) override
     {


### PR DESCRIPTION
Update a few methods which do not call throwing functions (or throw themselves) to use the `noexcept` annotation.

Also fixed a best-practice for constant initialization in MultipleLogManagersTests RequestHandler type.