### PR TITLE
Fix CodeQL violations of type 'cpp/path-injection in lib/pal

### DIFF
--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -126,7 +126,7 @@ namespace PAL_NS_BEGIN {
 
             if (!pathExists || containsParentDirectory)
             {
-                std::cerr << "Invalid trace folder path." << std::endl;
+                throw std::runtime_error("Invalid trace folder path.");
                 return false;
             }
 

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -126,7 +126,7 @@ namespace PAL_NS_BEGIN {
 
             if (!pathExists || containsParentDirectory)
             {
-                assert(false && "Invalid trace folder path.");
+                std::cerr << "Invalid trace folder path." << std::endl;
                 return false;
             }
 

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -126,7 +126,7 @@ namespace PAL_NS_BEGIN {
 
             if (!pathExists || containsParentDirectory)
             {
-                throw std::runtime_error("Invalid trace folder path.");
+                return false;
             }
 
             debugLogMutex.lock();

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -127,7 +127,6 @@ namespace PAL_NS_BEGIN {
             if (!pathExists || containsParentDirectory)
             {
                 throw std::runtime_error("Invalid trace folder path.");
-                return false;
             }
 
             debugLogMutex.lock();

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -47,6 +47,7 @@
 #include <Objbase.h>
 #pragma comment(lib, "Ole32.Lib")   /* CoCreateGuid */
 #include <oacr.h>
+#include <windows.h>
 #endif
 
 #ifdef ANDROID
@@ -113,8 +114,28 @@ namespace PAL_NS_BEGIN {
                 return result;
             }
 
+            // Check if the path exists
+#if defined(_WIN32) || defined(_WIN64)
+            DWORD fileAttr = GetFileAttributesA(traceFolderPath.c_str());
+            bool pathExists = (fileAttr != INVALID_FILE_ATTRIBUTES && (fileAttr & FILE_ATTRIBUTE_DIRECTORY));
+#else
+            bool pathExists = (access(traceFolderPath.c_str(), F_OK) != -1);
+#endif
+            // Check if the path contains ".."
+            bool containsParentDirectory = (traceFolderPath.find("..") != std::string::npos);
+
+            if (!pathExists || containsParentDirectory)
+            {
+                assert(false && "Invalid trace folder path.");
+                return false;
+            }
+
             debugLogMutex.lock();
             debugLogPath = traceFolderPath;
+            if (debugLogPath.back() != '/' && debugLogPath.back() != '\\')
+            {
+                debugLogPath += "/";
+            }
             debugLogPath += "mat-debug-";
             debugLogPath += std::to_string(MAT::GetCurrentProcessId());
             debugLogPath += ".log";
@@ -129,6 +150,16 @@ namespace PAL_NS_BEGIN {
             }
             debugLogMutex.unlock();
             return result;
+        }
+
+        const std::unique_ptr<std::fstream>& getDebugLogStream() noexcept
+        {
+            return debugLogStream;
+        }
+
+        const std::string& getDebugLogPath() noexcept
+        {
+            return debugLogPath;
         }
 
         void log_done()

--- a/lib/pal/PAL.hpp
+++ b/lib/pal/PAL.hpp
@@ -239,6 +239,16 @@ namespace PAL_NS_BEGIN
         return GetPAL().RegisterIkeyWithWindowsTelemetry(ikeyin, storageSize, uploadQuotaSize);
     }
 
+#ifdef HAVE_MAT_LOGGING
+    namespace detail
+    {
+        bool log_init(bool isTraceEnabled, const std::string& traceFolderPath);
+        const std::unique_ptr<std::fstream>& getDebugLogStream() noexcept;
+        const std::string& getDebugLogPath() noexcept;
+        void log_done();
+    }
+#endif
+
 } PAL_NS_END
 
 #endif

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -193,12 +193,12 @@ TEST_F(LogInitTest, LogInitValidPath)
 
 TEST_F(LogInitTest, LogInitParentDirectoryInvalidPath)
 {
-    EXPECT_FALSE(PAL::detail::log_init(true, "invalid/../path/"));
+    EXPECT_THROW(PAL::detail::log_init(true, "invalid/../path/"), std::runtime_error);
 }
 
 TEST_F(LogInitTest, LogInitPathDoesNotExist)
 {
-    EXPECT_FALSE(PAL::detail::log_init(true, "nonexistent/path/"));
+    EXPECT_THROW(PAL::detail::log_init(true, "nonexistent/path/"), std::runtime_error);
 }
 
 TEST_F(LogInitTest, LogInitAlreadyInitialized)

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -147,63 +147,37 @@ TEST_F(PalTests, SdkVersion)
 class LogInitTest : public Test
 {
     protected:
-    const std::string validPath = "valid/path/";
+        const std::string validPath = "valid/path/";
 
-    void SetUp() override
-    {
-        // Create the valid path directory and any intermediate directories
-#if defined(_WIN32) || defined(_WIN64)
-        if (CreateDirectoryA("valid", NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
+        void SetUp() override
         {
-            if (CreateDirectoryA(validPath.c_str(), NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
-            {
-                std::cerr << "Directory created: " << validPath << std::endl;
-            }
-            else
-            {
-                std::cerr << "Error creating directory: " << validPath << std::endl;
-            }
-        }
-        else
-        {
-            std::cerr << "Error creating directory: valid" << std::endl;
-        }
-#else
-        if (mkdir("valid", 0777) == 0 || errno == EEXIST)
-        {
-            if (mkdir(validPath.c_str(), 0777) == 0 || errno == EEXIST)
-            {
-                std::cerr << "Directory created: " << validPath << std::endl;
-            }
-            else
-            {
-                std::cerr << "Error creating directory: " << validPath << std::endl;
-            }
-        }
-        else
-        {
-            std::cerr << "Error creating directory: valid" << std::endl;
-        }
-#endif
-    }
-
-    void TearDown() override
-    {
-        PAL::detail::log_done();
-        if (!PAL::detail::getDebugLogPath().empty())
-        {
-            std::remove(PAL::detail::getDebugLogPath().c_str());
+            // Create the valid path directory and any intermediate directories
+    #if defined(_WIN32) || defined(_WIN64)
+            CreateDirectoryA("valid", NULL);
+            CreateDirectoryA(validPath.c_str(), NULL);
+    #else
+            mkdir("valid", 0777);
+            mkdir(validPath.c_str(), 0777);
+    #endif
         }
 
-        // Remove the valid path directory
-#if defined(_WIN32) || defined(_WIN64)
-        RemoveDirectoryA(validPath.c_str());
-        RemoveDirectoryA("valid");
-#else
-        rmdir(validPath.c_str());
-        rmdir("valid");
-#endif
-    }
+        void TearDown() override
+        {
+            PAL::detail::log_done();
+            if (!PAL::detail::getDebugLogPath().empty())
+            {
+                std::remove(PAL::detail::getDebugLogPath().c_str());
+            }
+
+            // Remove the valid path directory
+    #if defined(_WIN32) || defined(_WIN64)
+            RemoveDirectoryA(validPath.c_str());
+            RemoveDirectoryA("valid");
+    #else
+            rmdir(validPath.c_str());
+            rmdir("valid");
+    #endif
+        }
 };
 
 TEST_F(LogInitTest, LogInitDisabled)
@@ -243,8 +217,13 @@ TEST_F(LogInitTest, LogInitPathWithoutTrailingSlash)
 
 TEST_F(LogInitTest, LogInitPathWithoutTrailingBackslash)
 {
+#if defined(_WIN32) || defined(_WIN64)
     std::string pathWithoutBackslash = "valid\\path";
+#else
+    std::string pathWithoutBackslash = "valid//path";
+#endif
     EXPECT_TRUE(PAL::detail::log_init(true, pathWithoutBackslash));
     EXPECT_TRUE(PAL::detail::getDebugLogStream()->is_open());
 }
+
 #endif

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -193,12 +193,12 @@ TEST_F(LogInitTest, LogInitValidPath)
 
 TEST_F(LogInitTest, LogInitParentDirectoryInvalidPath)
 {
-    EXPECT_THROW(PAL::detail::log_init(true, "invalid/../path/"), std::runtime_error);
+    EXPECT_FALSE(PAL::detail::log_init(true, "invalid/../path/"));
 }
 
 TEST_F(LogInitTest, LogInitPathDoesNotExist)
 {
-    EXPECT_THROW(PAL::detail::log_init(true, "nonexistent/path/"), std::runtime_error);
+    EXPECT_FALSE(PAL::detail::log_init(true, "nonexistent/path/"));
 }
 
 TEST_F(LogInitTest, LogInitAlreadyInitialized)

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -147,33 +147,63 @@ TEST_F(PalTests, SdkVersion)
 class LogInitTest : public Test
 {
     protected:
-        const std::string validPath = "valid/path/";
+    const std::string validPath = "valid/path/";
 
-        void SetUp() override
+    void SetUp() override
+    {
+        // Create the valid path directory and any intermediate directories
+#if defined(_WIN32) || defined(_WIN64)
+        if (CreateDirectoryA("valid", NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
         {
-            // Create the valid path directory
-    #if defined(_WIN32) || defined(_WIN64)
-            CreateDirectoryA(validPath.c_str(), NULL);
-    #else
-            mkdir(validPath.c_str(), 0777);
-    #endif
-        }
-
-        void TearDown() override
-        {
-            PAL::detail::log_done();
-            if (!PAL::detail::getDebugLogPath().empty())
+            if (CreateDirectoryA(validPath.c_str(), NULL) || GetLastError() == ERROR_ALREADY_EXISTS)
             {
-                std::remove(PAL::detail::getDebugLogPath().c_str());
+                std::cerr << "Directory created: " << validPath << std::endl;
             }
-
-            // Remove the valid path directory
-    #if defined(_WIN32) || defined(_WIN64)
-            RemoveDirectoryA(validPath.c_str());
-    #else
-            rmdir(validPath.c_str());
-    #endif
+            else
+            {
+                std::cerr << "Error creating directory: " << validPath << std::endl;
+            }
         }
+        else
+        {
+            std::cerr << "Error creating directory: valid" << std::endl;
+        }
+#else
+        if (mkdir("valid", 0777) == 0 || errno == EEXIST)
+        {
+            if (mkdir(validPath.c_str(), 0777) == 0 || errno == EEXIST)
+            {
+                std::cerr << "Directory created: " << validPath << std::endl;
+            }
+            else
+            {
+                std::cerr << "Error creating directory: " << validPath << std::endl;
+            }
+        }
+        else
+        {
+            std::cerr << "Error creating directory: valid" << std::endl;
+        }
+#endif
+    }
+
+    void TearDown() override
+    {
+        PAL::detail::log_done();
+        if (!PAL::detail::getDebugLogPath().empty())
+        {
+            std::remove(PAL::detail::getDebugLogPath().c_str());
+        }
+
+        // Remove the valid path directory
+#if defined(_WIN32) || defined(_WIN64)
+        RemoveDirectoryA(validPath.c_str());
+        RemoveDirectoryA("valid");
+#else
+        rmdir(validPath.c_str());
+        rmdir("valid");
+#endif
+    }
 };
 
 TEST_F(LogInitTest, LogInitDisabled)

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -7,6 +7,21 @@
 #include "pal/PseudoRandomGenerator.hpp"
 #include "Version.hpp"
 
+#ifdef HAVE_MAT_LOGGING
+#include "pal/PAL.hpp"
+#include <gtest/gtest.h>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <cstdio>
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+using namespace PAL::detail;
+#endif
+
 using namespace testing;
 
 class PalTests : public Test {};
@@ -127,3 +142,79 @@ TEST_F(PalTests, SdkVersion)
 
     EXPECT_THAT(PAL::getSdkVersion(), Eq(v));
 }
+
+#ifdef HAVE_MAT_LOGGING
+class LogInitTest : public Test
+{
+    protected:
+        const std::string validPath = "valid/path/";
+
+        void SetUp() override
+        {
+            // Create the valid path directory
+    #if defined(_WIN32) || defined(_WIN64)
+            CreateDirectoryA(validPath, NULL);
+    #else
+            mkdir(validPath.c_str(), 0777);
+    #endif
+        }
+
+        void TearDown() override
+        {
+            PAL::detail::log_done();
+            if (!PAL::detail::getDebugLogPath().empty())
+            {
+                std::remove(PAL::detail::getDebugLogPath().c_str());
+            }
+
+            // Remove the valid path directory
+    #if defined(_WIN32) || defined(_WIN64)
+            RemoveDirectoryA(validPath);
+    #else
+            rmdir(validPath.c_str());
+    #endif
+        }
+};
+
+TEST_F(LogInitTest, LogInitDisabled)
+{
+    EXPECT_FALSE(log_init(false, validPath));
+}
+
+TEST_F(LogInitTest, LogInitValidPath)
+{
+    EXPECT_TRUE(PAL::detail::log_init(true, validPath));
+    EXPECT_TRUE(PAL::detail::getDebugLogStream()->is_open());
+}
+
+TEST_F(LogInitTest, LogInitParentDirectoryInvalidPath)
+{
+    EXPECT_FALSE(PAL::detail::log_init(true, "invalid/../path/"));
+}
+
+TEST_F(LogInitTest, LogInitPathDoesNotExist)
+{
+    EXPECT_FALSE(PAL::detail::log_init(true, "nonexistent/path/"));
+}
+
+TEST_F(LogInitTest, LogInitAlreadyInitialized)
+{
+    EXPECT_TRUE(PAL::detail::log_init(true, validPath));
+    EXPECT_TRUE(PAL::detail::getDebugLogStream()->is_open());
+    EXPECT_TRUE(PAL::detail::log_init(true, validPath)); // Should return true as it's already initialized
+}
+
+TEST_F(LogInitTest, LogInitPathWithoutTrailingSlash)
+{
+    std::string pathWithoutSlash = "valid/path";
+    EXPECT_TRUE(PAL::detail::log_init(true, pathWithoutSlash));
+    EXPECT_TRUE(PAL::detail::getDebugLogStream()->is_open());
+}
+
+TEST_F(LogInitTest, LogInitPathWithoutTrailingBackslash)
+{
+    std::string pathWithoutBackslash = "valid\\path";
+    EXPECT_TRUE(PAL::detail::log_init(true, pathWithoutBackslash));
+    EXPECT_TRUE(PAL::detail::getDebugLogStream()->is_open());
+}
+#endif

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -153,7 +153,7 @@ class LogInitTest : public Test
         {
             // Create the valid path directory
     #if defined(_WIN32) || defined(_WIN64)
-            CreateDirectoryA(validPath, NULL);
+            CreateDirectoryA(validPath.c_str(), NULL);
     #else
             mkdir(validPath.c_str(), 0777);
     #endif
@@ -169,7 +169,7 @@ class LogInitTest : public Test
 
             // Remove the valid path directory
     #if defined(_WIN32) || defined(_WIN64)
-            RemoveDirectoryA(validPath);
+            RemoveDirectoryA(validPath.c_str());
     #else
             rmdir(validPath.c_str());
     #endif


### PR DESCRIPTION
CodeQL has flagged one or more instances of violations of type "cpp/path-injection" in the file "third_party/cpp_client_telemetry/lib/pal/PAL.cpp".

Violation File Path: third_party/cpp_client_telemetry/lib/pal/PAL.cpp
Line Numbers: 123
Alert Message: Uncontrolled data used in path expression.
QueryID: cpp/path-injection

Example [fix](https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM01937#Zguide)