### PR TITLE
Remove extra semicolons in codebase

### DIFF
--- a/lib/api/AuthTokensController.cpp
+++ b/lib/api/AuthTokensController.cpp
@@ -9,7 +9,7 @@
 
 namespace MAT_NS_BEGIN {
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(AuthTokensController, "EventsSDK.AuthTokensController", "Events telemetry client - AuthTokensController class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(AuthTokensController, "EventsSDK.AuthTokensController", "Events telemetry client - AuthTokensController class")
 
     AuthTokensController::AuthTokensController()
         :m_IsStrictModeEnabled(false)

--- a/lib/api/DataViewerCollection.cpp
+++ b/lib/api/DataViewerCollection.cpp
@@ -8,7 +8,7 @@
 
 namespace MAT_NS_BEGIN {
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(DataViewerCollection, "EventsSDK.DataViewerCollection", "Microsoft Telemetry Client - DataViewerCollection class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(DataViewerCollection, "EventsSDK.DataViewerCollection", "Microsoft Telemetry Client - DataViewerCollection class")
 
     void DataViewerCollection::DispatchDataViewerEvent(const std::vector<uint8_t>& packetData) const noexcept
     {
@@ -21,7 +21,7 @@ namespace MAT_NS_BEGIN {
             // Task 3568800: Integrate ThreadPool to IDataViewerCollection
             viewer->ReceiveData(packetData);
         }
-    };
+    }
 
     void DataViewerCollection::RegisterViewer(const std::shared_ptr<IDataViewer>& dataViewer)
     {

--- a/lib/api/DataViewerCollection.hpp
+++ b/lib/api/DataViewerCollection.hpp
@@ -31,7 +31,7 @@ namespace MAT_NS_BEGIN {
 
         virtual bool IsViewerRegistered(const char* viewerName) const override;
 
-        virtual ~DataViewerCollection() noexcept {};
+        virtual ~DataViewerCollection() noexcept {}
     private:
         MATSDK_LOG_DECL_COMPONENT_CLASS();
 

--- a/lib/api/IRuntimeConfig.hpp
+++ b/lib/api/IRuntimeConfig.hpp
@@ -192,7 +192,7 @@ namespace MAT_NS_BEGIN
         /// <returns>Provider Group Id</returns>
         virtual const char* GetProviderGroupId() = 0;
 
-        virtual ~IRuntimeConfig() {};
+        virtual ~IRuntimeConfig() {}
     };
 
     /// @endcond

--- a/lib/api/LogManagerImpl.cpp
+++ b/lib/api/LogManagerImpl.cpp
@@ -102,7 +102,7 @@ namespace MAT_NS_BEGIN
         return true;
     }
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(LogManagerImpl, "EventsSDK.LogManager", "Microsoft Telemetry Client - LogManager class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(LogManagerImpl, "EventsSDK.LogManager", "Microsoft Telemetry Client - LogManager class")
 
 #if 1
     // TODO: integrate Tracing API from v1
@@ -348,7 +348,7 @@ namespace MAT_NS_BEGIN
             client->SetMsRootCheck(m_logConfiguration[CFG_MAP_HTTP][CFG_BOOL_HTTP_MS_ROOT_CHECK]);
         }
 #endif
-    };
+    }
 
     LogManagerImpl::~LogManagerImpl() noexcept
     {
@@ -507,7 +507,7 @@ namespace MAT_NS_BEGIN
     const std::string& LogManagerImpl::GetTransmitProfileName()
     {
         return TransmitProfiles::getProfile();
-    };
+    }
 
     ISemanticContext& LogManagerImpl::GetSemanticContext()
     {
@@ -665,7 +665,7 @@ namespace MAT_NS_BEGIN
     void LogManagerImpl::AddEventListener(DebugEventType type, DebugEventListener& listener)
     {
         m_debugEventSource.AddEventListener(type, listener);
-    };
+    }
 
     /// <summary>
     /// Removes the event listener.
@@ -675,7 +675,7 @@ namespace MAT_NS_BEGIN
     void LogManagerImpl::RemoveEventListener(DebugEventType type, DebugEventListener& listener)
     {
         m_debugEventSource.RemoveEventListener(type, listener);
-    };
+    }
 
     /// <summary>
     /// Dispatches the event.
@@ -685,7 +685,7 @@ namespace MAT_NS_BEGIN
     bool LogManagerImpl::DispatchEvent(DebugEvent evt)
     {
         return m_debugEventSource.DispatchEvent(std::move(evt));
-    };
+    }
 
     /// <summary>Attach cascaded DebugEventSource to forward all events to</summary>
     bool LogManagerImpl::AttachEventSource(DebugEventSource& other)

--- a/lib/api/LogManagerImpl.hpp
+++ b/lib/api/LogManagerImpl.hpp
@@ -182,7 +182,7 @@ namespace MAT_NS_BEGIN
         {
             const std::string val(value);
             return SetContext(name, val, piiKind);
-        };
+        }
 
         virtual inline status_t SetContext(const std::string& name, int8_t value, PiiKind piiKind = PiiKind_None) override
         {

--- a/lib/api/Logger.cpp
+++ b/lib/api/Logger.cpp
@@ -170,37 +170,37 @@ namespace MAT_NS_BEGIN
     void Logger::SetContext(const std::string& k, const char v[], PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     void Logger::SetContext(const std::string& k, const std::string& v, PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     void Logger::SetContext(const std::string& k, double v, PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     void Logger::SetContext(const std::string& k, int64_t v, PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     void Logger::SetContext(const std::string& k, time_ticks_t v, PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     void Logger::SetContext(const std::string& k, GUID_t v, PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     void Logger::SetContext(const std::string& k, bool v, PiiKind pii)
     {
         SetContext(k, EventProperty(v, pii));
-    };
+    }
 
     // The goal of this method is to rewire the logger instance to any other ISemanticContext issued by SDK.
     // SDK may provide a future option for a guest logger to opt-in into its own semantic context. The method will then

--- a/lib/config/RuntimeConfig_Default.hpp
+++ b/lib/config/RuntimeConfig_Default.hpp
@@ -104,7 +104,7 @@ namespace MAT_NS_BEGIN
             config(customConfig)
         {
             Variant::merge_map(*customConfig, *defaultRuntimeConfig());
-        };
+        }
 
         virtual ~RuntimeConfig_Default()
         {
@@ -125,14 +125,14 @@ namespace MAT_NS_BEGIN
             UNREFERENCED_PARAMETER(extension);
             UNREFERENCED_PARAMETER(experimentationProject);
             UNREFERENCED_PARAMETER(eventName);
-        };
+        }
 
         virtual EventLatency GetEventLatency(std::string const& tenantId = std::string(), std::string const& eventName = std::string()) override
         {
             UNREFERENCED_PARAMETER(tenantId);
             UNREFERENCED_PARAMETER(eventName);
             return EventLatency_Normal;
-        };
+        }
 
         virtual std::string GetMetaStatsTenantToken() override
         {
@@ -144,7 +144,7 @@ namespace MAT_NS_BEGIN
                     return std::string(token);
             }
             return std::string(defaultToken);
-        };
+        }
 
         virtual unsigned GetMetaStatsSendIntervalSec() override
         {
@@ -154,7 +154,7 @@ namespace MAT_NS_BEGIN
         virtual unsigned GetOfflineStorageMaximumSizeBytes() override
         {
             return config[CFG_INT_CACHE_FILE_SIZE];
-        };
+        }
 
         virtual unsigned GetOfflineStorageResizeThresholdPct() override
         {

--- a/lib/decorators/BaseDecorator.hpp
+++ b/lib/decorators/BaseDecorator.hpp
@@ -24,7 +24,7 @@ namespace MAT_NS_BEGIN
 
     public:
         BaseDecorator(ILogManager& owner);
-        virtual ~BaseDecorator() {};
+        virtual ~BaseDecorator() {}
         bool decorate(CsProtocol::Record& record);
 
     protected:

--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -53,7 +53,7 @@ namespace MAT_NS_BEGIN {
             //
             randomLocalId = "r:";
             randomLocalId+= PAL::generateUuidString();
-        };
+        }
 
         void dropPiiPartA(::CsProtocol::Record& record)
         {

--- a/lib/decorators/SemanticApiDecorators.hpp
+++ b/lib/decorators/SemanticApiDecorators.hpp
@@ -16,7 +16,7 @@ namespace MAT_NS_BEGIN {
     class SemanticApiDecorators : public BaseDecorator {
 
     public:
-        SemanticApiDecorators(ILogManager& owner) : BaseDecorator(owner) {};
+        SemanticApiDecorators(ILogManager& owner) : BaseDecorator(owner) {}
 
         bool decorateAggregatedMetricMessage(::CsProtocol::Record& record, AggregatedMetricData const& metricData)
         {

--- a/lib/http/HttpClientFactory.cpp
+++ b/lib/http/HttpClientFactory.cpp
@@ -33,7 +33,7 @@
 
 namespace MAT_NS_BEGIN {
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(HttpClientFactory, "EventsSDK.HttpClientFactory", "Events telemetry client - HttpClientFactory class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(HttpClientFactory, "EventsSDK.HttpClientFactory", "Events telemetry client - HttpClientFactory class")
 
 #if defined(MATSDK_PAL_WIN32)
 #ifdef _WINRT_DLL

--- a/lib/http/HttpClientManager.cpp
+++ b/lib/http/HttpClientManager.cpp
@@ -61,7 +61,7 @@ namespace MAT_NS_BEGIN {
             // as well pass the data back by updating the data structure.
             DebugEvent evt(EVT_HTTP_STATE, size_t(state), 0, data, size);
             m_hcm.m_logManager.DispatchEvent(evt);
-        };
+        }
 
 
         virtual ~HttpCallback()

--- a/lib/http/HttpClient_WinInet.cpp
+++ b/lib/http/HttpClient_WinInet.cpp
@@ -538,7 +538,7 @@ void HttpClient_WinInet::CancelAllRequests()
         PAL::sleep(100);
         std::this_thread::yield();
     }
-};
+}
 
 /// <summary>
 /// Enforces MS-root server certificate check.

--- a/lib/include/mat/IDeviceInformation.hpp
+++ b/lib/include/mat/IDeviceInformation.hpp
@@ -24,7 +24,7 @@ namespace PAL_NS_BEGIN {
     {
     public:
 
-        virtual ~IDeviceInformation() {};
+        virtual ~IDeviceInformation() {}
 
         /// <summary>
         /// Gets the unique ID of the current device

--- a/lib/include/mat/INetworkInformation.hpp
+++ b/lib/include/mat/INetworkInformation.hpp
@@ -27,7 +27,7 @@ namespace PAL_NS_BEGIN {
     {
     public:
 
-        virtual ~INetworkInformation() {};
+        virtual ~INetworkInformation() {}
 
         /// <summary>
         /// Gets the current network provider for the device

--- a/lib/include/mat/ISystemInformation.hpp
+++ b/lib/include/mat/ISystemInformation.hpp
@@ -16,7 +16,7 @@ namespace PAL_NS_BEGIN {
     {
     public:
 
-        virtual ~ISystemInformation() {};
+        virtual ~ISystemInformation() {}
 
         /// <summary>
         /// Gets the App ID.

--- a/lib/include/public/CAPIClient.hpp
+++ b/lib/include/public/CAPIClient.hpp
@@ -47,7 +47,7 @@ namespace MAT_NS_BEGIN
         {
             handle = evt_open(config);
             return handle;
-        };
+        }
 
         evt_status_t configure(const char* config)
         {

--- a/lib/include/public/CommonFields.h
+++ b/lib/include/public/CommonFields.h
@@ -118,6 +118,6 @@
     virtual void SETTER_METHOD (name) (const std::string & x)         \
     {                                                       \
         SetCommonField(placeholder, x);                     \
-    };
+    }
 
 #endif

--- a/lib/include/public/DebugEvents.hpp
+++ b/lib/include/public/DebugEvents.hpp
@@ -158,12 +158,12 @@ namespace MAT_NS_BEGIN
         size_t size;
 
         /// <summary>DebugEvent The default DebugEvent constructor.</summary>
-        DebugEvent() : seq(0), ts(0), type(EVT_UNKNOWN), param1(0), param2(0), data(NULL), size(0) {};
+        DebugEvent() : seq(0), ts(0), type(EVT_UNKNOWN), param1(0), param2(0), data(NULL), size(0) {}
 
-        DebugEvent(DebugEventType type) : seq(0), ts(0), type(type), param1(0), param2(0), data(NULL), size(0) {};
+        DebugEvent(DebugEventType type) : seq(0), ts(0), type(type), param1(0), param2(0), data(NULL), size(0) {}
 
         DebugEvent(DebugEventType type, size_t param1, size_t param2 = 0, void* data = nullptr, size_t size = 0) :
-            seq(0), ts(0), type(type), param1(param1), param2(param2), data(data), size(size) {};
+            seq(0), ts(0), type(type), param1(param1), param2(param2), data(data), size(size) {}
     };
 
     /// <summary>

--- a/lib/include/public/IHttpClient.hpp
+++ b/lib/include/public/IHttpClient.hpp
@@ -494,7 +494,7 @@ namespace MAT_NS_BEGIN
             std::ignore = state;
             std::ignore = data;
             std::ignore = size;
-        };
+        }
     };
 
     /// <summary>
@@ -542,7 +542,7 @@ namespace MAT_NS_BEGIN
         /// <param name="id">A string that contains the ID of the request to cancel.</param>
         virtual void CancelRequestAsync(std::string const& id) = 0;
 
-        virtual void CancelAllRequests() {};
+        virtual void CancelAllRequests() {}
     };
 
     /// @endcond

--- a/lib/include/public/IModule.hpp
+++ b/lib/include/public/IModule.hpp
@@ -27,13 +27,13 @@ namespace MAT_NS_BEGIN
         /// Initializes the module.
         /// Invoked as part of parent ILogManager is constructed.
         /// </summary>
-        virtual void Initialize(ILogManager*) noexcept {};
+        virtual void Initialize(ILogManager*) noexcept {}
 
         /// <summary>
         /// Tears down the module.
         /// Invoked as part of parent ILogManager's FlushAndTeardown() method.
         /// </summary>
-        virtual void Teardown() noexcept {};
+        virtual void Teardown() noexcept {}
     };
 
     /// @endcond

--- a/lib/include/public/IOfflineStorage.hpp
+++ b/lib/include/public/IOfflineStorage.hpp
@@ -335,7 +335,7 @@ namespace MAT_NS_BEGIN {
 
         virtual bool ResizeDb() = 0;
 
-        virtual void ReleaseAllRecords() {};
+        virtual void ReleaseAllRecords() {}
 
     };
 

--- a/lib/include/public/ISemanticContext.hpp
+++ b/lib/include/public/ISemanticContext.hpp
@@ -19,43 +19,43 @@ namespace MAT_NS_BEGIN
     class  MATSDK_LIBABI ISemanticContext
     {
     public:
-        virtual  ~ISemanticContext() {};
+        virtual  ~ISemanticContext() {}
 
         /// <summary>
         /// Set the application environment context information of telemetry event.
         /// </summary>
         /// <param name="appEnv">Environment from which this event originated</param>
-        DECLARE_COMMONFIELD(AppEnv, COMMONFIELDS_APP_ENV);
+        DECLARE_COMMONFIELD(AppEnv, COMMONFIELDS_APP_ENV)
 
         /// <summary>
         /// Set the application identifier context information of telemetry event.
         /// </summary>
         /// <param name="appId">Id that uniquely identifies the user-facing application from which this event originated</param>
-        DECLARE_COMMONFIELD(AppId, COMMONFIELDS_APP_ID);
+        DECLARE_COMMONFIELD(AppId, COMMONFIELDS_APP_ID)
 
         /// <summary>
         /// Set the application name context information of telemetry event.
         /// </summary>
         /// <param name="appName">Application Name</param>
-        DECLARE_COMMONFIELD(AppName, COMMONFIELDS_APP_NAME);
+        DECLARE_COMMONFIELD(AppName, COMMONFIELDS_APP_NAME)
 
         /// <summary>
         /// Set the application version context information of telemetry event.
         /// </summary>
         /// <param name="appVersion">Version of the application, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(AppVersion, COMMONFIELDS_APP_VERSION);
+        DECLARE_COMMONFIELD(AppVersion, COMMONFIELDS_APP_VERSION)
 
         /// <summary>
         /// Set the application language context information of telemetry event.
         /// </summary>
-        DECLARE_COMMONFIELD(AppLanguage, COMMONFIELDS_APP_LANGUAGE);
+        DECLARE_COMMONFIELD(AppLanguage, COMMONFIELDS_APP_LANGUAGE)
 
         /// <summary>
         /// Set the application's experiment IDs information of telemetry event.
         /// The experiment IDs information will be applied to all events unless it is overwritten by that set via SetEventExperimentIds  
         /// </summary>
         /// <param name="appVersion">list of IDs of experimentations into which the application is enlisted</param>
-        DECLARE_COMMONFIELD(AppExperimentIds, COMMONFIELDS_APP_EXPERIMENTIDS);
+        DECLARE_COMMONFIELD(AppExperimentIds, COMMONFIELDS_APP_EXPERIMENTIDS)
 
         /// <summary>
         /// Set the application version context information of telemetry event.
@@ -66,54 +66,54 @@ namespace MAT_NS_BEGIN
         {
             SetCommonField(COMMONFIELDS_APP_EXPERIMENTETAG, appExperimentETag);
             ClearExperimentIds();
-        };
+        }
 
         /// <summary>
         /// Set the application experimentation impression id information of telemetry event.
         /// </summary>
         /// <param name="appExperimentIds">List of expementation IDs which are app/platform specific</param>
-        DECLARE_COMMONFIELD(AppExperimentImpressionId, SESSION_IMPRESSION_ID);
+        DECLARE_COMMONFIELD(AppExperimentImpressionId, SESSION_IMPRESSION_ID)
 
         /// <summary>
         /// Set the experiment IDs information of the specified telemetry event.
         /// </summary>
         /// <param name="appVersion">list of IDs of experimentations into which the application is enlisted</param>
-        virtual void  SetEventExperimentIds(std::string const& /*eventName*/, std::string const& /*experimentIds*/) {};
+        virtual void  SetEventExperimentIds(std::string const& /*eventName*/, std::string const& /*experimentIds*/) {}
 
         /// <summary>
         /// Clear the experiment IDs information.
         /// </summary>
-        virtual void ClearExperimentIds() {};
+        virtual void ClearExperimentIds() {}
 
         /// <summary>
         /// Set the device identifier context information of telemetry event.
         /// </summary>
         /// <param name="deviceId">A unique device identifier, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(DeviceId, COMMONFIELDS_DEVICE_ID);
+        DECLARE_COMMONFIELD(DeviceId, COMMONFIELDS_DEVICE_ID)
 
         /// <summary>
         /// Set the device manufacturer context information of telemetry event.
         /// </summary>
         /// <param name="deviceMake">The manufacturer of the device, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(DeviceMake, COMMONFIELDS_DEVICE_MAKE);
+        DECLARE_COMMONFIELD(DeviceMake, COMMONFIELDS_DEVICE_MAKE)
 
         /// <summary>
         /// Set the device model context information of telemetry event.
         /// </summary>
         /// <param name="deviceModel">The model of the device, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(DeviceModel, COMMONFIELDS_DEVICE_MODEL);
+        DECLARE_COMMONFIELD(DeviceModel, COMMONFIELDS_DEVICE_MODEL)
 
         /// <summary>
         /// Set the device class context information of telemetry event.
         /// </summary>
         /// <param name="deviceClass">Device class.</param>
-        DECLARE_COMMONFIELD(DeviceClass, COMMONFIELDS_DEVICE_CLASS);
+        DECLARE_COMMONFIELD(DeviceClass, COMMONFIELDS_DEVICE_CLASS)
 
           /// <summary>
         /// Set the device orgId context information of telemetry event.
         /// </summary>
         /// <param name="deviceClass">Device orgId</param>
-        DECLARE_COMMONFIELD(DeviceOrgId, COMMONFIELDS_DEVICE_ORGID);
+        DECLARE_COMMONFIELD(DeviceOrgId, COMMONFIELDS_DEVICE_ORGID)
 
         /// <summary>
         /// Set the network cost context information of telemetry event.
@@ -153,7 +153,7 @@ namespace MAT_NS_BEGIN
         /// Set the network provider context information of telemetry event.
         /// </summary>
         /// <param name="networkProvider">The provider used to connect to the current network, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(NetworkProvider, COMMONFIELDS_NETWORK_PROVIDER);
+        DECLARE_COMMONFIELD(NetworkProvider, COMMONFIELDS_NETWORK_PROVIDER)
 
         /// Set the network type context information of telemetry event.
         /// </summary>
@@ -192,19 +192,19 @@ namespace MAT_NS_BEGIN
         /// Set the system name context information of telemetry event.
         /// </summary>
         /// <param name="osName">The system anme, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(OsName, COMMONFIELDS_OS_NAME);
+        DECLARE_COMMONFIELD(OsName, COMMONFIELDS_OS_NAME)
 
         /// <summary>
         /// Set the system version context information of telemetry event.
         /// </summary>
         /// <param name="osVersion">The system version, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(OsVersion, COMMONFIELDS_OS_VERSION);
+        DECLARE_COMMONFIELD(OsVersion, COMMONFIELDS_OS_VERSION)
 
         /// <summary>
         /// Set the system build number context information of telemetry event.
         /// </summary>
         /// <param name="osBuild">The system build, retrieved programmatically where possible and is app/platform specific</param>
-        DECLARE_COMMONFIELD(OsBuild, COMMONFIELDS_OS_BUILD);
+        DECLARE_COMMONFIELD(OsBuild, COMMONFIELDS_OS_BUILD)
 
         /// <summary>
         /// Set the userId context information of telemetry event.
@@ -221,58 +221,58 @@ namespace MAT_NS_BEGIN
         /// Set the user MsaId context information of telemetry event.
         /// </summary>
         /// <param name="userMsaId">Msa id that identifies a user in the application-specific user namespace</param>
-        DECLARE_COMMONFIELD(UserMsaId, COMMONFIELDS_USER_MSAID);
+        DECLARE_COMMONFIELD(UserMsaId, COMMONFIELDS_USER_MSAID)
 
         /// <summary>
         /// Set the user ANID context information of telemetry event.
         /// </summary>
         /// <param name="userANID">ANID that identifies a user in in the application-specific user namespace</param>
-        DECLARE_COMMONFIELD(UserANID, COMMONFIELDS_USER_ANID);
+        DECLARE_COMMONFIELD(UserANID, COMMONFIELDS_USER_ANID)
 
         /// <summary>
         /// Set the advertising Id context information of telemetry event.
         /// </summary>
         /// <param name="userAdvertingId">Advertising Id of a user to use in an application-specific user namespace</param>
-        DECLARE_COMMONFIELD(UserAdvertisingId, COMMONFIELDS_USER_ADVERTISINGID);
+        DECLARE_COMMONFIELD(UserAdvertisingId, COMMONFIELDS_USER_ADVERTISINGID)
 
         /// <summary>
         /// Set the user language context information of telemetry event.
         /// </summary>
         /// <param name="locale">user's language in IETF language tag format, as described in RFC 4646.</param>
-        DECLARE_COMMONFIELD(UserLanguage, COMMONFIELDS_USER_LANGUAGE);
+        DECLARE_COMMONFIELD(UserLanguage, COMMONFIELDS_USER_LANGUAGE)
 
         /// <summary>
         /// Set the user time zone context information of telemetry event.
         /// </summary>
         /// <param name="timeZone">user's time zone relative to UTC, in ISO 8601 time zone format</param>
-        DECLARE_COMMONFIELD(UserTimeZone, COMMONFIELDS_USER_TIMEZONE);
+        DECLARE_COMMONFIELD(UserTimeZone, COMMONFIELDS_USER_TIMEZONE)
 
         /// <summary>
         /// Set the Commercial Id context information of telemetry event.
         /// </summary>
         /// <param name="commercialId">CommercialId of a machine</param>
-        DECLARE_COMMONFIELD(CommercialId, COMMONFIELDS_COMMERCIAL_ID);
+        DECLARE_COMMONFIELD(CommercialId, COMMONFIELDS_COMMERCIAL_ID)
 
         /// <summary>
         /// Sets the common Part A/B field.
         /// </summary>
         /// <param name="name">Field name</param>
         /// <param name="value">Field value.</param>
-        virtual void SetCommonField(const std::string &, const EventProperty &) {};
+        virtual void SetCommonField(const std::string &, const EventProperty &) {}
 
         /// <summary>
         /// Sets the custom Part C field.
         /// </summary>
         /// <param name="name">Field name</param>
         /// <param name="value">Field value.</param>
-        virtual void SetCustomField(const std::string &, const EventProperty &) {};
+        virtual void SetCustomField(const std::string &, const EventProperty &) {}
 
         /// <summary>
         /// Sets the ticket (device ticket, user id ticket, etc.) for secure token validation.
         /// </summary>
         /// <param name="type">Ticket type</param>
         /// <param name="ticketValue">Ticket value.</param>
-        virtual void SetTicket(TicketType /*type*/, std::string const& /*ticketValue*/) {};
+        virtual void SetTicket(TicketType /*type*/, std::string const& /*ticketValue*/) {}
     };
 
 } MAT_NS_END

--- a/lib/include/public/ITaskDispatcher.hpp
+++ b/lib/include/public/ITaskDispatcher.hpp
@@ -61,7 +61,7 @@ namespace MAT_NS_BEGIN
 
         Task() :
             tid(GetNewTid())
-        {};
+        {}
 
         /// <summary>
         /// The time (in milliseconds since epoch) when this work item should be executed

--- a/lib/include/public/LogManagerProvider.hpp
+++ b/lib/include/public/LogManagerProvider.hpp
@@ -50,7 +50,7 @@ namespace MAT_NS_BEGIN
             cfg["sdkVersion"] = targetVersion; // TODO: SDK internally should convert this to semver
             cfg[CFG_MAP_FACTORY_CONFIG][CFG_STR_FACTORY_HOST] = (wantController) ? id : "*";
             return Get(cfg, status);
-        };
+        }
 
 #if 0   /* This method must be deprecated. Customers to use this method instead:
 

--- a/lib/include/public/NullObjects.hpp
+++ b/lib/include/public/NullObjects.hpp
@@ -15,17 +15,17 @@ namespace MAT_NS_BEGIN
     {
     public:
 
-        virtual void SetNetworkCost(NetworkCost /*networkCost*/) override {};
+        virtual void SetNetworkCost(NetworkCost /*networkCost*/) override {}
 
-        virtual void SetNetworkType(NetworkType /*networkType*/) override {};
+        virtual void SetNetworkType(NetworkType /*networkType*/) override {}
 
-        virtual void SetUserId(const std::string & /*userId*/, PiiKind /*piiKind*/ = PiiKind_Identity) override { };
+        virtual void SetUserId(const std::string & /*userId*/, PiiKind /*piiKind*/ = PiiKind_Identity) override { }
 
-        virtual void SetTicket(TicketType, const std::string &) override {};
+        virtual void SetTicket(TicketType, const std::string &) override {}
 
-        virtual void SetCommonField(const std::string &, const EventProperty &) override {};
+        virtual void SetCommonField(const std::string &, const EventProperty &) override {}
 
-        virtual void SetCustomField(const std::string &, const EventProperty &) override {};
+        virtual void SetCustomField(const std::string &, const EventProperty &) override {}
     };
 
     class NullEventFilterCollection : public IEventFilterCollection
@@ -34,8 +34,8 @@ namespace MAT_NS_BEGIN
         virtual void UnregisterEventFilter(const char*) override { }
         virtual void UnregisterAllFilters() noexcept override { }
         virtual bool CanEventPropertiesBeSent(const EventProperties&) const noexcept override { return true; }
-        virtual size_t Size() const noexcept override { return 0; };
-        virtual bool Empty() const noexcept override { return false; };
+        virtual size_t Size() const noexcept override { return 0; }
+        virtual bool Empty() const noexcept override { return false; }
     };
 
     class NullLogger : public ILogger
@@ -50,75 +50,75 @@ namespace MAT_NS_BEGIN
             return &nullContext;
         }
 
-        virtual void SetContext(const std::string & /*name*/, const char /*value*/[], PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, const char /*value*/[], PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, const std::string & /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, const std::string & /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, double /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, double /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, int8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, int16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, int32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, int64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, int64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, uint8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint8_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, uint16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint16_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, uint32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint32_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, uint64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, uint64_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, bool /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, bool /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, time_ticks_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, time_ticks_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, GUID_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {};
+        virtual void SetContext(const std::string & /*name*/, GUID_t /*value*/, PiiKind /*piiKind*/ = PiiKind_None) override {}
 
-        virtual void SetContext(const std::string & /*name*/, const EventProperty & /*prop*/) override {};
+        virtual void SetContext(const std::string & /*name*/, const EventProperty & /*prop*/) override {}
 
-        virtual void LogAppLifecycle(AppLifecycleState /*state*/, EventProperties const & /*properties*/) override {};
+        virtual void LogAppLifecycle(AppLifecycleState /*state*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogSession(SessionState /*state*/, const EventProperties & /*properties*/) override {};
+        virtual void LogSession(SessionState /*state*/, const EventProperties & /*properties*/) override {}
 
-        virtual void LogEvent(std::string const & /*name*/) override {};
+        virtual void LogEvent(std::string const & /*name*/) override {}
 
-        virtual void LogEvent(EventProperties const & /*properties*/) override {};
+        virtual void LogEvent(EventProperties const & /*properties*/) override {}
 
-        virtual void LogFailure(std::string const & /*signature*/, std::string const & /*detail*/, EventProperties const & /*properties*/) override {};
+        virtual void LogFailure(std::string const & /*signature*/, std::string const & /*detail*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogFailure(std::string const & /*signature*/, std::string const & /*detail*/, std::string const & /*category*/, std::string const & /*id*/, EventProperties const & /*properties*/) override {};
+        virtual void LogFailure(std::string const & /*signature*/, std::string const & /*detail*/, std::string const & /*category*/, std::string const & /*id*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogPageView(std::string const & /*id*/, std::string const & /*pageName*/, EventProperties const & /*properties*/) override {};
+        virtual void LogPageView(std::string const & /*id*/, std::string const & /*pageName*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogPageView(std::string const & /*id*/, std::string const & /*pageName*/, std::string const & /*category*/, std::string const & /*uri*/, std::string const & /*referrerUri*/, EventProperties const & /*properties*/) override {};
+        virtual void LogPageView(std::string const & /*id*/, std::string const & /*pageName*/, std::string const & /*category*/, std::string const & /*uri*/, std::string const & /*referrerUri*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogPageAction(std::string const & /*pageViewId*/, ActionType /*actionType*/, EventProperties const & /*properties*/) override {};
+        virtual void LogPageAction(std::string const & /*pageViewId*/, ActionType /*actionType*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogPageAction(PageActionData const & /*pageActionData*/, EventProperties const & /*properties*/) override {};
+        virtual void LogPageAction(PageActionData const & /*pageActionData*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogSampledMetric(std::string const & /*name*/, double /*value*/, std::string const & /*units*/, EventProperties const & /*properties*/) override {};
+        virtual void LogSampledMetric(std::string const & /*name*/, double /*value*/, std::string const & /*units*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogSampledMetric(std::string const & /*name*/, double /*value*/, std::string const & /*units*/, std::string const & /*instanceName*/, std::string const & /*objectClass*/, std::string const & /*objectId*/, EventProperties const & /*properties*/) override {};
+        virtual void LogSampledMetric(std::string const & /*name*/, double /*value*/, std::string const & /*units*/, std::string const & /*instanceName*/, std::string const & /*objectClass*/, std::string const & /*objectId*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogAggregatedMetric(std::string const & /*name*/, long /*duration*/, long /*count*/, EventProperties const & /*properties*/) override {};
+        virtual void LogAggregatedMetric(std::string const & /*name*/, long /*duration*/, long /*count*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogAggregatedMetric(AggregatedMetricData const & /*metricData*/, EventProperties const & /*properties*/) override {};
+        virtual void LogAggregatedMetric(AggregatedMetricData const & /*metricData*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogTrace(TraceLevel /*level*/, std::string const & /*message*/, EventProperties const & /*properties*/) override {};
+        virtual void LogTrace(TraceLevel /*level*/, std::string const & /*message*/, EventProperties const & /*properties*/) override {}
 
-        virtual void LogUserState(UserState /*state*/, long /*timeToLiveInMillis*/, EventProperties const & /*properties*/) override {};
+        virtual void LogUserState(UserState /*state*/, long /*timeToLiveInMillis*/, EventProperties const & /*properties*/) override {}
 
         virtual IEventFilterCollection& GetEventFilters() noexcept override { return m_filters; }
 
         virtual IEventFilterCollection const& GetEventFilters() const noexcept override { return m_filters; }
 
-        virtual void SetParentContext(ISemanticContext * /*context*/) override {};
+        virtual void SetParentContext(ISemanticContext * /*context*/) override {}
 
-        virtual void SetLevel(uint8_t /*level*/) override {};
+        virtual void SetLevel(uint8_t /*level*/) override {}
 
     private:
         NullEventFilterCollection m_filters;
@@ -127,13 +127,13 @@ namespace MAT_NS_BEGIN
     class NullDataViewerCollection : public IDataViewerCollection
     {
     public:
-        virtual void DispatchDataViewerEvent(const std::vector<uint8_t>&) const noexcept override {};
+        virtual void DispatchDataViewerEvent(const std::vector<uint8_t>&) const noexcept override {}
 
-        virtual void RegisterViewer(const std::shared_ptr<IDataViewer>&) override {};
+        virtual void RegisterViewer(const std::shared_ptr<IDataViewer>&) override {}
 
-        virtual void UnregisterViewer(const char*) override {};
+        virtual void UnregisterViewer(const char*) override {}
 
-        virtual void UnregisterAllViewers() override {};
+        virtual void UnregisterAllViewers() override {}
 
         virtual bool IsViewerEnabled(const char*) const override
         {
@@ -150,14 +150,14 @@ namespace MAT_NS_BEGIN
             return false;
         }
 
-        virtual ~NullDataViewerCollection() {};
+        virtual ~NullDataViewerCollection() {}
     };
 
     class NullLogManager : public ILogManager
     {
     public:
 
-        NullLogManager() { };
+        NullLogManager() { }
 
         // Inherited via ILogManager
         virtual bool DispatchEvent(DebugEvent /*evt*/) override
@@ -165,9 +165,9 @@ namespace MAT_NS_BEGIN
             return false;
         }
 
-        virtual void Configure() override {};
+        virtual void Configure() override {}
 
-        virtual void FlushAndTeardown() override {};
+        virtual void FlushAndTeardown() override {}
 
         virtual status_t Flush() override
         {
@@ -311,9 +311,9 @@ namespace MAT_NS_BEGIN
             return &nullLogger;
         }
 
-        virtual void AddEventListener(DebugEventType /*type*/, DebugEventListener & /*listener*/) override {};
+        virtual void AddEventListener(DebugEventType /*type*/, DebugEventListener & /*listener*/) override {}
 
-        virtual void RemoveEventListener(DebugEventType /*type*/, DebugEventListener & /*listener*/) override {};
+        virtual void RemoveEventListener(DebugEventType /*type*/, DebugEventListener & /*listener*/) override {}
 
         virtual bool AttachEventSource(DebugEventSource & /*other*/) override
         {
@@ -331,7 +331,7 @@ namespace MAT_NS_BEGIN
             return nullptr;
         }
 
-        virtual void ResetLogSessionData() override {};
+        virtual void ResetLogSessionData() override {}
 
         virtual ILogController* GetLogController() override
         {
@@ -353,9 +353,9 @@ namespace MAT_NS_BEGIN
             return m_filters;
         }
 
-        virtual void SetLevelFilter(uint8_t /*defaultLevel*/, uint8_t /*levelMin*/, uint8_t /*levelMax*/) override {};
+        virtual void SetLevelFilter(uint8_t /*defaultLevel*/, uint8_t /*levelMin*/, uint8_t /*levelMax*/) override {}
 
-        virtual void SetLevelFilter(uint8_t /*defaultLevel*/, const std::set<uint8_t>& /*allowedLevels*/) override {};
+        virtual void SetLevelFilter(uint8_t /*defaultLevel*/, const std::set<uint8_t>& /*allowedLevels*/) override {}
 
         virtual const IDataViewerCollection& GetDataViewerCollection() const noexcept override
         {

--- a/lib/include/public/PayloadDecoder.hpp
+++ b/lib/include/public/PayloadDecoder.hpp
@@ -20,7 +20,7 @@
 namespace CsProtocol
 {
     struct Record;
-};
+}
 
 namespace MAT_NS_BEGIN {
 
@@ -47,7 +47,7 @@ namespace MAT_NS_BEGIN {
         /// </returns>
         bool DecodeRequest(const std::vector<uint8_t>& in, std::string& out, bool compressed = true);
 
-    };
+    }
 
 } MAT_NS_END
 

--- a/lib/include/public/VariantType.hpp
+++ b/lib/include/public/VariantType.hpp
@@ -13,9 +13,9 @@
 
 // Constructor and getter for Variant type
 #define VARIANT_PROP(basetype, field, typeenum)                 \
-    Variant(basetype v) : field(v), type(typeenum) {} ;         \
-    operator basetype() { return (basetype)field; };            \
-    Variant& operator=(basetype v) { field = v; type = typeenum; return *this; };
+    Variant(basetype v) : field(v), type(typeenum) {}          \
+    operator basetype() { return (basetype)field; }            \
+    Variant& operator=(basetype v) { field = v; type = typeenum; return *this; }
 
 // Avoid conflict with Mac platforms where <ConditionalMacros.h> #defines TYPE_BOOL.
 //
@@ -52,7 +52,7 @@ class Variant
 public:
 
     // Thread-safe variants
-    VARIANT_LOCK(lock_object);
+    VARIANT_LOCK(lock_object)
 
     enum Type
     {
@@ -75,7 +75,7 @@ public:
         return nullVariant;
     }
 
-    Variant() : iV(0), type(TYPE_NULL) {};
+    Variant() : iV(0), type(TYPE_NULL) {}
 
     Variant(const Variant& other) noexcept
     {
@@ -88,22 +88,22 @@ public:
     }
 
     // All integer types
-    VARIANT_PROP(int8_t, iV, TYPE_INT);
-    VARIANT_PROP(int16_t, iV, TYPE_INT);
-    VARIANT_PROP(int32_t, iV, TYPE_INT);
-    VARIANT_PROP(int64_t, iV, TYPE_INT);
-    VARIANT_PROP(uint8_t, iV, TYPE_INT);
-    VARIANT_PROP(uint16_t, iV, TYPE_INT);
-    VARIANT_PROP(uint32_t, iV, TYPE_INT);
-    VARIANT_PROP(uint64_t, iV, TYPE_INT);
+    VARIANT_PROP(int8_t, iV, TYPE_INT)
+    VARIANT_PROP(int16_t, iV, TYPE_INT)
+    VARIANT_PROP(int32_t, iV, TYPE_INT)
+    VARIANT_PROP(int64_t, iV, TYPE_INT)
+    VARIANT_PROP(uint8_t, iV, TYPE_INT)
+    VARIANT_PROP(uint16_t, iV, TYPE_INT)
+    VARIANT_PROP(uint32_t, iV, TYPE_INT)
+    VARIANT_PROP(uint64_t, iV, TYPE_INT)
 
     // All floating point types
-    VARIANT_PROP(float, dV, TYPE_DOUBLE);
-    VARIANT_PROP(double, dV, TYPE_DOUBLE);
+    VARIANT_PROP(float, dV, TYPE_DOUBLE)
+    VARIANT_PROP(double, dV, TYPE_DOUBLE)
 
-    VARIANT_PROP(void*, pV, TYPE_PTR);
+    VARIANT_PROP(void*, pV, TYPE_PTR)
 
-    Variant(const char* v) : sV(v), type(TYPE_STRING) {};
+    Variant(const char* v) : sV(v), type(TYPE_STRING) {}
 
     operator const char*()
     {
@@ -114,7 +114,7 @@ public:
         if (type == TYPE_NULL)
             return "";
         return nullptr;
-    };
+    }
 
     Variant& operator=(std::string value)
     {
@@ -242,7 +242,7 @@ public:
     }
 
     // Boolean
-    VARIANT_PROP(bool, bV, TYPE_BOOL);
+    VARIANT_PROP(bool, bV, TYPE_BOOL)
 
     // Object (or map)
     Variant(VariantMap& m) :
@@ -252,7 +252,7 @@ public:
         {
             mV[kv.first] = kv.second;
         }
-    };
+    }
 
     Variant(VariantMap && m) :
         type(TYPE_OBJ)
@@ -273,11 +273,11 @@ public:
     // Array (or vector)
     Variant(VariantArray& a) :
         aV(a),
-        type(TYPE_ARR) {};
+        type(TYPE_ARR) {}
 
     Variant(VariantArray && a) :
         aV(std::move(a)),
-        type(TYPE_ARR) {};
+        type(TYPE_ARR) {}
 
     // Destroy all elements
     virtual ~Variant() {
@@ -320,13 +320,13 @@ public:
     {
         VARIANT_LOCKGUARD(lock_object);
         return mV;
-    };
+    }
 
     operator VariantMap&() const
     {
         VARIANT_LOCKGUARD(lock_object);
         return mV;
-    };
+    }
 
 
     /**
@@ -336,7 +336,7 @@ public:
     {
         VARIANT_LOCKGUARD(lock_object);
         return aV;
-    };
+    }
 
     /**
      *
@@ -361,7 +361,7 @@ public:
 
         // Otherwise it's an invalid op - return const NULL
         return ConstNull();
-    };
+    }
 
     /**
      *
@@ -376,7 +376,7 @@ public:
         // Accessing index of something that is not an array returns a null const variant.
         // We may consider adding an assert here for debug builds.
         return ConstNull();      // return const NULL Variant
-    };
+    }
 
     /**
      *

--- a/lib/include/public/mat.h
+++ b/lib/include/public/mat.h
@@ -293,7 +293,7 @@ extern "C" {
     {
         pv.as_double = val;
         return pv;
-    };
+    }
 #define _DBL(key, val)           { key, TYPE_DOUBLE,    _DBL2({ NULL }, val) }
 #define PII_DBL(key, val, kind)  { key, TYPE_DOUBLE,    _DBL2({ NULL }, val), kind }
 

--- a/lib/offline/MemoryStorage.cpp
+++ b/lib/offline/MemoryStorage.cpp
@@ -9,7 +9,7 @@
 
 namespace MAT_NS_BEGIN {
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(MemoryStorage, "EventsSDK.MemoryStorage", "Events telemetry client - MemoryStorage class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(MemoryStorage, "EventsSDK.MemoryStorage", "Events telemetry client - MemoryStorage class")
 
     MemoryStorage::MemoryStorage(ILogManager & logManager, IRuntimeConfig & runtimeConfig) :
         m_observer(nullptr),

--- a/lib/offline/OfflineStorageHandler.cpp
+++ b/lib/offline/OfflineStorageHandler.cpp
@@ -16,7 +16,7 @@
 namespace MAT_NS_BEGIN {
 
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(OfflineStorageHandler, "EventsSDK.StorageHandler", "Events telemetry client - OfflineStorageHandler class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(OfflineStorageHandler, "EventsSDK.StorageHandler", "Events telemetry client - OfflineStorageHandler class")
 
     OfflineStorageHandler::OfflineStorageHandler(ILogManager& logManager, IRuntimeConfig& runtimeConfig, ITaskDispatcher& taskDispatcher) :
         m_observer(nullptr),

--- a/lib/offline/OfflineStorage_SQLite.cpp
+++ b/lib/offline/OfflineStorage_SQLite.cpp
@@ -43,7 +43,7 @@ namespace MAT_NS_BEGIN {
             {
                 locked = m_db->trylock();
             }
-        };
+        }
 
         ~DbTransaction()
         {
@@ -54,7 +54,7 @@ namespace MAT_NS_BEGIN {
         }
     };
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(OfflineStorage_SQLite, "EventsSDK.Storage", "Events telemetry client - OfflineStorage_SQLite class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(OfflineStorage_SQLite, "EventsSDK.Storage", "Events telemetry client - OfflineStorage_SQLite class")
 
     static int const CURRENT_SCHEMA_VERSION = 1;
 #define TABLE_NAME_EVENTS   "events"

--- a/lib/offline/OfflineStorage_SQLite.hpp
+++ b/lib/offline/OfflineStorage_SQLite.hpp
@@ -31,7 +31,7 @@ namespace MAT_NS_BEGIN {
         virtual ~OfflineStorage_SQLite() override;
         virtual void Initialize(IOfflineStorageObserver& observer) override;
         virtual void Shutdown() override;
-        virtual void Flush() override {};
+        virtual void Flush() override {}
         virtual void Execute(std::string command);
         virtual bool StoreRecord(StorageRecord const& record) override;
         virtual size_t StoreRecords(std::vector<StorageRecord> & records) override;

--- a/lib/offline/SQLiteWrapper.hpp
+++ b/lib/offline/SQLiteWrapper.hpp
@@ -504,7 +504,7 @@ namespace MAT_NS_BEGIN {
         MATSDK_LOG_DECL_COMPONENT_CLASS();
     };
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(SqliteDB, "EventsSDK.SQLiteDB", "Events telemetry client - SqliteDB class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(SqliteDB, "EventsSDK.SQLiteDB", "Events telemetry client - SqliteDB class")
 
     //---
 
@@ -789,13 +789,13 @@ namespace MAT_NS_BEGIN {
         bool          m_error;
 
     public:
-        sqlite3_stmt * handle() { return m_stmt; };
+        sqlite3_stmt * handle() { return m_stmt; }
 
     private:
         MATSDK_LOG_DECL_COMPONENT_CLASS();
     };
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(SqliteStatement, "EventsSDK.SQLiteStatement", "Events telemetry client - Sqlite statement class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(SqliteStatement, "EventsSDK.SQLiteStatement", "Events telemetry client - Sqlite statement class")
 
 
 } MAT_NS_END

--- a/lib/pal/NetworkInformationImpl.hpp
+++ b/lib/pal/NetworkInformationImpl.hpp
@@ -28,7 +28,7 @@ namespace PAL_NS_BEGIN {
         virtual void UnRegisterInformationChangedCallback(int callbackToken) { --m_registeredCount; m_info_helper.UnRegisterInformationChangedCallback(callbackToken); }
 
         // INetworkInformation API
-        virtual std::string const& GetNetworkProvider() { return m_provider; };
+        virtual std::string const& GetNetworkProvider() { return m_provider; }
         virtual NetworkType GetNetworkType() { return m_type; }
         virtual NetworkCost GetNetworkCost() { return m_cost; }
 

--- a/lib/pal/SystemInformationImpl.hpp
+++ b/lib/pal/SystemInformationImpl.hpp
@@ -27,20 +27,20 @@ namespace PAL_NS_BEGIN {
         virtual void UnRegisterInformationChangedCallback(int callbackToken) override;
 
         // ISystemInformation API
-        virtual std::string const& GetAppId() const override { return m_app_id; };
+        virtual std::string const& GetAppId() const override { return m_app_id; }
         virtual std::string const& GetAppVersion() const override { return m_app_version; }
         virtual std::string const& GetAppLanguage() const override { return m_app_language; }
 
-        virtual std::string const& GetOsFullVersion() const override { return m_os_full_version; };
-        virtual std::string const& GetOsMajorVersion() const override { return m_os_major_version; };
-        virtual std::string const& GetOsName() const override { return m_os_name; };
+        virtual std::string const& GetOsFullVersion() const override { return m_os_full_version; }
+        virtual std::string const& GetOsMajorVersion() const override { return m_os_major_version; }
+        virtual std::string const& GetOsName() const override { return m_os_name; }
 
-        virtual std::string const& GetUserLanguage() const override { return m_user_language; };
-        virtual std::string const& GetUserTimeZone() const override { return m_user_timezone; };
-        virtual std::string const& GetUserAdvertisingId() const override { return m_user_advertising_id; };
+        virtual std::string const& GetUserLanguage() const override { return m_user_language; }
+        virtual std::string const& GetUserTimeZone() const override { return m_user_timezone; }
+        virtual std::string const& GetUserAdvertisingId() const override { return m_user_advertising_id; }
 
-        virtual std::string const& GetDeviceClass() const override { return m_device_class; };
-        virtual std::string const& GetCommercialId() const override { return m_commercial_id; };
+        virtual std::string const& GetDeviceClass() const override { return m_device_class; }
+        virtual std::string const& GetCommercialId() const override { return m_commercial_id; }
 
         SystemInformationImpl(MAT::IRuntimeConfig& configuration);
         ~SystemInformationImpl() override;

--- a/lib/pal/TaskDispatcher.hpp
+++ b/lib/pal/TaskDispatcher.hpp
@@ -69,12 +69,12 @@ namespace PAL_NS_BEGIN {
 
         DeferredCallbackHandle(MAT::Task* task, MAT::ITaskDispatcher* taskDispatcher) :
             m_task(task),
-            m_taskDispatcher(taskDispatcher) { };
-        DeferredCallbackHandle() {};
+            m_taskDispatcher(taskDispatcher) { }
+        DeferredCallbackHandle() {}
         DeferredCallbackHandle(DeferredCallbackHandle&& h)
         {
             *this = std::move(h);
-        };
+        }
 
         DeferredCallbackHandle& operator=(DeferredCallbackHandle&& other)
         {

--- a/lib/pal/desktop/WindowsEnvironmentInfo.hpp
+++ b/lib/pal/desktop/WindowsEnvironmentInfo.hpp
@@ -34,7 +34,7 @@ namespace MAT_NS_BEGIN {
             default:
                 return OsArchitectureType_Unknown;
             }
-        };
+        }
 
         static std::string GetTimeZone()
         {
@@ -49,7 +49,7 @@ namespace MAT_NS_BEGIN {
                 // Need to handle the case when API return TIME_ZONE_ID_UNKNOWN. Otherwise we may be reporting invalid timeZone.Bias
                 return TimeZoneBiasToISO8601(timeZone.Bias + timeZone.StandardBias);
             }
-        };
+        }
     protected:
         // Convert a bias in minutes to the ISO 8601 time zone representations.
         // ISO 8601 examples: +01:30, -08

--- a/lib/stats/MetaStats.cpp
+++ b/lib/stats/MetaStats.cpp
@@ -627,7 +627,7 @@ namespace MAT_NS_BEGIN {
         m_telemetryStats.offlineStorageStats.lastFailureReason = reason;
     }
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(RecordStats, "EventsSDK.RecordStats", "RecordStats");
+    MATSDK_LOG_INST_COMPONENT_CLASS(RecordStats, "EventsSDK.RecordStats", "RecordStats")
 
 } MAT_NS_END
 

--- a/lib/system/EventProperties.cpp
+++ b/lib/system/EventProperties.cpp
@@ -126,7 +126,7 @@ namespace MAT_NS_BEGIN {
         }
 
         return (*this);
-    };
+    }
 
     /// <summary>
     /// Set the Epoch unix timestamp in milliseconds of the event. 

--- a/lib/system/EventProperty.cpp
+++ b/lib/system/EventProperty.cpp
@@ -30,12 +30,12 @@ namespace MAT_NS_BEGIN {
     /// <summary>
     /// Default constructor for an empty object
     /// </summary>
-    time_ticks_t::time_ticks_t() : ticks(0) {};
+    time_ticks_t::time_ticks_t() : ticks(0) {}
 
     /// <summary>
     /// Convert number of .NET ticks to time_ticks_t structure
     /// </summary>
-    time_ticks_t::time_ticks_t(uint64_t raw) : ticks(raw) {};
+    time_ticks_t::time_ticks_t(uint64_t raw) : ticks(raw) {}
 
     /// <summary>
     /// time_t time must contain timestamp in UTC time
@@ -82,7 +82,7 @@ namespace MAT_NS_BEGIN {
         {
             Data4[i] = 0;
         }
-    };
+    }
 
     /// <summary>
     /// GUID_t constructor that accepts string
@@ -735,7 +735,7 @@ namespace MAT_NS_BEGIN {
         as_guid = {};
         as_string = new char[1];
         as_string[0] = 0;
-    };
+    }
 
     /// <summary>
     /// EventProperty constructor for string value
@@ -759,7 +759,7 @@ namespace MAT_NS_BEGIN {
             memcpy((void*)as_string, (void*)value, len);
             as_string[len] = 0;
         }
-    };
+    }
 
     /// <summary>
     /// EventProperty constructor for string value
@@ -776,54 +776,54 @@ namespace MAT_NS_BEGIN {
         memcpy((void*)as_string, (void*)value.c_str(), len);
         as_string[len] = 0;
 
-    };
+    }
 
     /// <summary>
     /// EventProperty constructor for int64 value
     /// </summary>
     /// <param name="value">int64_t value</param>
     /// <param name="piiKind">Pii kind</param>
-    EventProperty::EventProperty(int64_t       value, PiiKind piiKind, DataCategory category) : type(TYPE_INT64), piiKind(piiKind), dataCategory(category), as_int64(value) {};
+    EventProperty::EventProperty(int64_t       value, PiiKind piiKind, DataCategory category) : type(TYPE_INT64), piiKind(piiKind), dataCategory(category), as_int64(value) {}
 
     /// <summary>
     /// EventProperty constructor for double value
     /// </summary>
     /// <param name="value">double value</param>
     /// <param name="piiKind">Pii kind</param>
-    EventProperty::EventProperty(double        value, PiiKind piiKind, DataCategory category) : type(TYPE_DOUBLE), piiKind(piiKind), dataCategory(category), as_double(value) {};
+    EventProperty::EventProperty(double        value, PiiKind piiKind, DataCategory category) : type(TYPE_DOUBLE), piiKind(piiKind), dataCategory(category), as_double(value) {}
 
     /// <summary>
     /// EventProperty constructor for time in .NET ticks
     /// </summary>
     /// <param name="value">time_ticks_t value - time in .NET ticks</param>
     /// <param name="piiKind">Pii kind</param>
-    EventProperty::EventProperty(time_ticks_t  value, PiiKind piiKind, DataCategory category) : type(TYPE_TIME), piiKind(piiKind), dataCategory(category), as_time_ticks(value) {};
+    EventProperty::EventProperty(time_ticks_t  value, PiiKind piiKind, DataCategory category) : type(TYPE_TIME), piiKind(piiKind), dataCategory(category), as_time_ticks(value) {}
 
     /// <summary>
     /// EventProperty constructor for boolean value
     /// </summary>
     /// <param name="value">boolean value</param>
     /// <param name="piiKind">Pii kind</param>
-    EventProperty::EventProperty(bool          value, PiiKind piiKind, DataCategory category) : type(TYPE_BOOLEAN), piiKind(piiKind), dataCategory(category), as_bool(value) {};
+    EventProperty::EventProperty(bool          value, PiiKind piiKind, DataCategory category) : type(TYPE_BOOLEAN), piiKind(piiKind), dataCategory(category), as_bool(value) {}
 
     /// <summary>
     /// EventProperty constructor for GUID
     /// </summary>
     /// <param name="value">GUID_t value</param>
     /// <param name="piiKind">Pii kind</param>
-    EventProperty::EventProperty(GUID_t        value, PiiKind piiKind, DataCategory category) : type(TYPE_GUID), piiKind(piiKind), dataCategory(category), as_guid(value) {};
+    EventProperty::EventProperty(GUID_t        value, PiiKind piiKind, DataCategory category) : type(TYPE_GUID), piiKind(piiKind), dataCategory(category), as_guid(value) {}
 
     // All other integer types get converted to int64_t
 #ifndef LONG_IS_INT64_T
-    EventProperty::EventProperty(long     value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
+    EventProperty::EventProperty(long     value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
 #endif
-    EventProperty::EventProperty(int8_t   value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
-    EventProperty::EventProperty(int16_t  value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
-    EventProperty::EventProperty(int32_t  value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
-    EventProperty::EventProperty(uint8_t  value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
-    EventProperty::EventProperty(uint16_t value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
-    EventProperty::EventProperty(uint32_t value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
-    EventProperty::EventProperty(uint64_t value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {};
+    EventProperty::EventProperty(int8_t   value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
+    EventProperty::EventProperty(int16_t  value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
+    EventProperty::EventProperty(int32_t  value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
+    EventProperty::EventProperty(uint8_t  value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
+    EventProperty::EventProperty(uint16_t value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
+    EventProperty::EventProperty(uint32_t value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
+    EventProperty::EventProperty(uint64_t value, PiiKind piiKind, DataCategory category) : EventProperty((int64_t)value, piiKind, category) {}
 
     /// <summary>Returns true whether the type is string AND the value is empty (i.e. whether its length is 0).</summary>
     bool EventProperty::empty()

--- a/lib/system/ITelemetrySystem.hpp
+++ b/lib/system/ITelemetrySystem.hpp
@@ -24,7 +24,7 @@ namespace MAT_NS_BEGIN {
     class ITelemetrySystem : public DebugEventDispatcher
     {
     public:
-        virtual ~ITelemetrySystem() {};
+        virtual ~ITelemetrySystem() {}
 
         // Transmission control
         virtual void start() = 0;

--- a/lib/system/TelemetrySystem.hpp
+++ b/lib/system/TelemetrySystem.hpp
@@ -34,7 +34,7 @@ namespace MAT_NS_BEGIN {
     class NullCompression
     {
     public:
-          NullCompression(IRuntimeConfig & ) {};
+          NullCompression(IRuntimeConfig & ) {}
     };
 
     class TelemetrySystem : public TelemetrySystemBase

--- a/lib/system/TelemetrySystemBase.hpp
+++ b/lib/system/TelemetrySystemBase.hpp
@@ -41,7 +41,7 @@ namespace MAT_NS_BEGIN {
             onPause  = []() { return true; };
             onResume = []() { return true; };
             onCleanup  = []() { return true; };
-        };
+        }
         
         /// <summary>
         /// Starts this instance.
@@ -53,7 +53,7 @@ namespace MAT_NS_BEGIN {
                 onStart();
                 m_isPaused = false;
             }
-        };
+        }
         
         /// <summary>
         /// Stops this instance.
@@ -65,7 +65,7 @@ namespace MAT_NS_BEGIN {
                 onStop();
             }
         
-        };
+        }
         
         /// <summary>
         /// Uploads pending events.
@@ -73,7 +73,7 @@ namespace MAT_NS_BEGIN {
         virtual bool upload() override
         {
             return false;
-        };
+        }
         
         /// <summary>
         /// Pauses event upload.
@@ -87,7 +87,7 @@ namespace MAT_NS_BEGIN {
                     onPause();
                 }
             }
-        };
+        }
         
         /// <summary>
         /// Resumes event upload.
@@ -101,7 +101,7 @@ namespace MAT_NS_BEGIN {
                     onResume();
                 }
             }
-        };
+        }
 
         /// <summary>
         /// Cleanups pending events upload
@@ -112,27 +112,27 @@ namespace MAT_NS_BEGIN {
             {
                 onCleanup();       
             }
-        };
+        }
 
         // TODO: [MG] - consider for removal
         virtual void handleFlushTaskDispatcher() override
         {
 
-        };
+        }
 
         virtual void signalDone() override
         {
             m_done.post();
-        };
+        }
 
         virtual void handleIncomingEventPrepared(IncomingEventContextPtr const&) override
         {
-        };
+        }
 
         virtual void preparedIncomingEventAsync(IncomingEventContextPtr const& event) override
         {
             preparedIncomingEvent(event);
-        };
+        }
 
         void sendEvent(IncomingEventContextPtr const& event) override
         {

--- a/lib/tpm/TransmissionPolicyManager.cpp
+++ b/lib/tpm/TransmissionPolicyManager.cpp
@@ -41,7 +41,7 @@ namespace MAT_NS_BEGIN {
         return (a > b) ? (a - b) : (b - a);
     }
 
-    MATSDK_LOG_INST_COMPONENT_CLASS(TransmissionPolicyManager, "EventsSDK.TPM", "Events telemetry client - TransmissionPolicyManager class");
+    MATSDK_LOG_INST_COMPONENT_CLASS(TransmissionPolicyManager, "EventsSDK.TPM", "Events telemetry client - TransmissionPolicyManager class")
 
     TransmissionPolicyManager::TransmissionPolicyManager(ITelemetrySystem& system, ITaskDispatcher& taskDispatcher, IBandwidthController* bandwidthController) :
         m_system(system),

--- a/lib/tpm/TransmitProfiles.cpp
+++ b/lib/tpm/TransmitProfiles.cpp
@@ -92,7 +92,7 @@ static void initTransmitProfileFields()
     transmitProfilePowerState()["unknown"] = (PowerSource_Unknown);
     transmitProfilePowerState()["battery"] = (PowerSource_Battery);
     transmitProfilePowerState()["charging"] = (PowerSource_Charging);
-};
+}
 #endif
 
 #define LOCK_PROFILES       std::lock_guard<std::recursive_mutex> lock(profiles_mtx())
@@ -142,7 +142,7 @@ namespace MAT_NS_BEGIN {
     std::string& TransmitProfiles::getProfile() {
         LOCK_PROFILES;
         return currProfileName();
-    };
+    }
 
     /// <summary>
     /// Get current device network and power state
@@ -152,7 +152,7 @@ namespace MAT_NS_BEGIN {
         LOCK_PROFILES;
         netCost = currNetCost;
         powState = currPowState;
-    };
+    }
 
     /// <summary>
     /// Print transmit profiles to debug log

--- a/lib/utils/Utils.cpp
+++ b/lib/utils/Utils.cpp
@@ -35,7 +35,7 @@
 #include <codecvt>
 
 namespace MAT_NS_BEGIN {
-    MATSDK_LOG_INST_COMPONENT_NS("MATSDK", "MS App Telemetry client");
+    MATSDK_LOG_INST_COMPONENT_NS("MATSDK", "MS App Telemetry client")
 } MAT_NS_END
 
 namespace MAT_NS_BEGIN {


### PR DESCRIPTION
Cleanup codebase of warnings triggered by clang -Wextra-semi.