### PR TITLE
SampleCppMini - adjust ticketNames array size

### DIFF
--- a/examples/cpp/SampleCppMini/main.cpp
+++ b/examples/cpp/SampleCppMini/main.cpp
@@ -31,7 +31,7 @@ void test_cpp_api(const char * token, int ticketType, const char *ticket)
 
     if (ticket != nullptr)
     {
-        const char *ticketNames[7] =
+        const char *ticketNames[8] =
         {
             "TicketType_MSA_Device",
             "TicketType_MSA_User",


### PR DESCRIPTION
Fixes build break in SampleCppMini by adjusting `ticketNames` array size to match number of elements the array is initialized with.