### PR TITLE
Downgrade NDK from 29.0.13599879 to latest NDK(27) LTS version

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -46,7 +46,7 @@ jobs:
         java -version
         gci env:* | sort-object name
         new-item "C:\Users\runneradmin\.android\repositories.cfg" -ItemType "file"
-        echo yes | .\sdkmanager.bat "ndk-bundle" "cmake;3.10.2.4988404" "ndk;29.0.13599879" --sdk_root=$Env:ANDROID_SDK_ROOT
+        echo yes | .\sdkmanager.bat "ndk-bundle" "cmake;3.10.2.4988404" "ndk;27.0.12077973" --sdk_root=$Env:ANDROID_SDK_ROOT
       working-directory: ${{ env.ANDROID_SDK_ROOT }}\cmdline-tools\7.0\bin
     - name: Chocolatey
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -115,7 +115,7 @@ jobs:
         java -version
         gci env:* | sort-object name
         new-item "C:\Users\runneradmin\.android\repositories.cfg" -ItemType "file"
-        echo yes | .\sdkmanager.bat "ndk-bundle" "cmake;3.10.2.4988404" "ndk;29.0.13599879" --sdk_root=$Env:ANDROID_SDK_ROOT
+        echo yes | .\sdkmanager.bat "ndk-bundle" "cmake;3.10.2.4988404" "ndk;27.0.12077973" --sdk_root=$Env:ANDROID_SDK_ROOT
       working-directory: ${{ env.ANDROID_SDK_ROOT }}\cmdline-tools\7.0\bin
     - name: Chocolatey
       run: |

--- a/build-android.cmd
+++ b/build-android.cmd
@@ -4,7 +4,7 @@ pushd "%~dp0"
 REM Users may override the default %ANDROID_SDK_ROOT% location if necessary
 
 if "%ANDROID_SDK_ROOT%"      == "" set "ANDROID_SDK_ROOT=C:\Android\android-sdk"
-if "%ANDROID_NDK_VERSION%"   == "" set "ANDROID_NDK_VERSION=29.0.13599879"
+if "%ANDROID_NDK_VERSION%"   == "" set "ANDROID_NDK_VERSION=27.0.12077973"
 if "%ANDROID_CMAKE_VERSION%" == "" set "ANDROID_CMAKE_VERSION=3.10.2.4988404"
 if "%ANDROID_HOME%"          == "" set "ANDROID_HOME=%ANDROID_SDK_ROOT%"
 if "%ANDROID_NDK%"           == "" set "ANDROID_NDK=%ANDROID_SDK_ROOT%\ndk\%ANDROID_NDK_VERSION%"

--- a/docs/cpp-start-android.md
+++ b/docs/cpp-start-android.md
@@ -22,7 +22,7 @@ Default environment variables used by `build-android.cmd` script:
 
 ```console
 
-set "ANDROID_NDK_VERSION=29.0.13599879"
+set "ANDROID_NDK_VERSION=27.0.12077973"
 set "ANDROID_CMAKE_VERSION=3.10.2.4988404"
 set "ANDROID_SDK_ROOT=C:\Android\android-sdk"
 set "ANDROID_HOME=%ANDROID_SDK_ROOT%"

--- a/lib/android_build/ide.cmd
+++ b/lib/android_build/ide.cmd
@@ -9,7 +9,7 @@ set "PATH=%AndroidStudioPath%\bin;%PATH%"
 
 if "%ANDROID_SDK_ROOT%"   == "" set "ANDROID_SDK_ROOT=C:\Android\android-sdk"
 if "%ANDROID_HOME%"       == "" set "ANDROID_HOME=%ANDROID_SDK_ROOT%"
-if "%ANDROID_NDK_VERSION%"== "" set "ANDROID_NDK_VERSION=29.0.13599879"
+if "%ANDROID_NDK_VERSION%"== "" set "ANDROID_NDK_VERSION=27.0.12077973"
 if "%ANDROID_NDK%"        == "" set "ANDROID_NDK=%ANDROID_SDK_ROOT%\ndk\%ANDROID_NDK_VERSION%"
 if "%ANDROID_NDK_HOME%"   == "" set "ANDROID_NDK_HOME=%ANDROID_NDK%"
 

--- a/lib/android_build/tools.gradle
+++ b/lib/android_build/tools.gradle
@@ -2,7 +2,7 @@ android {
 
     compileSdkVersion    = 32
 
-    ndkVersion           =  System.getenv("ANDROID_NDK_VERSION") ?: "29.0.13599879"
+    ndkVersion           =  System.getenv("ANDROID_NDK_VERSION") ?: "27.0.12077973"
 
     defaultConfig {
         minSdkVersion    19


### PR DESCRIPTION
Downgrade to the last LTS (27.0.12077973) version, the previous version used was RC and not LTS, this downgraded version still supports 16 kb page size alignment