### PR TITLE
Suppress C4866 in PayloadDecoder and JsonFormatter's usage of json.hpp

### DIFF
--- a/lib/decoder/PayloadDecoder.cpp
+++ b/lib/decoder/PayloadDecoder.cpp
@@ -130,6 +130,12 @@ namespace clienttelemetry {
                 return true;
             }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4866) 
+// In C++17 left-to-right evaluation order for operands of operator[] is not guaranteed when the argument's copy constructor is run.
+// Evalutation order isn't not relied upon here, disabling warning.
+#endif // _MSC_VER
             void to_json(json& j, const Data& d)
             {
                 for (const auto &kv : d.properties)
@@ -230,6 +236,9 @@ namespace clienttelemetry {
                     }
                 }
             }
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif  // _MSC_VER
 
             void to_json(json& j, const Record& r)
             {

--- a/lib/system/JsonFormatter.cpp
+++ b/lib/system/JsonFormatter.cpp
@@ -40,6 +40,12 @@ namespace MAT_NS_BEGIN
         }
     }
 
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4866 )
+// In C++17 left-to-right evaluation order for operands of operator[] is not guaranteed when the argument's copy constructor is run.
+// Evalutation order isn't not relied upon here, disabling warning.
+#endif // _MSC_VER
     void addData(json& object, std::vector<::CsProtocol::Data>& data)
     {
         std::vector<::CsProtocol::Data>::const_iterator it;
@@ -126,6 +132,9 @@ namespace MAT_NS_BEGIN
             }
         }
     }
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif  // _MSC_VER
 
     std::string JsonFormatter::getJsonFormattedEvent(IncomingEventContextPtr const& event)
     {


### PR DESCRIPTION
In C++17 left-to-right evaluation order for operands of operator[] is not guaranteed when the argument's copy constructor is run.
Evalutation order isn't not relied upon here, so I'm disabling warning.