### PR TITLE
More robust parsing and arg validation for build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,16 +2,16 @@
 
 usage()
 {
-  echo "Usage: build.sh [clean] [arm64|x86_64|universal] [CUSTOM_CMAKE_CXX_FLAGS=x] [noroot] [release] [-h|-?] [-l (static|shared)] [-D CMAKE_OPTION] [-v]"
+  echo "Usage: build.sh [clean] [arm64|x86_64|universal] [CUSTOM_BUILD_FLAGS=x] [noroot] [release|debug] [-h|-?] [-l (static|shared)] [-D CMAKE_OPTION] [-v]"
   echo "                                                                                         "
   echo "options:                                                                                 "
   echo "                                                                                         "
-  echo "Positional options (1st three arguments):                                                "
+  echo "Positional options:                                                                          "
   echo "[clean]                  - perform clean build                                           "
   echo "[arm64|x86_64|universal] - Apple platform build type. Not applicable to other OS.        "
-  echo "[CUSTOM_CMAKE_CXX_FLAGS] - custom CXX compiler flags                                     "
+  echo "[CUSTOM_BUILD_FLAGS]     - custom CXX compiler flags                                     "
   echo "[noroot]                 - custom CXX compiler flags                                     "
-  echo "[release]                - build for Release                                             "
+  echo "[release|debug]          - Specify build type (defaults to Debug)                        "
   echo "                                                                                         "
   echo "Additional parameters:                                                                   "
   echo " -h | -?                 - this help.                                                    "
@@ -35,68 +35,68 @@ cd $DIR
 
 export NOROOT=$NOROOT
 
-PARAM1="$1"
-PARAM2="$2"
-PARAM3="$3"
+# Evaluate arguments that are not switches
+while [[ $# -gt 0 ]]; do
+  ARG="$1"
+  case "$ARG" in
+    clean|noroot|release|debug|arm64|x86_64|universal|CUSTOM_BUILD_FLAGS*)
+      case "$ARG" in
+        clean)
+          CLEAN=true
+          echo "CLEAN = true"
+          ;;
+        noroot)
+          export NOROOT=true
+          echo "NOROOT = true"
+          ;;
+        release|debug)
+          if [[ -n "$BUILD_TYPE" ]]; then
+              echo "Error: BUILD_TYPE is already set to '$BUILD_TYPE'. Cannot overwrite with $ARG." 1>&2
+              exit 1
+          elif [[ "$ARG" == "release" ]]; then
+              BUILD_TYPE="Release"
+          elif [[ "$ARG" == "debug" ]]; then
+              BUILD_TYPE="Debug"
+          fi
+          echo "BUILD_TYPE = $BUILD_TYPE"
+          ;;
+        arm64|x86_64|universal)
+          if [[ -n "$MAC_ARCH" ]]; then
+              echo "Error: MAC_ARCH is already set to '$MAC_ARCH'. Cannot overwrite with $ARG." 1>&2
+              exit 1
+          else
+              MAC_ARCH="$ARG"
+          fi
+          echo "MAC_ARCH = $MAC_ARCH"
+          ;;
+        CUSTOM_BUILD_FLAGS*)
+          CUSTOM_CMAKE_CXX_FLAG="\"${ARG:19:999}\""
+          echo "custom compiler flags = $CUSTOM_CMAKE_CXX_FLAG"
+          ;;
+        *)
+          echo "Error: case not added: $ARG" 1>&2
+          exit 1
+          ;;
+      esac
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
-if [ "$PARAM1" == "clean" ]; then
-  echo "Cleaning previous build artifacts"
-  rm -f CMakeCache.txt *.cmake
-  rm -rf out
-  rm -rf .buildtools
-  # make clean
-  shift
-fi
-
-if [ "$PARAM1" == "noroot" ] || [ "$PARAM2" == "noroot" ] || [ "$PARAM3" == "noroot" ]; then
-  export NOROOT=true
-  echo "NOROOT = true"
-  shift
-fi
-
-if [ "$PARAM1" == "release" ] || [ "$PARAM2" == "release" ] || [ "$PARAM3" == "release" ]; then
-  BUILD_TYPE="Release"
-  echo "BUILD_TYPE = Release"
-  shift
-elif [ "$PARAM1" == "debug" ] || [ "$PARAM2" == "debug" ] || [ "$PARAM3" == "debug" ]; then
-  BUILD_TYPE="Debug"
-  echo "BUILD_TYPE = Debug"
-  shift
-else
+if [[ -z "$BUILD_TYPE" ]]; then
   BUILD_TYPE="Debug"
   echo "Assuming default BUILD_TYPE = Debug"
 fi
 
-if [ "$PARAM1" == "arm64" ] || [ "$PARAM2" == "arm64" ] || [ "$PARAM3" == "arm64" ]; then
-  MAC_ARCH="arm64"
-  echo "MAC_ARCH = arm64"
-  shift
-elif [ "$PARAM1" == "universal" ] || [ "$PARAM2" == "universal" ] || [ "$PARAM3" == "universal" ]; then
-  MAC_ARCH="universal"
-  echo "MAC_ARCH = universal"
-  shift
-elif [ "$PARAM1" == "x86_64" ] || [ "$PARAM2" == "x86_64" ] || [ "$PARAM3" == "x86_64" ]; then
-  MAC_ARCH="x86_64"
-  echo "MAC_ARCH = x86_64"
-  shift
-else
+if [[ -z "$MAC_ARCH" ]]; then
   MAC_ARCH=$(/usr/bin/uname -m)
   echo "Using current machine MAC_ARCH = $MAC_ARCH"
 fi
 
-CUSTOM_CMAKE_CXX_FLAG=""
-if [[ $PARAM1 == CUSTOM_BUILD_FLAGS* ]] || [[ $PARAM2 == CUSTOM_BUILD_FLAGS* ]] || [[ $PARAM3 == CUSTOM_BUILD_FLAGS* ]]; then
-  if [[ $PARAM1 == CUSTOM_BUILD_FLAGS* ]]; then
-  CUSTOM_CMAKE_CXX_FLAG="\"${1:19:999}\""
-  elif [[ $PARAM2 == CUSTOM_BUILD_FLAGS* ]]; then
-  CUSTOM_CMAKE_CXX_FLAG="\"${2:19:999}\""
-  elif [[ $PARAM3 == CUSTOM_BUILD_FLAGS* ]]; then
-  CUSTOM_CMAKE_CXX_FLAG="\"${3:19:999}\""
-  fi
-  shift
-  echo "custom build flags = $CUSTOM_CMAKE_CXX_FLAG"
-fi
-
+# Evaluate switches
 LINK_TYPE=
 CMAKE_OPTS="${CMAKE_OPTS:--DBUILD_SHARED_LIBS=OFF}"
 while getopts "h?vl:D:" opt; do
@@ -114,7 +114,21 @@ while getopts "h?vl:D:" opt; do
         ;;
     esac
 done
+
+# Detect args accidentally passed after the last switch argument
 shift $((OPTIND -1))
+if [[ $# -gt 0 ]]; then
+    echo "Error: There are arguments remaining after parsing all positional arguments and switches: $@" 1>&2
+    exit 1
+fi
+
+if [[ "$CLEAN" == "true" ]]; then
+  echo "Cleaning previous build artifacts"
+  rm -f CMakeCache.txt *.cmake
+  rm -rf out
+  rm -rf .buildtools
+  # make clean
+fi
 
 echo "CMAKE_OPTS from caller: $CMAKE_OPTS"
 
@@ -175,6 +189,7 @@ set -e
 cmake_cmd="cmake -DMAC_ARCH=$MAC_ARCH -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PACKAGE_TYPE=$CMAKE_PACKAGE_TYPE -DCMAKE_CXX_FLAGS="${CUSTOM_CMAKE_CXX_FLAG}" $CMAKE_OPTS .."
 echo $cmake_cmd
 eval $cmake_cmd
+
 # TODO: strip symbols to minimize (release-only)
 
 # Build all


### PR DESCRIPTION
The issue prompting this PR is [#1341](https://github.com/microsoft/cpp_client_telemetry/issues/1341), where a positional argument following a switch will cause the switch to be swallowed and not evaluated.

This PR changes how commands are parsed so that:
* All positional arguments are parsed before any switches, in a loop
* Any number of positional arguments will be evaluated
* If there is a conflict (such as 'release' and 'debug', or 'arm64' and 'x86_64'), the error will be detected and the script will terminate
* All parsing occurs before any work (mainly affects the clean step)
* If any arguments follow the final switch, the error will be detected and the script will terminate

Additionally, there was a conflict between the usage statement and logic, in that the usage statement referred to a positional argument `CUSTOM_CMAKE_CXX_FLAGS=x`, but the actual parser looked for an argument `CUSTOM_BUILD_FLAGS=x` and set a variable `CUSTOM_CMAKE_CXX_FLAG`. The usage statement is updated to reflect the argument.

Testing performed includes:
* All arguments and the variables they set
* Conflicting arguments result in errors
* Default values are used if no value is set for BUILD_TYPE or MAC_ARCH
* Non-switch arguments following switches result in errors
* `./build.sh noroot -DBUILD_UNIT_TESTS=NO -DBUILD_FUNC_TESTS=NO` builds successfully