### PR TITLE
Remove ATL

### DIFF
--- a/lib/pal/desktop/NetworkDetector.cpp
+++ b/lib/pal/desktop/NetworkDetector.cpp
@@ -233,14 +233,35 @@ namespace MAT_NS_BEGIN
         /// <returns></returns>
         HRESULT NetworkDetector::QueryInterface(REFIID riid, void ** ppv) noexcept
         {
-            static const QITAB rgqit[] =
+            HRESULT hr;
+
+            if (IID_INetworkEvents == riid)
             {
-                QITABENT(NetworkDetector, INetworkEvents),
-                QITABENT(NetworkDetector, INetworkConnectionEvents),
-                QITABENT(NetworkDetector, INetworkListManagerEvents),
-                { nullptr,0 }
-            };
-            return QISearch(this, rgqit, riid, ppv);
+                *ppv = static_cast<INetworkEvents*>(this);
+                hr = S_OK;
+            }
+            else if (IID_INetworkConnectionEvents == riid)
+            {
+                *ppv = static_cast<INetworkConnectionEvents*>(this);
+                hr = S_OK;
+            }
+            else if (IID_INetworkListManagerEvents == riid)
+            {
+                *ppv = static_cast<INetworkListManagerEvents*>(this);
+                hr = S_OK;
+            }
+            else if (IID_IUnknown == riid)
+            {
+                *ppv = static_cast<IUnknown*>(static_cast<INetworkEvents*>(this));
+                hr = S_OK;
+            }
+            else
+            {
+                *ppv = nullptr;
+                hr = E_NOINTERFACE;
+            }
+
+            return hr;
         }
 
         ULONG NetworkDetector::AddRef(void) noexcept

--- a/lib/pal/desktop/NetworkDetector.cpp
+++ b/lib/pal/desktop/NetworkDetector.cpp
@@ -233,7 +233,13 @@ namespace MAT_NS_BEGIN
         /// <returns></returns>
         HRESULT NetworkDetector::QueryInterface(REFIID riid, void ** ppv) noexcept
         {
-            HRESULT hr;
+            if (!ppv)
+            {
+                return E_POINTER;
+            }
+
+            *ppv = nullptr;
+            HRESULT hr = E_NOINTERFACE;
 
             if (IID_INetworkEvents == riid)
             {
@@ -255,10 +261,10 @@ namespace MAT_NS_BEGIN
                 *ppv = static_cast<IUnknown*>(static_cast<INetworkEvents*>(this));
                 hr = S_OK;
             }
-            else
+
+            if (SUCCEEDED(hr))
             {
-                *ppv = nullptr;
-                hr = E_NOINTERFACE;
+                AddRef();
             }
 
             return hr;

--- a/lib/pal/desktop/NetworkDetector.hpp
+++ b/lib/pal/desktop/NetworkDetector.hpp
@@ -30,13 +30,6 @@
 #include <windows.networking.h>
 #include <windows.networking.connectivity.h>
 
-// ATL exceptions expose header incompatibilities with Edge's build, using libc++
-#ifndef _ATL_NO_EXCEPTIONS
-#define _ATL_NO_EXCEPTIONS
-#endif
-
-#include <atlbase.h>
-
 #include <Netlistmgr.h>
 #include <OCIdl.h>
 #include <oaidl.h>


### PR DESCRIPTION
Eliminates forced dependency on ATL for a single function call that can trivially be inlined