### PR TITLE
Deploy documentation to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs-pages.yml
+++ b/.github/workflows/deploy-docs-pages.yml
@@ -1,0 +1,78 @@
+name: Deploy documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/deploy-docs-pages.yml
+      - .readthedocs.yaml
+      - docs/**
+      - lib/include/**
+  pull_request:
+    paths:
+      - .github/workflows/deploy-docs-pages.yml
+      - .readthedocs.yaml
+      - docs/**
+      - lib/include/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes doxygen graphviz
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r docs/public/requirements.txt
+
+      - name: Build Sphinx documentation
+        run: python -m sphinx -q -b html docs/public docs/public/_build/html
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public/_build/html
+
+  deploy:
+    name: Deploy documentation
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-24.04
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds `docs/public` with Sphinx, Exhale, Breathe, Doxygen, and Graphviz
- upload `docs/public/_build/html` as a GitHub Pages artifact on `main` pushes
- deploy that artifact to the `github-pages` environment with the official Pages actions
- run the docs build on future docs/header PRs without deploying from pull requests

## Why
PR #1435 restored the Sphinx/Doxygen site build configuration, but after it merged there was still no repository workflow that published the generated HTML to GitHub Pages. The current `github-pages` deployment records are stale failures from 2022 and no fresh deployment was created by the #1435 merge.

## Validation
- parsed `.github/workflows/deploy-docs-pages.yml` as YAML
- ran `python -m sphinx -q -b html docs/public docs/public/_build/html` with Doxygen on PATH
- generated `docs/public/_build/html/index.html`