### PR TITLE
ci: least-privilege permissions for all workflows + harden spellcheck install

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -18,6 +18,13 @@ on:
     - dev
 
 
+# Least-privilege GITHUB_TOKEN scope: this workflow only checks out source
+# and builds + uploads artifacts (upload-artifact uses its own per-run SAS,
+# not GITHUB_TOKEN). Explicit block satisfies CodeQL rule
+# actions/missing-workflow-permissions if Actions analysis is enabled.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-ios-mac.yml
+++ b/.github/workflows/build-ios-mac.yml
@@ -20,6 +20,12 @@ on:
   - cron: 0 2 * * 1-5
 
 
+# Least-privilege GITHUB_TOKEN scope: this workflow only checks out source
+# and runs the iOS/macOS build matrix. Explicit block satisfies CodeQL rule
+# actions/missing-workflow-permissions if Actions analysis is enabled.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-posix-latest.yml
+++ b/.github/workflows/build-posix-latest.yml
@@ -20,6 +20,12 @@ on:
   - cron: 0 2 * * 1-5
 
 
+# Least-privilege GITHUB_TOKEN scope: this workflow only checks out source
+# and runs the Linux/Mac build matrix. Explicit block satisfies CodeQL rule
+# actions/missing-workflow-permissions if Actions analysis is enabled.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-ubuntu-2204.yml
+++ b/.github/workflows/build-ubuntu-2204.yml
@@ -20,6 +20,12 @@ on:
   - cron: 0 2 * * 1-5
 
 
+# Least-privilege GITHUB_TOKEN scope: this workflow only checks out source
+# and runs the Ubuntu 22.04 build. Explicit block satisfies CodeQL rule
+# actions/missing-workflow-permissions if Actions analysis is enabled.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-windows-vs2022.yaml
+++ b/.github/workflows/build-windows-vs2022.yaml
@@ -13,6 +13,12 @@ on:
     - main
     - dev
 
+# Least-privilege GITHUB_TOKEN scope: this workflow only checks out source
+# and runs the Visual Studio 2022 build. Explicit block satisfies CodeQL
+# rule actions/missing-workflow-permissions if Actions analysis is enabled.
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ master, main ]
 
+# Least-privilege GITHUB_TOKEN scope: misspell only reads .md/.txt files
+# (no PR comments, no status updates, no package writes). Explicit block
+# satisfies CodeQL "actions/missing-workflow-permissions" and keeps the
+# token narrowly scoped if Actions analysis is enabled here later.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,9 +28,22 @@ jobs:
       continue-on-error: true
 
     - name: install misspell
+      env:
+        # misspell v0.3.4 linux 64-bit tarball SHA256 (from upstream
+        # release checksums.txt). Pinning version + verifying SHA
+        # avoids executing an unpinned bootstrap script from a floating
+        # ref (the prior 'curl https://git.io/misspell | sh' pattern is
+        # a supply-chain risk) and keeps CI reproducible. Bump
+        # deliberately when upstream releases.
+        MISSPELL_VERSION: "0.3.4"
+        MISSPELL_SHA256: "afd95caf1eecc72ff382791e00b3b11523a20b0579d95e2295c1c043688743d5"
       run: |
-        curl -L -o ./install-misspell.sh https://git.io/misspell
-        sh ./install-misspell.sh
+        curl -fsSL -o misspell.tar.gz \
+          "https://github.com/client9/misspell/releases/download/v${MISSPELL_VERSION}/misspell_${MISSPELL_VERSION}_linux_64bit.tar.gz"
+        echo "${MISSPELL_SHA256}  misspell.tar.gz" | sha256sum -c -
+        mkdir -p bin
+        tar -xzf misspell.tar.gz -C bin misspell
+        rm misspell.tar.gz
 
     - name: run misspell
       run: |

--- a/.github/workflows/test-win-latest.yml
+++ b/.github/workflows/test-win-latest.yml
@@ -20,6 +20,12 @@ on:
   - cron: 0 2 * * 1-5
 
 
+# Least-privilege GITHUB_TOKEN scope: this workflow only checks out source
+# and runs Windows unit/functional tests. Explicit block satisfies CodeQL
+# rule actions/missing-workflow-permissions if Actions analysis is enabled.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## What

Adds an explicit least-privilege `permissions:` block to every workflow in `.github/workflows/` that previously lacked one, and hardens `spellcheck.yml`'s `misspell` install.

(Originally two PRs — #1451 for the 6 build/test workflows, #1450 for the spellcheck hardening. Folded into this one PR per maintainer request to ease review.)

## Why

- **Least-privilege GITHUB_TOKEN.** Without an explicit `permissions:` block, workflows inherit the repo default scope (typically read+write on most APIs), which is far broader than any of these jobs need. None of the affected workflows post PR comments, deploy artifacts via `GITHUB_TOKEN`, or otherwise write through it.
- **Mitigates `actions/missing-workflow-permissions` CodeQL findings** if Actions analysis is later added to the matrix here (already part of the modules-repo CodeQL config).
- **Mirrors the same hardening already shipped in the sister modules repo** (commits `8d26e4882` and `decc96501` on PR `microsoft/cpp_client_telemetry_modules#320`).
- **`spellcheck.yml` install was a supply-chain risk.** The prior `curl https://git.io/misspell | sh` pattern executed a shell script from the `master` branch of an external repo via a `git.io` redirect — both non-reproducible and trivially modifiable upstream without notice.

## Changes

### Workflows getting a new `permissions: contents: read` block (6 files)

| Workflow | Reason `contents: read` is sufficient |
|---|---|
| `build-android.yml` | Build only; `actions/upload-artifact@v4` uses its own per-run SAS URL, not GITHUB_TOKEN |
| `build-ios-mac.yml` | Build only |
| `build-posix-latest.yml` | Build only |
| `build-ubuntu-2204.yml` | Build only |
| `build-windows-vs2022.yaml` | Build only |
| `test-win-latest.yml` | Test only |

Each file gets a short explanatory comment naming the CodeQL rule it satisfies.

### `spellcheck.yml` (1 file) — three fixes

1. Add `permissions: contents: read`. `misspell` only reads `.md` / `.txt` / `examples/**` / `lib/**` (excluding `json.hpp`) / `tests/**` and prints typos to stdout.
2. Replace `curl https://git.io/misspell | sh` with a pinned tarball download of `misspell v0.3.4` from GitHub releases.
3. Verify the tarball SHA256 against the published checksum (`afd95caf1eecc72ff382791e00b3b11523a20b0579d95e2295c1c043688743d5`, linux_64bit). Any tampering or unexpected upstream change fails CI rather than silently running.

The set of files scanned by `misspell` is unchanged.

### Workflows deliberately NOT touched

| Workflow | Why |
|---|---|
| `codeql-analysis.yml` | Already has a `permissions:` block |
| `deploy-docs-pages.yml` | Already has a `permissions:` block (and legitimately needs `pages: write` / `id-token: write`) |

## Testing

- All 6 + 1 workflow files YAML-parse cleanly.
- `Build for Android > Checkout` step succeeded in CI on the original `bhamehta/workflow-permissions-hardening` push → confirms `contents: read` is sufficient for `actions/checkout@v4`.
- The spellcheck run on the original `bhamehta/spellcheck-hardening` push passed end-to-end with the pinned tarball + SHA verification.

## CI signal on this branch (after consolidation)

The two PRs separately reproduced two pre-existing infra flakes that are unrelated to the changes here:

- **`Analyze (cpp)` (CodeQL)** has been timing out across `main` and most PRs (4–6 h runtimes); see runs `26551009149`, `26302618182`, `26393096056` on `main`. The error is `CodeQL is out of memory` on the Windows runner — a runner-sizing/CodeQL-version issue, not a code defect.
- **`build (release, ubuntu-latest)`** hit a 6 h job-timeout cancellation on one of the prior runs; the same path passed on the other PR's run.

Both are well-known infra flakes; not caused by anything in this diff. Happy to re-run after consolidation if needed.
