### PR TITLE
using COPY_FILE only with cmake 3.21+ where it is introduced

### DIFF
--- a/tests/functests/CMakeLists.txt
+++ b/tests/functests/CMakeLists.txt
@@ -35,7 +35,14 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests)
         ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/ECSConfigCacheFuncTests.cpp
         )
     if (EXISTS ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/test.json)
-      file(COPY_FILE ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/test.json ${CMAKE_BINARY_DIR}/test.json)
+      if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
+        # Use file(COPY_FILE ...) for CMake 3.19 and later
+        file(COPY_FILE ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/test.json ${CMAKE_BINARY_DIR}/test.json)
+      else()
+        # Use file(COPY ...) as an alternative for older versions
+        file(COPY ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/test.json
+          DESTINATION ${CMAKE_BINARY_DIR})
+      endif()
     endif()
 endif()
 

--- a/tests/functests/CMakeLists.txt
+++ b/tests/functests/CMakeLists.txt
@@ -35,8 +35,8 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests)
         ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/ECSConfigCacheFuncTests.cpp
         )
     if (EXISTS ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/test.json)
-      if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
-        # Use file(COPY_FILE ...) for CMake 3.19 and later
+      if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
+        # Use file(COPY_FILE ...) for CMake 3.21 and later
         file(COPY_FILE ${CMAKE_SOURCE_DIR}/lib/modules/exp/tests/functests/test.json ${CMAKE_BINARY_DIR}/test.json)
       else()
         # Use file(COPY ...) as an alternative for older versions


### PR DESCRIPTION
This PR https://github.com/microsoft/cpp_client_telemetry/commit/c480743a8603dd34bb8b054877ced15bc48870c1 added COPY_FILE which is a new command in cmake 3.19 and not present in cmake 3.16.3-1ubuntu1.20.04.1. 

Fixing this by using COPY_FILE only with cmake 3.19+ where it is introduced