### PR TITLE
ci(spellcheck): pin misspell + add least-privilege permissions

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ master, main ]
 
+# Least-privilege GITHUB_TOKEN scope: misspell only reads .md/.txt files
+# (no PR comments, no status updates, no package writes). Explicit block
+# satisfies CodeQL "actions/missing-workflow-permissions" and keeps the
+# token narrowly scoped if Actions analysis is enabled here later.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,9 +28,22 @@ jobs:
       continue-on-error: true
 
     - name: install misspell
+      env:
+        # misspell v0.3.4 linux 64-bit tarball SHA256 (from upstream
+        # release checksums.txt). Pinning version + verifying SHA
+        # avoids executing an unpinned bootstrap script from a floating
+        # ref (the prior 'curl https://git.io/misspell | sh' pattern is
+        # a supply-chain risk) and keeps CI reproducible. Bump
+        # deliberately when upstream releases.
+        MISSPELL_VERSION: "0.3.4"
+        MISSPELL_SHA256: "afd95caf1eecc72ff382791e00b3b11523a20b0579d95e2295c1c043688743d5"
       run: |
-        curl -L -o ./install-misspell.sh https://git.io/misspell
-        sh ./install-misspell.sh
+        curl -fsSL -o misspell.tar.gz \
+          "https://github.com/client9/misspell/releases/download/v${MISSPELL_VERSION}/misspell_${MISSPELL_VERSION}_linux_64bit.tar.gz"
+        echo "${MISSPELL_SHA256}  misspell.tar.gz" | sha256sum -c -
+        mkdir -p bin
+        tar -xzf misspell.tar.gz -C bin misspell
+        rm misspell.tar.gz
 
     - name: run misspell
       run: |


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/spellcheck.yml` with the same three fixes already landed in the sister modules repo (microsoft/cpp_client_telemetry_modules#320, commits `f596201` + `7540eec` + `8d26e48`):

1. **Least-privilege `GITHUB_TOKEN`** — adds a top-level `permissions: { contents: read }` block. Without it, the workflow inherits the repo default (read+write on most APIs); misspell only needs to walk `.md`/`.txt`/`lib`/`tests` files. Also forward-compatible with enabling `actions` analysis in `codeql-analysis.yml` later (it would immediately flag `actions/missing-workflow-permissions` otherwise — that rule is what surfaced the same issue on the modules side).
2. **Pin misspell to v0.3.4 release tarball** — replaces the unpinned `curl https://git.io/misspell | sh` bootstrap (executes a shell script from `master` of an external repo via a redirect — supply-chain risk + non-reproducible) with a direct download of a specific release artifact from GitHub releases.
3. **SHA256 verify the tarball** against the upstream-published `afd95caf1eecc72ff382791e00b3b11523a20b0579d95e2295c1c043688743d5` (linux_64bit). Any tampering or unexpected upstream change fails CI rather than silently executing.

**Scope of misspell unchanged:** still scans `.md`, `.txt`, `examples/**`, all of `lib/` (excluding `json.hpp`), and `tests/**`. The fix is purely the install + permissions layer.

## Why now

GHAS in this repo doesn't currently scan workflow files (the `codeql-analysis.yml` matrix is `[cpp, javascript, python]` + `java` — no `actions` language), so this gap wasn't surfaced as a security alert. The audit on modules revealed it by analogy; small enough to fix proactively.

## Validation

The misspell workflow will run on this PR automatically (push trigger). On the modules-side equivalent commit, the same workflow passed first try.

## Bump procedure (for posterity)

To bump misspell: download the new tarball + checksum from `https://github.com/client9/misspell/releases`, update `MISSPELL_VERSION` and `MISSPELL_SHA256` in this workflow.