### PR TITLE
Bump version for new release - "3.9.22.1"

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.8.249.1"
-#define BUILD_VERSION 3,8,249,1
+#define BUILD_VERSION_STR "3.9.22.1"
+#define BUILD_VERSION 3,9,22,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include "ctmacros.hpp"
@@ -17,8 +17,8 @@ namespace MAT_NS_BEGIN {
 
 uint64_t const Version =
     ((uint64_t)3 << 48) |
-    ((uint64_t)8 << 32) |
-    ((uint64_t)249 << 16) |
+    ((uint64_t)9 << 32) |
+    ((uint64_t)22 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END
@@ -27,4 +27,3 @@ namespace PAL_NS_BEGIN { } PAL_NS_END
 
 #endif // RESOURCE_COMPILER_INVOKED
 #endif
-

--- a/tools/version-node.js
+++ b/tools/version-node.js
@@ -1,17 +1,21 @@
 const fs = require('fs');
 
 function dayNumber() {
-  var now = new Date();
-  var start = new Date(now.getFullYear(), 0, 0);
-  var diff = now - start;
-  var oneDay = 1000 * 60 * 60 * 24;
-  var dayOfYear = Math.floor(diff / oneDay);
-  return dayOfYear;
+  const now = new Date();
+  const start = new Date(now.getFullYear(), 0, 0);
+  const diff = now - start;
+  const oneDay = 1000 * 60 * 60 * 24;
+  return Math.floor(diff / oneDay);
+}
+
+function calculateMinorVersion() {
+  const baseYear = 2020; // VER_MINOR starts at 4 in 2020
+  const currentYear = new Date().getFullYear();
+  return (currentYear - baseYear) + 4; // Increment annually
 }
 
 function readAll(filename) {
-  var contents = fs.readFileSync(filename, 'utf8');
-  return contents;
+  return fs.readFileSync(filename, 'utf8');
 }
 
 function fileExists(path) {
@@ -19,35 +23,41 @@ function fileExists(path) {
 }
 
 function generateVersionHpp() {
-  var palTxt = "CPP11";
-  // Read version tag
-  var ver1 = readAll("../Solutions/version.txt");
-  // Remove end-of-line
-  ver1 = ver1.replace("\n", "");
-  // Replace 999 by today's dayNumber for nightly builds
-  ver1 = ver1.replace("999", dayNumber());
-  // console.log("version.txt => " + ver1 + "\n");
-  var ver2 = ver1.split(".").join(",");
-  var arr = ver1.split(".");
-  var versionHpp = "../lib/include/public/Version.hpp";
+  const palTxt = "CPP11";
+  const verMajor = 3; // Constant major version
+  const verMinor = calculateMinorVersion(); // Calculate minor version dynamically
+  const verPatch = dayNumber(); // Day of the year as the patch version
+  const verBuild = 1; // Constant build number
+
+  // Read version template from Solutions.txt
+  let ver1 = readAll("../Solutions/version.txt").replace(/\n/g, "");
+  ver1 = ver1.replace("year", verMinor).replace("day", verPatch); // Replace placeholders
+
+  const arr = ver1.split(".");
+  const versionHpp = "../lib/include/public/Version.hpp";
+
+  // Check if Version.hpp exists and matches the current version
   if (fileExists(versionHpp)) {
-    var versionHppTxt = readAll(versionHpp);
-    if (versionHppTxt.search(ver1) != -1) {
-      console.log("Version.hpp " + ver1 + " kept (incremental build)\n");
+    const versionHppTxt = readAll(versionHpp);
+    if (versionHppTxt.includes(ver1)) {
+      console.log(`Version.hpp ${ver1} kept (incremental build)\n`);
       return;
     }
-    // Delete and recreate
-    fs.unlinkSync(versionHpp);
+    fs.unlinkSync(versionHpp); // Delete if outdated
   }
-  var templText = readAll("../lib/include/public/Version.hpp.template");
-  templText = templText.replace(/\@ull/gi, "@");
-  templText = templText.replace(/\@BUILD_VERSION_MAJOR\@/g, arr[0]);
-  templText = templText.replace(/\@BUILD_VERSION_MINOR\@/g, arr[1]);
-  templText = templText.replace(/\@BUILD_VERSION_PATCH\@/g, arr[2]);
-  templText = templText.replace(/\@BUILD_NUMBER\@/g, arr[3]);
-  templText = templText.replace(/\@PAL_IMPLEMENTATION_UPPER\@/g, palTxt);
+
+  // Read template and generate Version.hpp
+  const templText = readAll("../lib/include/public/Version.hpp.template")
+    .replace(/\@ull/gi, "@")
+    .replace(/\@BUILD_VERSION_MAJOR\@/g, arr[0])
+    .replace(/\@BUILD_VERSION_MINOR\@/g, arr[1])
+    .replace(/\@BUILD_VERSION_PATCH\@/g, arr[2])
+    .replace(/\@BUILD_NUMBER\@/g, arr[3])
+    .replace(/\@PAL_IMPLEMENTATION_UPPER\@/g, palTxt);
+
   fs.writeFileSync(versionHpp, templText);
-  console.log("Version.hpp " + ver1 + " generated (clean build)\n");
+  console.log(`Version.hpp ${ver1} generated (clean build)\n`);
 }
 
 generateVersionHpp();
+

--- a/tools/version-node.js
+++ b/tools/version-node.js
@@ -1,21 +1,23 @@
 const fs = require('fs');
 
 function dayNumber() {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 0);
-  const diff = now - start;
-  const oneDay = 1000 * 60 * 60 * 24;
-  return Math.floor(diff / oneDay);
+  var now = new Date();
+  var start = new Date(now.getFullYear(), 0, 0);
+  var diff = now - start;
+  var oneDay = 1000 * 60 * 60 * 24;
+  var dayOfYear = Math.floor(diff / oneDay);
+  return dayOfYear;
 }
 
 function calculateMinorVersion() {
-  const baseYear = 2020; // VER_MINOR starts at 4 in 2020
-  const currentYear = new Date().getFullYear();
+  var baseYear = 2020; // VER_MINOR starts at 4 in 2020
+  var currentYear = new Date().getFullYear();
   return (currentYear - baseYear) + 4; // Increment annually
 }
 
 function readAll(filename) {
-  return fs.readFileSync(filename, 'utf8');
+  var contents = fs.readFileSync(filename, 'utf8');
+  return contents;
 }
 
 function fileExists(path) {
@@ -23,40 +25,42 @@ function fileExists(path) {
 }
 
 function generateVersionHpp() {
-  const palTxt = "CPP11";
-  const verMajor = 3; // Constant major version
-  const verMinor = calculateMinorVersion(); // Calculate minor version dynamically
-  const verPatch = dayNumber(); // Day of the year as the patch version
-  const verBuild = 1; // Constant build number
+  var palTxt = "CPP11";
+  var verMinor = calculateMinorVersion(); // Calculate minor version dynamically
+  var verPatch = dayNumber(); // Day of the year as the patch version
 
-  // Read version template from Solutions.txt
-  let ver1 = readAll("../Solutions/version.txt").replace(/\n/g, "");
-  ver1 = ver1.replace("year", verMinor).replace("day", verPatch); // Replace placeholders
+  // Read version tag
+  var ver1 = readAll("../Solutions/version.txt");
+  // Remove end-of-line
+  ver1 = ver1.replace("\n", "");
+  // Replace placeholders in version tag
+  ver1 = ver1.replace("year", verMinor).replace("day", verPatch);
 
-  const arr = ver1.split(".");
-  const versionHpp = "../lib/include/public/Version.hpp";
+  // Parse version tag into components
+  var ver2 = ver1.split(".").join(",");
+  var arr = ver1.split(".");
+  var versionHpp = "../lib/include/public/Version.hpp";
 
-  // Check if Version.hpp exists and matches the current version
   if (fileExists(versionHpp)) {
-    const versionHppTxt = readAll(versionHpp);
-    if (versionHppTxt.includes(ver1)) {
-      console.log(`Version.hpp ${ver1} kept (incremental build)\n`);
+    var versionHppTxt = readAll(versionHpp);
+    if (versionHppTxt.search(ver1) != -1) {
+      console.log("Version.hpp " + ver1 + " kept (incremental build)\n");
       return;
     }
-    fs.unlinkSync(versionHpp); // Delete if outdated
+    // Delete and recreate
+    fs.unlinkSync(versionHpp);
   }
 
-  // Read template and generate Version.hpp
-  const templText = readAll("../lib/include/public/Version.hpp.template")
-    .replace(/\@ull/gi, "@")
-    .replace(/\@BUILD_VERSION_MAJOR\@/g, arr[0])
-    .replace(/\@BUILD_VERSION_MINOR\@/g, arr[1])
-    .replace(/\@BUILD_VERSION_PATCH\@/g, arr[2])
-    .replace(/\@BUILD_NUMBER\@/g, arr[3])
-    .replace(/\@PAL_IMPLEMENTATION_UPPER\@/g, palTxt);
+  var templText = readAll("../lib/include/public/Version.hpp.template");
+  templText = templText.replace(/\@ull/gi, "@");
+  templText = templText.replace(/\@BUILD_VERSION_MAJOR\@/g, arr[0]);
+  templText = templText.replace(/\@BUILD_VERSION_MINOR\@/g, arr[1]);
+  templText = templText.replace(/\@BUILD_VERSION_PATCH\@/g, arr[2]);
+  templText = templText.replace(/\@BUILD_NUMBER\@/g, arr[3]);
+  templText = templText.replace(/\@PAL_IMPLEMENTATION_UPPER\@/g, palTxt);
 
   fs.writeFileSync(versionHpp, templText);
-  console.log(`Version.hpp ${ver1} generated (clean build)\n`);
+  console.log("Version.hpp " + ver1 + " generated (clean build)\n");
 }
 
 generateVersionHpp();


### PR DESCRIPTION
Also fix the version generation script to increment the minor and patch release properly. Somehow it stopped worked with previous commits.