### PR TITLE
[HttpClient][Curl] Use poll api to avoid select 1024 FD hard limit

### DIFF
--- a/lib/http/HttpClient_Curl.hpp
+++ b/lib/http/HttpClient_Curl.hpp
@@ -23,6 +23,7 @@
 #include <future>
 #include <atomic>
 
+#include <poll.h>
 #include <curl/curl.h>
 
 #include <unistd.h>
@@ -462,28 +463,18 @@ protected:
      */
     static int WaitOnSocket(curl_socket_t sockfd, int for_recv, long timeout_ms)
     {
-        struct timeval tv;
-        fd_set infd, outfd, errfd;
-        int res;
-
-        tv.tv_sec = timeout_ms / 1000;
-        tv.tv_usec = (timeout_ms % 1000) * 1000;
-
-        FD_ZERO(&infd);
-        FD_ZERO(&outfd);
-        FD_ZERO(&errfd);
-
-        FD_SET(sockfd, &errfd); /* always check for error */
+        struct pollfd pfd;
+        
+        pfd.fd = sockfd;
+        pfd.revents = 0;
 
         if(for_recv) {
-            FD_SET(sockfd, &infd);
+            pfd.events = POLLIN | POLLERR;
         } else {
-            FD_SET(sockfd, &outfd);
+            pfd.events = POLLOUT | POLLERR;
         }
 
-        /* select() returns the number of signalled sockets or -1 */
-        res = select((int)sockfd + 1, &infd, &outfd, &errfd, &tv);
-        return res;
+        return poll(&pfd, 1, timeout_ms);
     }
 
     // Raw response buffer

--- a/lib/http/HttpClient_Curl.hpp
+++ b/lib/http/HttpClient_Curl.hpp
@@ -464,17 +464,11 @@ protected:
     static int WaitOnSocket(curl_socket_t sockfd, int for_recv, long timeout_ms)
     {
         struct pollfd pfd;
-        
         pfd.fd = sockfd;
-        pfd.revents = 0;
-
-        if(for_recv) {
-            pfd.events = POLLIN | POLLERR;
-        } else {
-            pfd.events = POLLOUT | POLLERR;
-        }
-
-        return poll(&pfd, 1, timeout_ms);
+        pfd.events = for_recv ? POLLIN : POLLOUT;
+        // Cap timeout to max int value to avoid overflow in poll()
+        auto timeout = std::min(timeout_ms, static_cast<long>(std::numeric_limits<int>::max()));   
+        return poll(&pfd, 1, static_cast<int>(timeout));
     }
 
     // Raw response buffer


### PR DESCRIPTION
Using `select` causes a crash because of its implementation 1024 FD hard limit. 
```
*** bit out of range 0 - FD_SETSIZE on fd_set ***: terminated
```

This is crash happens depending on the application running if it has held other file descriptors around in the process.
So even though the number of request simultaneously is guarded here:
https://github.com/microsoft/cpp_client_telemetry/blob/1fd167fa1595853cd423f9d3229915ad0092a09b/lib/tpm/TransmissionPolicyManager.cpp#L120

It doesn't prevent application to have hold onto other file descriptors opened which is outside of control of this library.

### How to repro:
* Pretend application has done a lot of things that caused them to have a lot of things opened. (We had to pretend in this case because we had not access to customer application nor environment).
* Then start normal flow of telemetry. 

```cpp
int main () {
 // Pretend application has a lot of file description opened in the current process.
    for (int i = 0; i < 900; i++) {
        int fd = open("/dev/null", O_RDONLY);
        if (fd < 0) {
            break;
        }
    }

    printf("Next fd allocation should be >= 900\n");
   auto handle = my_domain_telemetry_sender_init(...);
   // ..... 
   return 0;
}

TelemetrySenderHandle my_domain_telemetry_sender_init(
    const char* event_collector_uri, const char* ingestion_token) {
  auto& configuration =
      Microsoft::Applications::Events::LogManager::GetLogConfiguration();
  configuration[Microsoft::Applications::Events::CFG_STR_COLLECTOR_URL] =
      event_collector_uri;
  Microsoft::Applications::Events::ILogger* logger =
      Microsoft::Applications::Events::LogManager::Initialize(ingestion_token);
  assert(logger && "Could not create logger");
  return (TelemetrySenderHandle)(new TelemetrySender{logger});
}
```
### Results:
```
*** bit out of range 0 - FD_SETSIZE on fd_set ***: terminated
```

Customer stack trace:
```
Full Native Call Stack (Symbolicated)

  #0  libc          syscall — tkill(SIGABRT)
  #1  libc +0x1d27e  raise()
  #2  libc +0x98f    abort()
  #3  libc +0x17b6   __fortify_fail — "bit out of range 0 - FD_SETSIZE on fd_set"
  #4  libc +0x10ec49  } select() fd bounds check
  #5  libc +0x10e745  }
  #6  libcurl.so.4   +0xbd4d  — curl's select-based socket wait
  #7  libacsmediart.so  Microsoft::Applications::Events::CurlHttpOperation::WaitOnSocket(int, int, long) +189
  #8  libacsmediart.so  CurlHttpOperation::SendAsync(λ)::'lambda'() — std::async task body
  #9  libacsmediart.so  std::__future_base::_Async_state_impl::_M_run() +257
  #10 libacsmediart.so  std::__future_base::_State_baseV2::_M_do_set(...)
```

### Fix

Those changes fix it by not relying on `select` hard limit and bullet proving our SDK to not fail on conditions that we as SDK do not control such as those and make the library more resilient. 

Fixes #1060