### PR TITLE
Support iOS Simulator on arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,9 @@ if(APPLE)
 
     if(FORCE_RESET_OSX_DEPLOYMENT_TARGET)
       set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment target for iOS" FORCE)
-      if((${IOS_PLAT} STREQUAL "iphonesimulator") AND ((${IOS_ARCH} STREQUAL "arm64") OR (${IOS_ARCH} STREQUAL "arm64e")))
-        # iOS arm64 simulator is supported starting BigSur
-        # Unfortunately, CMAKE produces a device binary (not simulator) when providing -miphoneos-version-min flag when building iOS arm64 simulator
+      if (${IOS_PLAT} STREQUAL "iphonesimulator")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mios-simulator-version-min=${IOS_DEPLOYMENT_TARGET}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mios-simulator-version-min=${IOS_DEPLOYMENT_TARGET}")
       else()
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_TARGET}")


### PR DESCRIPTION
Hi - I'm working on migrating my team's project to use the arm64 iOS simulator. I spent many hours today trying to track down this same issue in another one of our dependencies, so I thought I should contribute my findings back here.

It looks like for the x86_64 simulator, it will assume you want the simulator build even if you pass -miphoneos-version-min (because an x86 iphone makes no sense), but for the arm64 simulator, you need to specify you want the simulator with -mios-simulator-version-min.