### PR TITLE
Make LLVM install optional in setup-buildtools

### DIFF
--- a/tools/setup-buildtools.cmd
+++ b/tools/setup-buildtools.cmd
@@ -16,8 +16,9 @@ if ERRORLEVEL 0 (
   vswhere -property installationPath
 )
 
-REM Install tools needed to build SDK with either Visual Studio or CMake
-choco install -y cmake svn git llvm zip
+REM Install baseline tools needed to build SDK with either Visual Studio or CMake
+REM LLVM is optional and handled below when INSTALL_LLVM is defined.
+choco install -y cmake svn git zip
 
 REM Try to autodetect Visual Studio
 call "%~dp0\vcvars.cmd"


### PR DESCRIPTION
Fixes #1014

Make `tools/setup-buildtools.cmd` stop installing LLVM unless `INSTALL_LLVM` is set. This matches the behavior described in the docs.

### Changes
- remove `llvm` from the unconditional Chocolatey bootstrap package list
- keep LLVM installation behind the existing `INSTALL_LLVM` gate
- clarify in the script comments that LLVM remains optional and is still handled by `install-llvm.cmd` when requested
