### PR TITLE
Including payload decoder into CMakeList.txt for the library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SRCS decorators/BaseDecorator.cpp
   pal/PAL.cpp
   pal/TaskDispatcher_CAPI.cpp
   pal/WorkerThread.cpp
+  decoder/PayloadDecoder.cpp
 )
 
 # Support for Azure Monitor / Application Insights


### PR DESCRIPTION
Since `PayloadDecoder.hpp` is a public interface, if people try to use it they will face a linker error because that symbol is not compiled in the library so therefore not included in final binary.
So this PR adds it to CMakeList.txt to ensure payload decoder is compiled and included in the final library binary and we are able to compile and link successfully.

Fixes #1381 