### PR TITLE
update version to point to PG unified schema

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.8.323.1"
-#define BUILD_VERSION 3,8,323,1
+#define BUILD_VERSION_STR "3.8.249.1"
+#define BUILD_VERSION 3,8,249,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include "ctmacros.hpp"
@@ -18,7 +18,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)8 << 32) |
-    ((uint64_t)323 << 16) |
+    ((uint64_t)249 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END

--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.8.249.1"
-#define BUILD_VERSION 3,8,249,1
+#define BUILD_VERSION_STR "3.8.323.1"
+#define BUILD_VERSION 3,8,323,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include "ctmacros.hpp"
@@ -18,7 +18,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)8 << 32) |
-    ((uint64_t)249 << 16) |
+    ((uint64_t)323 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -70,7 +70,11 @@ endif()
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/modules/privacyguard/ AND BUILD_PRIVACYGUARD)
   add_definitions(-DHAVE_MAT_PRIVACYGUARD)
   list(APPEND SRCS
-     ${CMAKE_SOURCE_DIR}/lib/modules/privacyguard/tests/unittests/PrivacyGuardTests.cpp
+  ${CMAKE_SOURCE_DIR}/lib/modules/privacyguard/tests/unittests/InitializationConfigurationTests.cpp
+  ${CMAKE_SOURCE_DIR}/lib/modules/privacyguard/tests/unittests/PrivacyConcernEventTests.cpp
+  ${CMAKE_SOURCE_DIR}/lib/modules/privacyguard/tests/unittests/PrivacyConcernMetadataProviderTests.cpp
+  ${CMAKE_SOURCE_DIR}/lib/modules/privacyguard/tests/unittests/PrivacyGuardTests.cpp
+  ${CMAKE_SOURCE_DIR}/lib/modules/privacyguard/tests/unittests/SystematicSamplerTests.cpp
   )
 endif()
 

--- a/tests/unittests/UnitTests.vcxproj
+++ b/tests/unittests/UnitTests.vcxproj
@@ -481,6 +481,9 @@
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientUtilsTests.cpp" />
   </ItemGroup>
   <ItemGroup Condition="exists('$(ProjectDir)..\..\lib\modules\privacyguard')">
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\InitializationConfigurationTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyConcernEventTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyConcernMetadataProviderTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyGuardTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\SystematicSamplerTests.cpp" />
   </ItemGroup>

--- a/tests/unittests/UnitTests.vcxproj.filters
+++ b/tests/unittests/UnitTests.vcxproj.filters
@@ -56,7 +56,11 @@
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSConfigCacheTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\exp\tests\unittests\ECSClientUtilsTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\InitializationConfigurationTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyConcernEventTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyConcernMetadataProviderTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\PrivacyGuardTests.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\lib\modules\privacyguard\tests\unittests\SystematicSamplerTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\dataviewer\tests\unittests\DefaultDataViewerTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\signals\tests\unittests\SignalsTests.cpp" />
     <ClCompile Include="$(ProjectDir)\InformationProviderImplTests.cpp" />


### PR DESCRIPTION
Privacy Guard has an initiative for point to a unified schema. 
The new schema stores the data in the Privacy Concern Event. This idea has been implemented in https://github.com/microsoft/cpp_client_telemetry_modules/pull/253.

- Implemented Privacy Concern Event
- Integrated NotifyConcern with the new schema 
- Added tests to cover the new changes. 
