### PR TITLE
Fix cancelAllRequests drain race and spin

### DIFF
--- a/lib/http/HttpClientManager.cpp
+++ b/lib/http/HttpClientManager.cpp
@@ -152,44 +152,9 @@ namespace MAT_NS_BEGIN {
     {
         cancelAllRequestsAsync();
 
-        // Defense-in-depth hardening for the telemetryd_v2 96 percent CPU
-        // bug. The original loop had two issues:
-        //
-        //   1. Data race (UB): m_httpCallbacks.empty() was read WITHOUT
-        //      holding m_httpCallbacksMtx, while onHttpResponse (a few
-        //      lines above) calls m_httpCallbacks.remove(callback) under
-        //      that same mutex. Concurrent access to a std::list's internal
-        //      state from two threads without synchronization is undefined
-        //      behavior; it only "worked" because empty() happens to be
-        //      cheap and rarely visibly miscompiled.
-        //
-        //   2. Liveness / CPU: std::this_thread::yield() on Darwin maps to
-        //      sched_yield / swtch_pri, which the scheduler treats as
-        //      "willing to give up the slice but want it back ASAP". With a
-        //      broken IHttpClient adapter that does not honor the cancel
-        //      contract, this manifests as a thread sitting at ~96 percent
-        //      CPU forever -- exactly what the customer's sysdiagnose
-        //      reported. Even with a correctly-implementing adapter, the
-        //      yield burns more CPU than necessary during the brief drain
-        //      window.
-        //
-        // Fix:
-        //   - Read m_httpCallbacks.empty() under m_httpCallbacksMtx every
-        //     iteration -- removes the data race.
-        //   - Replace yield() with a 50ms sleep -- caps drain-window CPU
-        //     at about 1 percent, even if the IHttpClient adapter is slow
-        //     to honor the cancel.
-        //
-        // Note: the wait is intentionally still unbounded. Adding a
-        // deadline would let cancelAllRequests return while in-flight
-        // callbacks are still pending; those callbacks operate on this
-        // HttpClientManager's state (m_httpCallbacks, requestDone), so
-        // returning before drainage is unsafe when the caller is about to
-        // destroy this object (e.g. the onStop / onCleanup paths in
-        // TelemetrySystem). The primary protection against indefinite
-        // waits is the matching change in OneDsHttpClient which actually
-        // implements CancelAllRequests; this loop simply finishes promptly
-        // once the adapter starts delivering OnHttpResponse calls.
+        // Wait for callbacks to drain before shutdown can destroy state that
+        // those callbacks still use. Keep the list check synchronized and sleep
+        // between polls so a slow adapter does not burn CPU while draining.
         for (;;)
         {
             {
@@ -206,4 +171,3 @@ namespace MAT_NS_BEGIN {
     // start async cancellation
 
 } MAT_NS_END
-

--- a/lib/http/HttpClientManager.cpp
+++ b/lib/http/HttpClientManager.cpp
@@ -9,6 +9,8 @@
 
 #include <assert.h>
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 #ifdef linux
 #include <unistd.h>
@@ -149,8 +151,56 @@ namespace MAT_NS_BEGIN {
     void HttpClientManager::cancelAllRequests()
     {
         cancelAllRequestsAsync();
-        while (!m_httpCallbacks.empty())
-            std::this_thread::yield();
+
+        // Defense-in-depth hardening for the telemetryd_v2 96 percent CPU
+        // bug. The original loop had two issues:
+        //
+        //   1. Data race (UB): m_httpCallbacks.empty() was read WITHOUT
+        //      holding m_httpCallbacksMtx, while onHttpResponse (a few
+        //      lines above) calls m_httpCallbacks.remove(callback) under
+        //      that same mutex. Concurrent access to a std::list's internal
+        //      state from two threads without synchronization is undefined
+        //      behavior; it only "worked" because empty() happens to be
+        //      cheap and rarely visibly miscompiled.
+        //
+        //   2. Liveness / CPU: std::this_thread::yield() on Darwin maps to
+        //      sched_yield / swtch_pri, which the scheduler treats as
+        //      "willing to give up the slice but want it back ASAP". With a
+        //      broken IHttpClient adapter that does not honor the cancel
+        //      contract, this manifests as a thread sitting at ~96 percent
+        //      CPU forever -- exactly what the customer's sysdiagnose
+        //      reported. Even with a correctly-implementing adapter, the
+        //      yield burns more CPU than necessary during the brief drain
+        //      window.
+        //
+        // Fix:
+        //   - Read m_httpCallbacks.empty() under m_httpCallbacksMtx every
+        //     iteration -- removes the data race.
+        //   - Replace yield() with a 50ms sleep -- caps drain-window CPU
+        //     at about 1 percent, even if the IHttpClient adapter is slow
+        //     to honor the cancel.
+        //
+        // Note: the wait is intentionally still unbounded. Adding a
+        // deadline would let cancelAllRequests return while in-flight
+        // callbacks are still pending; those callbacks operate on this
+        // HttpClientManager's state (m_httpCallbacks, requestDone), so
+        // returning before drainage is unsafe when the caller is about to
+        // destroy this object (e.g. the onStop / onCleanup paths in
+        // TelemetrySystem). The primary protection against indefinite
+        // waits is the matching change in OneDsHttpClient which actually
+        // implements CancelAllRequests; this loop simply finishes promptly
+        // once the adapter starts delivering OnHttpResponse calls.
+        for (;;)
+        {
+            {
+                LOCKGUARD(m_httpCallbacksMtx);
+                if (m_httpCallbacks.empty())
+                {
+                    return;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
     }
 
     // start async cancellation

--- a/lib/http/HttpClientManager.hpp
+++ b/lib/http/HttpClientManager.hpp
@@ -32,6 +32,12 @@ class HttpClientManager
 
         size_t requestCount() const
         {
+            // Access to m_httpCallbacks must be serialized via m_httpCallbacksMtx.
+            // Without the lock this is a std::list data race vs onHttpResponse,
+            // handleSendRequest, and cancelAllRequests (same UB class as the
+            // empty()-check bug fixed in cancelAllRequests). The mutex is
+            // declared mutable below so a const observer can take it.
+            LOCKGUARD(m_httpCallbacksMtx);
             return m_httpCallbacks.size();
         }
 
@@ -54,7 +60,7 @@ class HttpClientManager
         ILogManager&              m_logManager;
         IHttpClient&              m_httpClient;
         ITaskDispatcher&          m_taskDispatcher;
-        std::recursive_mutex      m_httpCallbacksMtx;
+        mutable std::recursive_mutex m_httpCallbacksMtx;
         std::list<HttpCallback*>  m_httpCallbacks;
 };
 

--- a/lib/http/HttpClient_Apple.mm
+++ b/lib/http/HttpClient_Apple.mm
@@ -214,10 +214,16 @@ void HttpClient_Apple::CancelAllRequests()
     for (const auto &id : ids)
         CancelRequestAsync(id);
 
-    while (!m_requests.empty())
+    for (;;)
     {
+        {
+            std::lock_guard<std::mutex> lock(m_requestsMtx);
+            if (m_requests.empty())
+            {
+                return;
+            }
+        }
         PAL::sleep(100);
-        std::this_thread::yield();
     }
 }
 

--- a/lib/http/HttpClient_Apple.mm
+++ b/lib/http/HttpClient_Apple.mm
@@ -132,23 +132,6 @@ public:
     void Cancel()
     {
         [m_dataTask cancel];
-        [session getTasksWithCompletionHandler:^(NSArray* dataTasks, NSArray* uploadTasks, NSArray* downloadTasks)
-        {
-            for (NSURLSessionTask* _task in dataTasks)
-            {
-                [_task cancel];
-            }
-
-            for (NSURLSessionTask* _task in downloadTasks)
-            {
-                [_task cancel];
-            }
-
-            for (NSURLSessionTask* _task in uploadTasks)
-            {
-                [_task cancel];
-            }
-        }];
     }
 
 private:


### PR DESCRIPTION
## Summary
- extracts the `HttpClientManager` cancel/drain fix from #1429 into a small PR
- locks `m_httpCallbacks` reads in `cancelAllRequests()` and `requestCount()`
- replaces the tight `yield()` drain loop with a 50ms sleep to avoid high CPU while waiting for callbacks to drain
- applies the same synchronized drain check to `HttpClient_Apple::CancelAllRequests()` and removes its redundant `yield()` after the existing sleep
- removes the session-wide `getTasksWithCompletionHandler` cancel-all from each Apple request cancel; `CancelAllRequests()` already cancels each SDK-tracked request individually

## Context
This keeps shutdown drain behavior intentionally unbounded: returning before in-flight callbacks drain can leave callbacks touching HTTP client manager/request state after teardown. The companion HTTP adapter fix should make cancellation complete promptly; these changes prevent SDK-side container races and avoid burning CPU while waiting.

## Validation
- `msbuild Solutions\MSTelemetrySDK.sln /m:1 /nr:false /t:Tests\UnitTests /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v145`
- `Solutions\out\Release\x64\UnitTests\UnitTests.exe --gtest_filter=HttpClientManagerTests.*`