### PR TITLE
Validate custom build props inputs before starting builds

### DIFF
--- a/build-all.bat
+++ b/build-all.bat
@@ -1,8 +1,37 @@
 @echo off
 
 cd %~dp0
-call tools\gen-version.cmd
 @setlocal ENABLEEXTENSIONS
+
+set CUSTOM_PROPS=
+if not "%~1"=="" (
+  if not exist "%~f1" (
+    goto custom_props_missing
+  )
+  if /I not "%~x1"==".props" (
+    if /I not "%~x1"==".targets" (
+      goto custom_props_invalid_type
+    )
+  )
+  set CUSTOM_PROPS="/p:ForceImportBeforeCppTargets=%~f1"
+  echo Using custom properties file for the build:
+  echo %CUSTOM_PROPS%
+)
+
+goto after_custom_props_validation
+
+:custom_props_missing
+echo ERROR: Custom build input not found: %~1
+echo        Pass an existing MSBuild .props or .targets file to ForceImportBeforeCppTargets.
+exit /b 1
+
+:custom_props_invalid_type
+echo ERROR: Custom build input must be an MSBuild .props or .targets file: %~1
+echo        Pass the MSBuild import file, not the CONFIG_CUSTOM_H header.
+exit /b 1
+
+:after_custom_props_validation
+call tools\gen-version.cmd
 
 echo Update all public submodules...
 git -c submodule."lib/modules".update=none submodule update --init --recursive
@@ -16,13 +45,6 @@ set GTEST_PATH=third_party\googletest
 if NOT EXIST %GTEST_PATH%\CMakeLists.txt (
  git clone --depth 1 --branch release-1.12.1 https://github.com/google/googletest %GTEST_PATH%
 )
-
-set CUSTOM_PROPS=
-if ("%~1"=="") goto skip
-set CUSTOM_PROPS="/p:ForceImportBeforeCppTargets=%1"
-echo Using custom properties file for the build:
-echo %CUSTOM_PROPS%
-:skip
 
 if NOT DEFINED SKIP_MD_BUILD (
   REM DLL and static /MD build

--- a/build-tests.cmd
+++ b/build-tests.cmd
@@ -1,7 +1,36 @@
 @echo off
 cd %~dp0
-call tools\gen-version.cmd
 @setlocal ENABLEEXTENSIONS
+
+set CUSTOM_PROPS=
+if not "%~3"=="" (
+  if not exist "%~f3" (
+    goto custom_props_missing
+  )
+  if /I not "%~x3"==".props" (
+    if /I not "%~x3"==".targets" (
+      goto custom_props_invalid_type
+    )
+  )
+  set CUSTOM_PROPS="/p:ForceImportBeforeCppTargets=%~f3"
+  echo Using custom properties file for the build:
+  echo %CUSTOM_PROPS%
+)
+
+goto after_custom_props_validation
+
+:custom_props_missing
+echo ERROR: Custom build input not found: %~3
+echo        Pass an existing MSBuild .props or .targets file to ForceImportBeforeCppTargets.
+exit /b 1
+
+:custom_props_invalid_type
+echo ERROR: Custom build input must be an MSBuild .props or .targets file: %~3
+echo        Pass the MSBuild import file, not the CONFIG_CUSTOM_H header.
+exit /b 1
+
+:after_custom_props_validation
+call tools\gen-version.cmd
 
 if DEFINED GIT_PULL_TOKEN (
   rd /s /q lib\modules
@@ -19,13 +48,6 @@ REM Possible platforms: Win32|x64
 set PLAT=%1
 REM Possible configurations: Release|Debug
 set CONFIGURATION=%2
-
-set CUSTOM_PROPS=
-if ("%3"=="") goto skip
-set CUSTOM_PROPS="/p:ForceImportBeforeCppTargets=%3"
-echo Using custom properties file for the build:
-echo %CUSTOM_PROPS%
-:skip
 
 set MAXCPUCOUNT=%NUMBER_OF_PROCESSORS%
 set SOLUTION=Solutions\MSTelemetrySDK.sln

--- a/build-win.ps1
+++ b/build-win.ps1
@@ -143,7 +143,18 @@ foreach ($arch in $archs) {
       }
 
       # Build!
-      & cmd /c "msbuild $solution /target:$targetStr /p:BuildProjectReferences=true /maxcpucount:$cpuCount /p:Configuration=$actualConfig /p:Platform=$actualArch $actualCustomProps"
+      $msbuildArgs = @(
+        $solution
+        "/target:$targetStr"
+        "/p:BuildProjectReferences=true"
+        "/maxcpucount:$cpuCount"
+        "/p:Configuration=$actualConfig"
+        "/p:Platform=$actualArch"
+      )
+      if ($actualCustomProps -ne "") {
+        $msbuildArgs += $actualCustomProps
+      }
+      & msbuild @msbuildArgs
 
       echo "...Done!"
       echo ""

--- a/build-win.ps1
+++ b/build-win.ps1
@@ -15,7 +15,17 @@ $cpuCount = $env:NUMBER_OF_PROCESSORS
 
 $actualCustomProps = ""
 if ($customProps -ne "") {
-  $actualCustomProps = "/p:ForceImportBeforeCppTargets=$customProps"
+  if (-not (Test-Path -LiteralPath $customProps -PathType Leaf)) {
+    throw "Custom build input not found: $customProps`nPass an existing MSBuild .props or .targets file to ForceImportBeforeCppTargets."
+  }
+
+  $customPropsExtension = [System.IO.Path]::GetExtension($customProps)
+  if ($customPropsExtension -ine ".props" -and $customPropsExtension -ine ".targets") {
+    throw "Custom build input must be an MSBuild .props or .targets file: $customProps`nPass the MSBuild import file, not the CONFIG_CUSTOM_H header."
+  }
+
+  $resolvedCustomProps = (Resolve-Path -LiteralPath $customProps).Path
+  $actualCustomProps = "/p:ForceImportBeforeCppTargets=$resolvedCustomProps"
 }
 
 $coreTargets = @("zlib")

--- a/docs/building-custom-SKU.md
+++ b/docs/building-custom-SKU.md
@@ -44,6 +44,8 @@ build-all.bat %CD%\Solutions\build.compact.props
 
 produces a custom compact SDK build.
 
+The argument passed to `build-all.bat` must be an MSBuild `.props` or `.targets` file that sets the required preprocessor definitions. Do not pass the `config-*.h` header directly to `ForceImportBeforeCppTargets`.
+
 How it works:
 
 **build.compact.props** - contains the preprocessor definition that is functionally equivalent to


### PR DESCRIPTION
Addresses #1255

Fail early when a custom build input is missing or is not an MSBuild import file.

### Changes
- validate `.props` and `.targets` inputs before starting `build-all.bat` and `build-tests.cmd`
- add the same guard to `build-win.ps1`
- clarify in `docs/building-custom-SKU.md` that callers must pass the MSBuild import file, not the `config-*.h` header directly
