### PR TITLE
Auto-enable Pages on first deploy

### DIFF
--- a/.github/workflows/deploy-docs-pages.yml
+++ b/.github/workflows/deploy-docs-pages.yml
@@ -72,6 +72,8 @@ jobs:
     steps:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Pass `enablement: true` to `actions/configure-pages@v5` so the Deploy documentation to GitHub Pages workflow provisions the Pages site on first run.

## Why
The post-merge deploy job has been failing on every push to `main` with::

    Error: Get Pages site failed. Please verify that the repository has Pages
    enabled and configured to build using GitHub Actions, or consider exploring
    the `enablement` parameter for this action.
    Error: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site

`gh api repos/microsoft/cpp_client_telemetry/pages` returns 404, which means GitHub Pages has never been provisioned for this repository. `actions/configure-pages` accepts an `enablement` parameter that asks the action to create the Pages site on first run; the workflow already grants the `pages: write` and `id-token: write` permissions it needs to do so.

## Fallback
If the org-level `GITHUB_TOKEN` restrictions still prevent automatic provisioning, a repository admin only needs to flip **Settings -> Pages -> Build and deployment -> Source** to `GitHub Actions` once; subsequent deploys will then succeed without the failure.

## Validation
- YAML parsed cleanly with `python -c "import yaml; yaml.safe_load(open(...))"`
- Diff is a two-line addition under the existing `actions/configure-pages@v5` step
