### PR TITLE
Reachability: use NSURLSession for MacOS 10.14 or higher

### DIFF
--- a/tests/unittests/obj-c/ODWReachabilityTests.mm
+++ b/tests/unittests/obj-c/ODWReachabilityTests.mm
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ODWReachabilityTests.mm
+// Tests
+//
+// Created by Abu Sayem on 13/12/2024.
+//
+
+#import <XCTest/XCTest.h>
+#import "ODWReachability.h"
+
+#import <sys/socket.h>
+#import <netinet/in.h>
+#import <netinet6/in6.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
+#import <Foundation/Foundation.h>
+
+@interface ODWReachabilityTests : XCTestCase
+@end
+
+@implementation ODWReachabilityTests
+
+- (void)testReachabilityWithHostname
+{
+    NSString *hostname = @"www.microsoft.com";
+    ODWReachability *reachability = [ODWReachability reachabilityWithHostname:hostname];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachability check"];
+    NSString *hostUrl = [NSString stringWithFormat:@"https://%@", hostname];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(reachability);
+        XCTAssertEqualObjects(reachability.url.absoluteString, hostUrl);
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+- (void)testReachabilityWithInvalidHostname
+{
+    NSString *hostname = @"invalid.hostname";
+    ODWReachability *reachability = [ODWReachability reachabilityWithHostname:hostname];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachability check"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertNil(reachability);
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+- (void)testReachabilityWithAddress
+{
+    struct sockaddr_in address;
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = inet_addr("8.8.8.8");
+    ODWReachability *reachability = [ODWReachability reachabilityWithAddress:&address];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachability check"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(reachability);
+        XCTAssertEqualObjects(reachability.url.absoluteString, @"https://8.8.8.8");
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+- (void)testReachabilityWithInvalidAddress
+{
+    struct sockaddr_in address;
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = inet_addr("0.0.0.0");
+    ODWReachability *reachability = [ODWReachability reachabilityWithAddress:&address];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachability check"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertNil(reachability);
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+- (void)testReachabilityForInternetConnection
+{
+    ODWReachability *reachability = [ODWReachability reachabilityForInternetConnection];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachability check"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(reachability);
+        XCTAssertEqual(reachability.currentReachabilityStatus, ReachableViaWiFi);
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+- (void)testReachabilityForLocalWiFi
+{
+    ODWReachability *reachability = [ODWReachability reachabilityForLocalWiFi];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Reachability check"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(reachability);
+        XCTAssertEqual(reachability.currentReachabilityStatus, ReachableViaWiFi);
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+@end
+

--- a/tests/unittests/unittests-ios.xcodeproj/project.pbxproj
+++ b/tests/unittests/unittests-ios.xcodeproj/project.pbxproj
@@ -117,7 +117,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		16CC106F2D4D58DA00C03295 /* ODWReachabilityTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ODWReachabilityTests.mm; path = "obj-c/ODWReachabilityTests.mm"; sourceTree = "<group>"; };
+		16CC106F2D4D58DA00C03295 /* ODWReachabilityTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ODWReachabilityTests.mm; path = "obj-c/ODWReachabilityTests.mm"; sourceTree = "<group>"; };
 		430102E4235E660F00836D50 /* iOSWrapper.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = iOSWrapper.mm; path = ../../common/iOSWrapper.mm; sourceTree = "<group>"; };
 		431EFE1E233EBDF2002FCC18 /* libunittests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libunittests.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		431EFE2A233EBE53002FCC18 /* HttpClientTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpClientTests.cpp; sourceTree = "<group>"; };
@@ -402,7 +402,6 @@
 				431EFE60233EBE54002FCC18 /* ControlPlaneProviderTests.cpp in Sources */,
 				431EFE5D233EBE54002FCC18 /* ClockSkewManagerTests.cpp in Sources */,
 				431EFE58233EBE54002FCC18 /* PalTests.cpp in Sources */,
-				16CC10702D4D58DA00C03295 /* ODWReachabilityTests.mm in Sources */,
 				431EFED423425535002FCC18 /* DataViewerCollectionTests.cpp in Sources */,
 				431EFE70233EBE54002FCC18 /* OfflineStorageTests.cpp in Sources */,
 				431EFE6B233EBE54002FCC18 /* OacrTests.cpp in Sources */,

--- a/tests/unittests/unittests-ios.xcodeproj/project.pbxproj
+++ b/tests/unittests/unittests-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		16CC10702D4D58DA00C03295 /* ODWReachabilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 16CC106F2D4D58DA00C03295 /* ODWReachabilityTests.mm */; };
 		430102E5235E660F00836D50 /* iOSWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 430102E4235E660F00836D50 /* iOSWrapper.mm */; };
 		431EFE50233EBE54002FCC18 /* HttpClientTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 431EFE2A233EBE53002FCC18 /* HttpClientTests.cpp */; };
 		431EFE51233EBE54002FCC18 /* LoggerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 431EFE2B233EBE53002FCC18 /* LoggerTests.cpp */; };
@@ -116,6 +117,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		16CC106F2D4D58DA00C03295 /* ODWReachabilityTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ODWReachabilityTests.mm; path = "obj-c/ODWReachabilityTests.mm"; sourceTree = "<group>"; };
 		430102E4235E660F00836D50 /* iOSWrapper.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = iOSWrapper.mm; path = ../../common/iOSWrapper.mm; sourceTree = "<group>"; };
 		431EFE1E233EBDF2002FCC18 /* libunittests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libunittests.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		431EFE2A233EBE53002FCC18 /* HttpClientTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpClientTests.cpp; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		431EFE15233EBDF2002FCC18 = {
 			isa = PBXGroup;
 			children = (
+				16CC106F2D4D58DA00C03295 /* ODWReachabilityTests.mm */,
 				43BD496F26B8B0C300EC3C0C /* EventPropertiesDecoratorTests.cpp */,
 				437C72F024D2286F0046F545 /* ODWLogConfigurationTests.mm */,
 				437C72EE24D21ACE0046F545 /* ODWSemanticContextTests.mm */,
@@ -399,6 +402,7 @@
 				431EFE60233EBE54002FCC18 /* ControlPlaneProviderTests.cpp in Sources */,
 				431EFE5D233EBE54002FCC18 /* ClockSkewManagerTests.cpp in Sources */,
 				431EFE58233EBE54002FCC18 /* PalTests.cpp in Sources */,
+				16CC10702D4D58DA00C03295 /* ODWReachabilityTests.mm in Sources */,
 				431EFED423425535002FCC18 /* DataViewerCollectionTests.cpp in Sources */,
 				431EFE70233EBE54002FCC18 /* OfflineStorageTests.cpp in Sources */,
 				431EFE6B233EBE54002FCC18 /* OacrTests.cpp in Sources */,
@@ -433,6 +437,7 @@
 				431EFEA7233EC590002FCC18 /* HttpDeflateCompressionTests.cpp in Sources */,
 				431EFEB3233EC590002FCC18 /* OfflineStorageTests.cpp in Sources */,
 				431EFEB8233EC590002FCC18 /* TaskDispatcherCAPITests.cpp in Sources */,
+				16CC10712D4D58DA00C03295 /* ODWReachabilityTests.mm in Sources */,
 				437C72ED24D0C5D70046F545 /* ODWEventPropertiesTests.mm in Sources */,
 				431EFEB6233EC590002FCC18 /* RouteTests.cpp in Sources */,
 				431EFEA8233EC590002FCC18 /* HttpRequestEncoderTests.cpp in Sources */,

--- a/third_party/Reachability/ODWReachability.h
+++ b/third_party/Reachability/ODWReachability.h
@@ -60,6 +60,7 @@ typedef void (^NetworkUnreachable)(ODWReachability * reachability);
 
 @property (nonatomic, assign) BOOL reachableOnWWAN;
 
+@property (nonatomic, strong) NSURL *url;
 
 +(ODWReachability*)reachabilityWithHostname:(NSString*)hostname;
 // This is identical to the function above, but is here to maintain
@@ -68,6 +69,7 @@ typedef void (^NetworkUnreachable)(ODWReachability * reachability);
 +(ODWReachability*)reachabilityForInternetConnection;
 +(ODWReachability*)reachabilityWithAddress:(void *)hostAddress;
 +(ODWReachability*)reachabilityForLocalWiFi;
++(void)setTimeoutDurationInSeconds:(int)timeoutDuration;
 
 -(ODWReachability *)initWithReachabilityRef:(SCNetworkReachabilityRef)ref;
 

--- a/third_party/Reachability/ODWReachability.m
+++ b/third_party/Reachability/ODWReachability.m
@@ -245,13 +245,13 @@ static int kTimeoutDurationInSeconds = 10;
 
 +(void)setTimeoutDurationInSeconds:(int)timeoutDuration
 {
-    if (timeoutDuration > 0)
+    if (timeoutDuration >= kTimeoutDurationInSeconds)
     {
         kTimeoutDurationInSeconds = timeoutDuration;
     }
     else
     {
-        NSLog(@"Timeout duration must be positive.");
+        NSLog(@"Timeout duration must be at least 10.");
     }
 }
 


### PR DESCRIPTION
Reachability uses SCNetworkReachabilityRef library which is deprecated in MacOS 10.14 or higher.
Hence, Use NSURLSession for MacOS 10.14 or higher in cpp_client_telemetry/third_party/Reachability and have backward compatibility with SCNetworkReachabilityRef library for versions lower than MacOS 10.14