### PR TITLE
MacOS CI failure fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,11 +101,12 @@ FILE=.buildtools
 OS_NAME=`uname -a`
 if [ ! -f $FILE ]; then
   case "$OS_NAME" in
-    *Darwin*) tools/setup-buildtools-apple.sh $MAC_ARCH ;;
-    *Linux*)  [[ -z "$NOROOT" ]] && sudo tools/setup-buildtools.sh || echo "No root: skipping build tools installation." ;;
-    *)        echo "WARNING: unsupported OS $OS_NAME , skipping build tools installation.."
+    *Darwin*) CMD="tools/setup-buildtools-apple.sh $MAC_ARCH" ;;
+    *Linux*)  CMD="tools/setup-buildtools.sh" ;;
+    *)        echo "WARNING: unsupported OS $OS_NAME, skipping build tools installation.." && exit 1 ;;
   esac
-  # Assume that the build tools have been successfully installed
+  
+  [[ -z "$NOROOT" ]] && sudo $CMD || $CMD
   echo > $FILE
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -103,11 +103,18 @@ if [ ! -f $FILE ]; then
   case "$OS_NAME" in
     *Darwin*) CMD="tools/setup-buildtools-apple.sh $MAC_ARCH" ;;
     *Linux*)  CMD="tools/setup-buildtools.sh" ;;
-    *)        echo "WARNING: unsupported OS $OS_NAME, skipping build tools installation.." && exit 1 ;;
+    *)        echo "WARNING: unsupported OS $OS_NAME, skipping build tools installation.." && CMD="" ;;
   esac
   
-  [[ -z "$NOROOT" ]] && sudo $CMD || $CMD
-  echo > $FILE
+ if [ -n "$CMD" ]; then
+    if [[ -z "$NOROOT" ]]; then
+      sudo $CMD
+    else
+      echo "No root: skipping build tools installation."
+      $CMD
+    fi
+    echo > $FILE
+  fi
 fi
 
 if [ -f /usr/bin/gcc ]; then

--- a/build.sh
+++ b/build.sh
@@ -99,22 +99,16 @@ echo "macosx deployment target="$MACOSX_DEPLOYMENT_TARGET
 # Install build tools and recent sqlite3
 FILE=.buildtools
 OS_NAME=`uname -a`
+
 if [ ! -f $FILE ]; then
   case "$OS_NAME" in
     *Darwin*) CMD="tools/setup-buildtools-apple.sh $MAC_ARCH" ;;
     *Linux*)  CMD="tools/setup-buildtools.sh" ;;
-    *)        echo "WARNING: unsupported OS $OS_NAME, skipping build tools installation.." && CMD="" ;;
+    *)        CMD=""; echo "WARNING: unsupported OS $OS_NAME, skipping build tools installation.." ;;
   esac
-  
- if [ -n "$CMD" ]; then
-    if [[ -z "$NOROOT" ]]; then
-      sudo $CMD
-    else
-      echo "No root: skipping build tools installation."
-      $CMD
-    fi
-    echo > $FILE
-  fi
+
+  [[ -n "$CMD" ]] && { [[ -z "$NOROOT" ]] && sudo $CMD || echo "No root: skipping build tools installation."; }
+  echo > $FILE
 fi
 
 if [ -f /usr/bin/gcc ]; then


### PR DESCRIPTION
Fixes: #1269 

It [seems ](https://github.com/actions/runner-images/issues/9272)that macOS-13 image has `runner:admin` permissions for `/usr/local/`. But macOS-14 has `root:wheel`. So modified `build.sh` so that the build-tools script for Apple is executed as `sudo`, just like for Linux.