### PR TITLE
Fix Privacy Guard unit test failures

### DIFF
--- a/tests/functests/MultipleLogManagersTests.cpp
+++ b/tests/functests/MultipleLogManagersTests.cpp
@@ -248,6 +248,7 @@ TEST_F(MultipleLogManagersTests, PrivacyGuardSharedWithTwoInstancesCoexist)
     MockLogger mockLogger;
     auto privacyConcernLogCount = 0;
     InitializationConfiguration config(&mockLogger, CommonDataContext {});
+    config.ScanForUrls = true;
     const auto privacyGuard = std::make_shared<PrivacyGuard>(config);
     mockLogger.m_logEventOverride = [&privacyConcernLogCount, &privacyGuard](const EventProperties& properties) {
         if (equalsIgnoreCase(properties.GetName(), privacyGuard->GetNotificationEventName()))


### PR DESCRIPTION
This change fixes Privacy Guard related unit test and functional test failures.
1) one unit test failure that fails 1/3 of the time due to a probabilistic issue.
2) one unit test failure due to test code out of date with production code
3) one functional test failure due to test code out of date with production code.

They were not discovered earlier because some of the test cases are not run in 1DS C++ SDK main repo build pipelines - privacy guard is in submodule repo, so main repo does not compile them along with public SDK files, hence some unit tests are disabled using a macro.

I discussed with Lalit and the agreement we settled is that developers need to run all unit test locally before submitting PR for review. I also modified our developers guide to include this in Privacy Guard team guide.