### PR TITLE
Restore documentation website build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,19 @@
 version: 2
 
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - doxygen
+    - graphviz
+
 submodules:
   exclude: all
 
 python:
-   install:
-   - requirements: docs/public/requirements.txt
+  install:
+    - requirements: docs/public/requirements.txt
 
 sphinx:
-   configuration: docs/public/conf.py
+  configuration: docs/public/conf.py

--- a/docs/public/conf.py
+++ b/docs/public/conf.py
@@ -16,7 +16,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Microsoft C++ Client Telemetry SDK"'
+project = 'Microsoft C++ Client Telemetry SDK'
 copyright = 'Microsoft Corporation'
 author = 'Microsoft Corporation'
 
@@ -28,8 +28,6 @@ release = '1.0.0'
 # This is necessary so the readthedocs build works. It doesn't invoke the
 # Makefile, but just runs sphinx on this conf.py.
 import os
-import shutil
-import subprocess
 if not os.path.exists('doxyoutput'):
         os.makedirs('doxyoutput')
 
@@ -61,7 +59,7 @@ breathe_default_project = "Microsoft C++ Client Telemetry SDK"
 
 primary_domain = "cpp"
 
-higlight_language = "cpp"
+highlight_language = "cpp"
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -78,10 +76,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-#html_theme = "furo"
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/docs/public/requirements.txt
+++ b/docs/public/requirements.txt
@@ -1,3 +1,4 @@
+sphinx<10
 breathe
 exhale
 furo


### PR DESCRIPTION
## Summary
- configure ReadTheDocs to use a current Ubuntu/Python build image
- install Doxygen and Graphviz for the Exhale/Breathe API reference build
- use the installed Furo theme instead of the missing `sphinx_rtd_theme`
- pin Sphinx below 10 because the current Exhale release emits Sphinx 10 compatibility warnings

## Validation
- `python -m sphinx -q -b html docs/public docs/public/_build/html` with Doxygen on PATH
- generated `docs/public/_build/html/index.html`
- parsed `.readthedocs.yaml` successfully