### PR TITLE
Fix submodule checkout in CI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -25,8 +25,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        depth: 1
-        submodules: 'false'
+        submodules: false
     - name: Update submodules
       run: |
         git submodule sync

--- a/.github/workflows/build-ios-mac11.yml
+++ b/.github/workflows/build-ios-mac11.yml
@@ -29,7 +29,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: true
+        depth: 1
       continue-on-error: true
     - name: build
       run: export IOS_DEPLOYMENT_TARGET=11.0 && ./build-tests-ios.sh ${{ matrix.config }} ${{ matrix.simulator }}

--- a/.github/workflows/test-android-mac.yml.off
+++ b/.github/workflows/test-android-mac.yml.off
@@ -28,7 +28,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: true
+        depth: 1
       continue-on-error: true
 
     - name: Build and Test


### PR DESCRIPTION
Setting `submodules` as bool instead of string. The latter seems not working.