### PR TITLE
Prepare for new release - 3.10.159.1

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.10.100.1"
-#define BUILD_VERSION 3,10,100,1
+#define BUILD_VERSION_STR "3.10.159.1"
+#define BUILD_VERSION 3,10,159,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include "ctmacros.hpp"
@@ -18,7 +18,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)10 << 32) |
-    ((uint64_t)100 << 16) |
+    ((uint64_t)159 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END


### PR DESCRIPTION
Prepare for the next release: bump the SDK build version from `3.10.100.1` to `3.10.159.1`.

Once merged, a matching `v3.10.159.1` tag and GitHub Release will be cut from `main`.