### PR TITLE
Fix for build errors when building with gcc 13

### DIFF
--- a/lib/api/CorrelationVector.cpp
+++ b/lib/api/CorrelationVector.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <random>
+#include <stdexcept>
 #include <limits>
 
 using std::string;

--- a/lib/filter/EventFilterCollection.cpp
+++ b/lib/filter/EventFilterCollection.cpp
@@ -8,6 +8,7 @@
 
 #if (HAVE_EXCEPTIONS)
 #include <exception>
+#include <stdexcept>
 #endif
 
 namespace MAT_NS_BEGIN

--- a/lib/include/public/Enums.hpp
+++ b/lib/include/public/Enums.hpp
@@ -7,6 +7,7 @@
 
 #include "ctmacros.hpp"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>

--- a/lib/include/public/IDataViewer.hpp
+++ b/lib/include/public/IDataViewer.hpp
@@ -8,6 +8,7 @@
 #include "ctmacros.hpp"
 #include "IModule.hpp"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/tests/unittests/BondSplicerTests.cpp
+++ b/tests/unittests/BondSplicerTests.cpp
@@ -32,7 +32,7 @@ class ShadowBondSplicer : protected MAT::BondSplicer
     {
         FullDumpBinaryBlob output;
         static_cast<std::vector<uint8_t>&>(output) = MAT::BondSplicer::splice();
-        return std::move(output);
+        return output;
     }
 };
 


### PR DESCRIPTION
A few files use types defined in headers that are missing, and this is revealed through build errors when building with gcc. Something about libstdc++ may have refactored header files such that headers that previously were inherited now must be explicitly included.

fixes #1288 