### PR TITLE
Extend iOS workflow timeout

### DIFF
--- a/.github/workflows/build-ios-mac.yml
+++ b/.github/workflows/build-ios-mac.yml
@@ -47,7 +47,7 @@ jobs:
           - os: macos-15
             simulator: "'iPad Pro (11-inch) (4th generation)'"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     steps:


### PR DESCRIPTION
Increase the iOS workflow timeout from 30 minutes to 60 minutes so slower simulator startup does not cancel otherwise healthy runs.

Context:
- #1461 passed after rerunning the failed JavaScript CodeQL job.
- The remaining failure pattern is an iOS simulator leg timing out at about 30 minutes.
- The earlier simulator timing/deadlock issue appears to have been addressed separately, so a longer timeout is now appropriate.

Validation performed locally:
- `git diff --check`
- Workflow sanity check confirmed `timeout-minutes: 60` is present and the temporary CodeQL gitlink detector was removed.