### PR TITLE
Remove hard dependency on wininet.dll from mip_ClientTelemetry

### DIFF
--- a/Solutions/win32-dll/win32-dll.vcxproj
+++ b/Solutions/win32-dll/win32-dll.vcxproj
@@ -217,7 +217,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MSVCRTD.lib;msvcprtd.lib;atls.lib;shlwapi.lib;iphlpapi.lib;vcruntimed.lib;ucrtd.lib;wininet.lib;crypt32.lib;version.lib;kernel32.lib;user32.lib;advapi32.lib;ole32.lib;uuid.lib</AdditionalDependencies>
+      <AdditionalDependencies>MSVCRTD.lib;msvcprtd.lib;atls.lib;shlwapi.lib;iphlpapi.lib;vcruntimed.lib;ucrtd.lib;crypt32.lib;version.lib;kernel32.lib;user32.lib;advapi32.lib;ole32.lib;uuid.lib</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(DisableWinRT)'!='true'">runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
@@ -301,7 +301,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>MSVCRT.lib;msvcprt.lib;atls.lib;shlwapi.lib;iphlpapi.lib;vcruntime.lib;ucrt.lib;wininet.lib;crypt32.lib;version.lib;kernel32.lib;user32.lib;advapi32.lib;ole32.lib;uuid.lib</AdditionalDependencies>
+      <AdditionalDependencies>MSVCRT.lib;msvcprt.lib;atls.lib;shlwapi.lib;iphlpapi.lib;vcruntime.lib;ucrt.lib;crypt32.lib;version.lib;kernel32.lib;user32.lib;advapi32.lib;ole32.lib;uuid.lib</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(DisableWinRT)'!='true'">runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>

--- a/Solutions/win32-lib/win32-lib.vcxproj
+++ b/Solutions/win32-lib/win32-lib.vcxproj
@@ -284,7 +284,6 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <LinkStatus>false</LinkStatus>
@@ -352,7 +351,6 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <LinkStatus>false</LinkStatus>
@@ -430,7 +428,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <ForceFileOutput>
@@ -506,7 +503,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <ForceFileOutput>

--- a/Solutions/win32-lib/win32-lib.vcxproj
+++ b/Solutions/win32-lib/win32-lib.vcxproj
@@ -284,6 +284,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <LinkStatus>false</LinkStatus>
@@ -351,6 +352,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <LinkStatus>false</LinkStatus>
@@ -428,6 +430,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <ForceFileOutput>
@@ -503,6 +506,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <ForceFileOutput>

--- a/Solutions/win32-mini-dll/win32-mini-dll.vcxproj
+++ b/Solutions/win32-mini-dll/win32-mini-dll.vcxproj
@@ -240,6 +240,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(DisableWinRT)'!='true'">runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
@@ -267,6 +268,7 @@
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
     </ProjectReference>
     <Lib>
+      <AdditionalDependencies>user32.lib;shell32.lib;Advapi32.lib;Ole32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
     <Bscmake>
@@ -355,6 +357,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(DisableWinRT)'!='true'">runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
@@ -382,6 +385,7 @@
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
     </ProjectReference>
     <Lib>
+      <AdditionalDependencies>user32.lib;shell32.lib;Advapi32.lib;Ole32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>

--- a/Solutions/win32-mini-dll/win32-mini-dll.vcxproj
+++ b/Solutions/win32-mini-dll/win32-mini-dll.vcxproj
@@ -240,7 +240,6 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(DisableWinRT)'!='true'">runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
@@ -268,7 +267,6 @@
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
     </ProjectReference>
     <Lib>
-      <AdditionalDependencies>wininet.lib;user32.lib;shell32.lib;Advapi32.lib;Ole32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
     <Bscmake>
@@ -357,7 +355,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(DisableWinRT)'!='true'">runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
@@ -385,7 +382,6 @@
       <UseLibraryDependencyInputs>true</UseLibraryDependencyInputs>
     </ProjectReference>
     <Lib>
-      <AdditionalDependencies>wininet.lib;user32.lib;shell32.lib;Advapi32.lib;Ole32.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>

--- a/Solutions/win32-mini-lib/win32-mini-lib.vcxproj
+++ b/Solutions/win32-mini-lib/win32-mini-lib.vcxproj
@@ -321,7 +321,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <LinkStatus>false</LinkStatus>
@@ -427,7 +427,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <LinkStatus>false</LinkStatus>
@@ -534,7 +534,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <ForceFileOutput>
@@ -642,7 +642,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>uuid.lib;wininet.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>uuid.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs Condition="'$(DisableWinRT)'!='true'">api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-string-l1-1-0.dll</DelayLoadDLLs>
       <ForceFileOutput>

--- a/lib/http/HttpClientFactory.cpp
+++ b/lib/http/HttpClientFactory.cpp
@@ -16,8 +16,6 @@
 #if defined(MATSDK_PAL_WIN32)
   #ifdef _WINRT_DLL
     #include "http/HttpClient_WinRt.hpp"
-  #elif defined(HAVE_MAT_WININET_HTTP_CLIENT)
-    #include "http/HttpClient_WinInet.hpp"
   #endif
 #elif defined(MATSDK_PAL_CPP11)
   #if TARGET_OS_IPHONE || (defined(__APPLE__) && defined(APPLE_HTTP))
@@ -42,13 +40,13 @@ namespace MAT_NS_BEGIN {
         LOG_TRACE("Creating HttpClient_WinRt");
         return std::make_shared<HttpClient_WinRt>();
     }
-#elif defined(HAVE_MAT_WININET_HTTP_CLIENT)
-    /* Win32 WinInet HTTP client */
-    std::shared_ptr<IHttpClient> HttpClientFactory::Create() {
-        LOG_TRACE("Creating HttpClient_WinInet");
-        return std::make_shared<HttpClient_WinInet>();
+#else
+    /* Win32 desktop - no default HTTP client; caller must supply their own IHttpClient */
+    std::shared_ptr<IHttpClient> HttpClientFactory::Create()
+    {
+        LOG_TRACE("No default HTTP client available for Win32 desktop");
+        return nullptr;
     }
-
 #endif
 #elif defined(HAVE_MAT_CURL_HTTP_CLIENT)
     std::shared_ptr<IHttpClient> HttpClientFactory::Create() {

--- a/lib/http/HttpClientFactory.hpp
+++ b/lib/http/HttpClientFactory.hpp
@@ -23,12 +23,6 @@ private:
 
 } MAT_NS_END
 
-// TODO: [maxgolov] - remove this once there is a better way to pass HTTP client configuration
-#if defined(MATSDK_PAL_WIN32) && !defined(_WINRT_DLL)
-#define HAVE_MAT_WININET_HTTP_CLIENT
-#include "http/HttpClient_WinInet.hpp"
-#endif
-
 #endif // HAVE_MAT_DEFAULT_HTTP_CLIENT
 
 #endif // HTTPCLIENTFACTORY_HPP

--- a/lib/pal/desktop/desktop.vcxitems
+++ b/lib/pal/desktop/desktop.vcxitems
@@ -13,10 +13,6 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\http\HttpClient_WinInet.hpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\http\HttpClient_WinInet.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NetworkDetector.cpp">
       <AdditionalIncludeDirectories>..\..;..\..\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories);$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/lib/pal/desktop/desktop.vcxitems.filters
+++ b/lib/pal/desktop/desktop.vcxitems.filters
@@ -1,14 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\http\HttpClient_WinInet.hpp" />
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)WindowsDesktopDeviceInformationImpl.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WindowsDesktopNetworkInformationImpl.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WindowsDesktopSystemInformationImpl.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NetworkDetector.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\http\HttpClient_WinInet.cpp" />
   </ItemGroup>
   <ItemGroup Condition="exists('$(MSBuildThisFileDirectory)..\..\modules\utc\')">
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\modules\utc\desktop\UtcHelpers.cpp" />


### PR DESCRIPTION
The SDK links against wininet.lib, creating a load-time dependency on wininet.dll. When customers disable WinINet on their servers, the DLL fails to load entirely, breaking MIP SDK usage even though no WinINet functions are actually called.

This change Removes the hard link-time dependency on wininet.dll from the mip_ClientTelemetry.dll. The MIP SDK never uses the built-in WinINet HTTP client it always provides its own IHttpClient implementation so this dependency is unnecessary and causes failures for customers who disable WinINet on their servers.