### PR TITLE
Suppress SCNetworkReachability deprecation warnings

### DIFF
--- a/third_party/Reachability/ODWReachability.m
+++ b/third_party/Reachability/ODWReachability.m
@@ -31,6 +31,12 @@
 #import <netinet/in.h>
 #import <arpa/inet.h>
 
+// The SCNetworkReachability APIs used throughout this file were deprecated
+// in iOS 17.4.  A full migration to NWPathMonitor is tracked separately;
+// suppress the warnings for the entire file until then.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 
 NSString *const kNetworkReachabilityChangedNotification = @"NetworkReachabilityChangedNotification";
 
@@ -432,7 +438,10 @@ static int kTimeoutDurationInSeconds = 10;
 
     SCNetworkReachabilityFlags flags = 0;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+#pragma clang diagnostic pop
     {
         // Check we're REACHABLE
         if(flags & kSCNetworkReachabilityFlagsReachable)


### PR DESCRIPTION
Add a file-level pragma to suppress all SCNetworkReachability deprecation warnings in ODWReachability.m. This entire file is a third-party reachability wrapper that uses these APIs pervasively (50+ call sites). The APIs were deprecated in iOS 17.4 and trigger `-Werror` build failures in Xcode 26.4+.

A single file-level suppression is cleaner than wrapping each individual call site (the file already had ~15 per-site pragma pairs from earlier fixes).

A full migration to `NWPathMonitor` is tracked separately; this unblocks the build.

Fixes #1425