### PR TITLE
Remove stale MSBuild references

### DIFF
--- a/Solutions/before.targets
+++ b/Solutions/before.targets
@@ -3,12 +3,13 @@
     <CustomIncludePath>$(SolutionDir)\..\third_party\krabsetw\krabs;$(CustomIncludePath)</CustomIncludePath>
   </PropertyGroup>
   <PropertyGroup Label="Globals">
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
-    <!-- Fallback to Visual Studio 2017 (v141) toolset by default -->
+    <!-- before.targets is imported before Microsoft.Cpp.Default.props, so DefaultPlatformToolset is not reliable here. -->
+    <!-- Map known-shipped toolsets explicitly; callers can still override PlatformToolset. -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '18.0'))">v145</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '16.0'))">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '15.0'))">v141</PlatformToolset>
     <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolset)' != ''">$(PlatformToolset)</PlatformToolset>
     <!-- Customers may override WindowsTargetPlatformVersion before auto-detection of latest Win 10 SDK -->
     <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>

--- a/Solutions/build.MIP.props
+++ b/Solutions/build.MIP.props
@@ -10,8 +10,13 @@
   </ItemDefinitionGroup>
   <PropertyGroup>
     <DisableWinRT>true</DisableWinRT>
-    <PlatformToolset>v141</PlatformToolset>
-    <VCToolsVersion>14.1</VCToolsVersion>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND '$(DefaultPlatformToolset)' != ''">$(DefaultPlatformToolset)</PlatformToolset>
+    <!-- Map known-shipped toolsets explicitly when DefaultPlatformToolset is unavailable. -->
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '18.0'))">v145</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '16.0'))">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '15.0'))">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)' == ''">v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RootNamespace)'=='ClientTelemetry'">
     <TargetName>mip_ClientTelemetry</TargetName>

--- a/examples/cpp/SampleCpp/SampleCpp.vcxproj
+++ b/examples/cpp/SampleCpp/SampleCpp.vcxproj
@@ -1080,7 +1080,6 @@
     <ClInclude Include="DefaultApiKey.h" />
     <ClInclude Include="LogManagerA.hpp" />
     <ClInclude Include="LogManagerB.hpp" />
-    <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DebugCallback.cpp" />

--- a/examples/cpp/SampleCpp/SampleCpp.vcxproj.filters
+++ b/examples/cpp/SampleCpp/SampleCpp.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="targetver.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="LogManagerA.hpp">
       <Filter>Source Files</Filter>
     </ClInclude>

--- a/examples/cpp/SampleCppMini/SampleCppMini.vcxproj
+++ b/examples/cpp/SampleCppMini/SampleCppMini.vcxproj
@@ -1542,7 +1542,6 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="demo.c" />

--- a/examples/cpp/SampleCppMini/SampleCppMini.vcxproj.filters
+++ b/examples/cpp/SampleCppMini/SampleCppMini.vcxproj.filters
@@ -15,11 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="targetver.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/lib/shared/Shared.vcxitems
+++ b/lib/shared/Shared.vcxitems
@@ -24,7 +24,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)LoggerCX.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)LogManagerCX.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)LogManagerEventReceiver.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)LogManagerV1.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PageActionData.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PlatformHelpers.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)SchemaStub.hpp" />

--- a/lib/shared/Shared.vcxitems.filters
+++ b/lib/shared/Shared.vcxitems.filters
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClInclude Include="$(MSBuildThisFileDirectory)LogManagerV1.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)AggregatedMetricData.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ECSClientCX.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)EventPropertiesCX.hpp" />

--- a/tests/functests/FuncTests.vcxproj
+++ b/tests/functests/FuncTests.vcxproj
@@ -436,7 +436,6 @@
     <ClCompile Include="$(ProjectDir)..\common\Mocks.cpp" />
     <ClInclude Include="..\common\MockIBandwidthController.hpp" />
     <ClInclude Include="..\common\MockIEcsClient.hpp" />
-    <ClInclude Include="..\common\MockILocalStorageReader.hpp" />
     <ClInclude Include="..\common\MockITelemetrySystem.hpp" />
     <ClInclude Include="..\common\MockITenantDataSerializer.hpp" />
     <ClInclude Include="EventDecoderListener.hpp" />

--- a/tests/functests/FuncTests.vcxproj.filters
+++ b/tests/functests/FuncTests.vcxproj.filters
@@ -53,9 +53,6 @@
     <ClInclude Include="..\common\MockIEcsClient.hpp">
       <Filter>mocks</Filter>
     </ClInclude>
-    <ClInclude Include="..\common\MockILocalStorageReader.hpp">
-      <Filter>mocks</Filter>
-    </ClInclude>
     <ClInclude Include="..\common\MockITenantDataSerializer.hpp">
       <Filter>mocks</Filter>
     </ClInclude>

--- a/tests/unittests/UnitTests.vcxproj
+++ b/tests/unittests/UnitTests.vcxproj
@@ -495,7 +495,6 @@
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\signals\tests\unittests\SignalsTests.cpp" />
   </ItemGroup>
   <ItemGroup Condition="exists('$(ProjectDir)..\..\lib\modules\sanitizer')">
-    <ClInclude Include="$(ProjectDir)..\..\lib\modules\sanitizer\tests\unittests\SanitizerBaseTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\sanitizer\tests\unittests\SanitizerEmailTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\sanitizer\tests\unittests\SanitizerJwtTests.cpp" />
     <ClCompile Include="$(ProjectDir)..\..\lib\modules\sanitizer\tests\unittests\SanitizerSitePathTests.cpp" />


### PR DESCRIPTION
This is split out of #1416 to keep the review surface small and focused.

Changes:
- Remove stale Visual Studio project/filter entries for files that no longer exist.
- Keep the Windows toolset fallback mapping current for VS 2026.
- Avoid forcing future Visual Studio versions into the VS 2022 toolset path.

Validation performed locally:
- CRLF-aware `git diff --check`
- MSBuild property evaluation confirmed `VisualStudioVersion=18.0` resolves to `v145`