### PR TITLE
make _wrappedConfiguration into member variable

### DIFF
--- a/wrappers/obj-c/ODWLogConfiguration.mm
+++ b/wrappers/obj-c/ODWLogConfiguration.mm
@@ -288,11 +288,13 @@ NSString *const ODWCFG_BOOL_TPM_CLOCK_SKEW_ENABLED = @"clockSkewEnabled";
 NSString *const ODWCFG_BOOL_SESSION_RESET_ENABLED = @"sessionResetEnabled";
 
 @implementation ODWLogConfiguration
+{
+    ILogConfiguration* _wrappedConfiguration;
+}
     static bool _enableTrace;
     static bool _enableConsoleLogging;
     static bool _enableSessionReset;
     static bool _surfaceCppExceptions;
-    ILogConfiguration* _wrappedConfiguration;
 
 -(instancetype)initWithILogConfiguration:(ILogConfiguration*)config
 {


### PR DESCRIPTION
**PROBLEM:**
_wrappedConfiguration is a global variable which causes ODWLogConfiguration.getCopy() to return objects with a shared underlying ILogConfiguration instead of unique copies.
 
**SOLUTION:**
I believe _wrappedConfiguration was intended to be member variable of the ODWLogConfiguration, so patching it as such.