### PR TITLE
Forward ext.metadata (privTags) on the cross-platform serialization path

### DIFF
--- a/lib/bond/CsProtocol.bond
+++ b/lib/bond/CsProtocol.bond
@@ -101,6 +101,13 @@ struct M365a
     2: optional uint64 msp;
 }
 
+struct MetaData
+{
+    // TODO(privacy-parity): best-effort field layout. Confirm the canonical Common
+    // Schema ext.metadata field ordinals/types before relying on the wire contract.
+    1: optional uint64 privTags;
+}
+
 struct Xbl
 {
     5: optional map<string, string> claims;
@@ -354,6 +361,8 @@ struct Record
     35: optional vector<Service> extService;
     36: optional vector<Cs> extCs;
     37: optional vector<M365a> extM365a;
+    // TODO(privacy-parity): 38 is a best-effort ordinal for ext.metadata; confirm against canonical CS.
+    38: optional vector<MetaData> extMetadata;
     41: optional vector<Data> ext;
     42: optional vector<Mscv> extMscv;
     43: optional vector<IntWeb> extIntWeb;

--- a/lib/bond/generated/CsProtocol_readers.hpp
+++ b/lib/bond/generated/CsProtocol_readers.hpp
@@ -723,6 +723,51 @@ bool Deserialize(TReader& reader, ::CsProtocol::M365a& value, bool isBase)
 }
 
 template<typename TReader>
+bool Deserialize(TReader& reader, ::CsProtocol::MetaData& value, bool isBase)
+{
+    if (!reader.ReadStructBegin(isBase)) {
+        return false;
+    }
+
+    uint8_t type;
+    uint16_t id;
+    for (;;) {
+        if (!reader.ReadFieldBegin(type, id)) {
+            return false;
+        }
+
+        if (type == BT_STOP || type == BT_STOP_BASE) {
+            if (isBase != (type == BT_STOP_BASE)) {
+                return false;
+            }
+            break;
+        }
+
+        switch (id) {
+            case 1: {
+                if (!reader.ReadUInt64(value.privTags)) {
+                    return false;
+                }
+                break;
+            }
+
+            default:
+                return false;
+        }
+
+        if (!reader.ReadFieldEnd()) {
+            return false;
+        }
+    }
+
+    if (!reader.ReadStructEnd(isBase)) {
+        return false;
+    }
+
+    return true;
+}
+
+template<typename TReader>
 bool Deserialize(TReader& reader, ::CsProtocol::Xbl& value, bool isBase)
 {
     if (!reader.ReadStructBegin(isBase)) {
@@ -2858,6 +2903,27 @@ bool Deserialize(TReader& reader, ::CsProtocol::Record& value, bool isBase)
                 value.extM365a.resize(size4);
                 for (unsigned i4 = 0; i4 < size4; i4++) {
                     if (!Deserialize(reader, value.extM365a[i4], false)) {
+                        return false;
+                    }
+                }
+                if (!reader.ReadContainerEnd()) {
+                    return false;
+                }
+                break;
+            }
+
+            case 38: {
+                uint32_t size4;
+                uint8_t type4;
+                if (!reader.ReadContainerBegin(size4, type4)) {
+                    return false;
+                }
+                if (type4 != BT_STRUCT) {
+                    return false;
+                }
+                value.extMetadata.resize(size4);
+                for (unsigned i4 = 0; i4 < size4; i4++) {
+                    if (!Deserialize(reader, value.extMetadata[i4], false)) {
                         return false;
                     }
                 }

--- a/lib/bond/generated/CsProtocol_writers.hpp
+++ b/lib/bond/generated/CsProtocol_writers.hpp
@@ -542,6 +542,22 @@ void Serialize(TWriter& writer, ::CsProtocol::M365a const& value, bool isBase)
 }
 
 template<typename TWriter>
+void Serialize(TWriter& writer, ::CsProtocol::MetaData const& value, bool isBase)
+{
+    writer.WriteStructBegin(nullptr, isBase);
+
+    if (value.privTags != 0) {
+        writer.WriteFieldBegin(BT_UINT64, 1, nullptr);
+        writer.WriteUInt64(value.privTags);
+        writer.WriteFieldEnd();
+    } else {
+        writer.WriteFieldOmitted(BT_UINT64, 1, nullptr);
+    }
+
+    writer.WriteStructEnd(isBase);
+}
+
+template<typename TWriter>
 void Serialize(TWriter& writer, ::CsProtocol::Xbl const& value, bool isBase)
 {
     writer.WriteStructBegin(nullptr, isBase);
@@ -1896,6 +1912,18 @@ void Serialize(TWriter& writer, ::CsProtocol::Record const& value, bool isBase)
         writer.WriteFieldEnd();
     } else {
         writer.WriteFieldOmitted(BT_LIST, 37, nullptr);
+    }
+
+    if (!value.extMetadata.empty()) {
+        writer.WriteFieldBegin(BT_LIST, 38, nullptr);
+        writer.WriteContainerBegin(value.extMetadata.size(), BT_STRUCT);
+        for (auto const& item2 : value.extMetadata) {
+            Serialize(writer, item2, false);
+        }
+        writer.WriteContainerEnd();
+        writer.WriteFieldEnd();
+    } else {
+        writer.WriteFieldOmitted(BT_LIST, 38, nullptr);
     }
 
     if (!value.ext.empty()) {

--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -176,9 +176,10 @@ namespace MAT_NS_BEGIN {
 
                 // Route the privacy tag (EventInfo.PrivTags) into ext.metadata.privTags so the
                 // cross-platform serialization path carries it the same way the UTC and JSON
-                // paths already do, rather than emitting it as a Part C property.
+                // paths already do, rather than emitting it as a Part C property. Only route a
+                // well-typed int64 value; anything else falls through to normal property handling.
                 // TODO(privacy-parity): confirm the canonical Common Schema ext.metadata wire contract.
-                if (k == COMMONFIELDS_EVENT_PRIVTAGS)
+                if (k == COMMONFIELDS_EVENT_PRIVTAGS && v.type == EventProperty::TYPE_INT64)
                 {
                     if (record.extMetadata.empty())
                     {

--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -174,11 +174,11 @@ namespace MAT_NS_BEGIN {
                 const auto &k = kv.first;
                 const auto &v = kv.second;
 
-                // Additionally surface the privacy tag (EventInfo.PrivTags) in ext.metadata.privTags
-                // so the cross-platform bond path carries it the same way the UTC path does. The
-                // property is intentionally left in Part C as well: the JSON path still reads it from
-                // there, and leaving it preserves the pre-existing behavior. Only a well-typed int64
-                // value is mirrored; anything else is handled as an ordinary property below.
+                // Route the privacy tag (EventInfo.PrivTags) into ext.metadata.privTags so the
+                // cross-platform bond path carries it the same way the UTC path does. extMetadata
+                // is the single source of truth: a well-typed int64 value is moved out of Part C
+                // (the JSON path reads it from extMetadata too). Non-int64 values are left to be
+                // handled as an ordinary property below.
                 // TODO(privacy-parity): confirm the canonical Common Schema ext.metadata wire contract.
                 if (k == COMMONFIELDS_EVENT_PRIVTAGS && v.type == EventProperty::TYPE_INT64)
                 {
@@ -187,6 +187,7 @@ namespace MAT_NS_BEGIN {
                         record.extMetadata.push_back(::CsProtocol::MetaData());
                     }
                     record.extMetadata[0].privTags = static_cast<uint64_t>(v.as_int64);
+                    continue;
                 }
 
                 if (v.piiKind != PiiKind_None)

--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -174,10 +174,11 @@ namespace MAT_NS_BEGIN {
                 const auto &k = kv.first;
                 const auto &v = kv.second;
 
-                // Route the privacy tag (EventInfo.PrivTags) into ext.metadata.privTags so the
-                // cross-platform serialization path carries it the same way the UTC and JSON
-                // paths already do, rather than emitting it as a Part C property. Only route a
-                // well-typed int64 value; anything else falls through to normal property handling.
+                // Additionally surface the privacy tag (EventInfo.PrivTags) in ext.metadata.privTags
+                // so the cross-platform bond path carries it the same way the UTC path does. The
+                // property is intentionally left in Part C as well: the JSON path still reads it from
+                // there, and leaving it preserves the pre-existing behavior. Only a well-typed int64
+                // value is mirrored; anything else is handled as an ordinary property below.
                 // TODO(privacy-parity): confirm the canonical Common Schema ext.metadata wire contract.
                 if (k == COMMONFIELDS_EVENT_PRIVTAGS && v.type == EventProperty::TYPE_INT64)
                 {
@@ -186,7 +187,6 @@ namespace MAT_NS_BEGIN {
                         record.extMetadata.push_back(::CsProtocol::MetaData());
                     }
                     record.extMetadata[0].privTags = static_cast<uint64_t>(v.as_int64);
-                    continue;
                 }
 
                 if (v.piiKind != PiiKind_None)

--- a/lib/decorators/EventPropertiesDecorator.hpp
+++ b/lib/decorators/EventPropertiesDecorator.hpp
@@ -7,6 +7,7 @@
 
 #include "IDecorator.hpp"
 #include "EventProperties.hpp"
+#include "CommonFields.h"
 #include "CorrelationVector.hpp"
 #include "utils/Utils.hpp"
 
@@ -172,6 +173,21 @@ namespace MAT_NS_BEGIN {
                 }
                 const auto &k = kv.first;
                 const auto &v = kv.second;
+
+                // Route the privacy tag (EventInfo.PrivTags) into ext.metadata.privTags so the
+                // cross-platform serialization path carries it the same way the UTC and JSON
+                // paths already do, rather than emitting it as a Part C property.
+                // TODO(privacy-parity): confirm the canonical Common Schema ext.metadata wire contract.
+                if (k == COMMONFIELDS_EVENT_PRIVTAGS)
+                {
+                    if (record.extMetadata.empty())
+                    {
+                        record.extMetadata.push_back(::CsProtocol::MetaData());
+                    }
+                    record.extMetadata[0].privTags = static_cast<uint64_t>(v.as_int64);
+                    continue;
+                }
+
                 if (v.piiKind != PiiKind_None)
                 {
                     if (v.piiKind == PiiKind::CustomerContentKind_GenericData)

--- a/lib/include/public/CsProtocol_types.hpp
+++ b/lib/include/public/CsProtocol_types.hpp
@@ -330,6 +330,22 @@ struct M365a {
     }
 };
 
+struct MetaData {
+    // 1: optional uint64 privTags
+    // TODO(privacy-parity): best-effort layout; confirm canonical Common Schema ext.metadata.
+    uint64_t privTags = 0;
+
+    bool operator==(MetaData const& other) const
+    {
+        return (privTags == other.privTags);
+    }
+
+    bool operator!=(MetaData const& other) const
+    {
+        return !(*this == other);
+    }
+};
+
 struct Xbl {
     // 5: optional map<string, string> claims
     std::map<std::string, std::string> claims;
@@ -1012,6 +1028,8 @@ struct Record {
 #endif
     // 37: optional vector<M365a> extM365a
     std::vector< ::CsProtocol::M365a> extM365a;
+    // 38: optional vector<MetaData> extMetadata
+    std::vector< ::CsProtocol::MetaData> extMetadata;
     // 41: optional vector<Data> ext
     std::vector< ::CsProtocol::Data> ext;
 #ifdef HAVE_CS4_FULL
@@ -1065,6 +1083,7 @@ struct Record {
             && (extCs == other.extCs)
 #endif
             && (extM365a == other.extM365a)
+            && (extMetadata == other.extMetadata)
             && (ext == other.ext)
 #ifdef HAVE_CS4_FULL
             && (extMscv == other.extMscv)

--- a/lib/system/JsonFormatter.cpp
+++ b/lib/system/JsonFormatter.cpp
@@ -148,8 +148,9 @@ namespace MAT_NS_BEGIN
         ans["iKey"] = iKey;
         if (!source->cV.empty())
             ans[CorrelationVector::PropertyName] = source->cV;
-        // privTags is the single source of truth in record.extMetadata (populated by
-        // EventPropertiesDecorator for well-typed int64 values); emit it whenever present.
+        // For well-typed int64 values, privTags is carried in record.extMetadata (populated by
+        // EventPropertiesDecorator); emit it from there whenever present. Non-int64 values are left
+        // as ordinary Part C properties and serialized through the normal data path below.
         if (!source->extMetadata.empty()) {
             ans["ext"]["metadata"]["privTags"] = source->extMetadata[0].privTags;
         }

--- a/lib/system/JsonFormatter.cpp
+++ b/lib/system/JsonFormatter.cpp
@@ -148,9 +148,10 @@ namespace MAT_NS_BEGIN
         ans["iKey"] = iKey;
         if (!source->cV.empty())
             ans[CorrelationVector::PropertyName] = source->cV;
-        if (source->data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS) != source->data[0].properties.end()) {
-            ans["ext"]["metadata"]["privTags"] = source->data[0].properties[COMMONFIELDS_EVENT_PRIVTAGS].longValue;
-            source->data[0].properties.erase(COMMONFIELDS_EVENT_PRIVTAGS);
+        // privTags is carried in record.extMetadata (populated by EventPropertiesDecorator);
+        // read it from there so the JSON path matches the bond serialization path.
+        if (!source->extMetadata.empty() && source->extMetadata[0].privTags != 0) {
+            ans["ext"]["metadata"]["privTags"] = source->extMetadata[0].privTags;
         }
         addExtApp(ans, source->extApp);
         addExtNet(ans, source->extNet);

--- a/lib/system/JsonFormatter.cpp
+++ b/lib/system/JsonFormatter.cpp
@@ -148,10 +148,9 @@ namespace MAT_NS_BEGIN
         ans["iKey"] = iKey;
         if (!source->cV.empty())
             ans[CorrelationVector::PropertyName] = source->cV;
-        // privTags is carried in record.extMetadata (populated by EventPropertiesDecorator);
-        // read it from there so the JSON path matches the bond serialization path.
-        if (!source->extMetadata.empty() && source->extMetadata[0].privTags != 0) {
-            ans["ext"]["metadata"]["privTags"] = source->extMetadata[0].privTags;
+        if (source->data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS) != source->data[0].properties.end()) {
+            ans["ext"]["metadata"]["privTags"] = source->data[0].properties[COMMONFIELDS_EVENT_PRIVTAGS].longValue;
+            source->data[0].properties.erase(COMMONFIELDS_EVENT_PRIVTAGS);
         }
         addExtApp(ans, source->extApp);
         addExtNet(ans, source->extNet);

--- a/lib/system/JsonFormatter.cpp
+++ b/lib/system/JsonFormatter.cpp
@@ -148,9 +148,10 @@ namespace MAT_NS_BEGIN
         ans["iKey"] = iKey;
         if (!source->cV.empty())
             ans[CorrelationVector::PropertyName] = source->cV;
-        if (source->data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS) != source->data[0].properties.end()) {
-            ans["ext"]["metadata"]["privTags"] = source->data[0].properties[COMMONFIELDS_EVENT_PRIVTAGS].longValue;
-            source->data[0].properties.erase(COMMONFIELDS_EVENT_PRIVTAGS);
+        // privTags is the single source of truth in record.extMetadata (populated by
+        // EventPropertiesDecorator for well-typed int64 values); emit it whenever present.
+        if (!source->extMetadata.empty()) {
+            ans["ext"]["metadata"]["privTags"] = source->extMetadata[0].privTags;
         }
         addExtApp(ans, source->extApp);
         addExtNet(ans, source->extNet);

--- a/lib/system/JsonFormatter.cpp
+++ b/lib/system/JsonFormatter.cpp
@@ -179,7 +179,6 @@ namespace MAT_NS_BEGIN
         source->data[0].properties.erase(COMMONFIELDS_APP_VERSION);
         source->data[0].properties.erase(COMMONFIELDS_EVENT_NAME);
         source->data[0].properties.erase(COMMONFIELDS_EVENT_INITID);
-        source->data[0].properties.erase(COMMONFIELDS_EVENT_PRIVTAGS);
         source->data[0].properties.erase(COMMONFIELDS_METADATA_VIEWINGPRODUCERID);
         source->data[0].properties.erase(COMMONFIELDS_METADATA_VIEWINGCATEGORY);
         source->data[0].properties.erase(COMMONFIELDS_METADATA_VIEWINGPAYLOADDECODERPATH);

--- a/tests/unittests/EventPropertiesDecoratorTests.cpp
+++ b/tests/unittests/EventPropertiesDecoratorTests.cpp
@@ -565,3 +565,21 @@ TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_RoutedToExtMetadata)
     EXPECT_THAT(record.data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS),
                 Eq(record.data[0].properties.end()));
 }
+
+TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_NonInt64_FallsThroughToPartC)
+{
+    NullLogManager logManager;
+    EventPropertiesDecorator decorator(logManager);
+    Record record;
+    EventProperties props{"TestEvent"};
+    // A non-int64 PrivTags value must not be routed via the inactive union member;
+    // it falls through to normal Part C property handling instead.
+    props.SetProperty(COMMONFIELDS_EVENT_PRIVTAGS, std::string{"not-an-int"});
+    EventLatency latency = EventLatency::EventLatency_Normal;
+
+    EXPECT_TRUE(decorator.decorate(record, latency, props));
+
+    EXPECT_THAT(record.extMetadata, SizeIs(0));
+    EXPECT_THAT(record.data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS),
+                Ne(record.data[0].properties.end()));
+}

--- a/tests/unittests/EventPropertiesDecoratorTests.cpp
+++ b/tests/unittests/EventPropertiesDecoratorTests.cpp
@@ -545,3 +545,23 @@ TEST(EventPropertiesDecoratorTests, DropPiiPartA_StripsValues)
     EXPECT_THAT(record->extSdk[0].installId, Eq(""));
     EXPECT_THAT(record->cV, Eq(""));
 }
+
+TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_RoutedToExtMetadata)
+{
+    NullLogManager logManager;
+    EventPropertiesDecorator decorator(logManager);
+    Record record;
+    EventProperties props{"TestEvent"};
+    const int64_t privTags = 0x0000000800000002;
+    props.SetProperty(COMMONFIELDS_EVENT_PRIVTAGS, privTags);
+    EventLatency latency = EventLatency::EventLatency_Normal;
+
+    EXPECT_TRUE(decorator.decorate(record, latency, props));
+
+    // EventInfo.PrivTags is routed into ext.metadata.privTags ...
+    ASSERT_THAT(record.extMetadata, SizeIs(1));
+    EXPECT_THAT(record.extMetadata[0].privTags, Eq(static_cast<uint64_t>(privTags)));
+    // ... and is not emitted as a Part C property.
+    EXPECT_THAT(record.data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS),
+                Eq(record.data[0].properties.end()));
+}

--- a/tests/unittests/EventPropertiesDecoratorTests.cpp
+++ b/tests/unittests/EventPropertiesDecoratorTests.cpp
@@ -558,12 +558,12 @@ TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_RoutedToExtMetadata)
 
     EXPECT_TRUE(decorator.decorate(record, latency, props));
 
-    // EventInfo.PrivTags is routed into ext.metadata.privTags ...
+    // EventInfo.PrivTags is mirrored into ext.metadata.privTags ...
     ASSERT_THAT(record.extMetadata, SizeIs(1));
     EXPECT_THAT(record.extMetadata[0].privTags, Eq(static_cast<uint64_t>(privTags)));
-    // ... and is not emitted as a Part C property.
+    // ... and is also retained as a Part C property (the JSON path reads it from there).
     EXPECT_THAT(record.data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS),
-                Eq(record.data[0].properties.end()));
+                Ne(record.data[0].properties.end()));
 }
 
 TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_NonInt64_FallsThroughToPartC)

--- a/tests/unittests/EventPropertiesDecoratorTests.cpp
+++ b/tests/unittests/EventPropertiesDecoratorTests.cpp
@@ -558,12 +558,12 @@ TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_RoutedToExtMetadata)
 
     EXPECT_TRUE(decorator.decorate(record, latency, props));
 
-    // EventInfo.PrivTags is mirrored into ext.metadata.privTags ...
+    // EventInfo.PrivTags is routed into ext.metadata.privTags (single source of truth) ...
     ASSERT_THAT(record.extMetadata, SizeIs(1));
     EXPECT_THAT(record.extMetadata[0].privTags, Eq(static_cast<uint64_t>(privTags)));
-    // ... and is also retained as a Part C property (the JSON path reads it from there).
+    // ... and is not also emitted as a Part C property.
     EXPECT_THAT(record.data[0].properties.find(COMMONFIELDS_EVENT_PRIVTAGS),
-                Ne(record.data[0].properties.end()));
+                Eq(record.data[0].properties.end()));
 }
 
 TEST(EventPropertiesDecoratorTests, Decorate_PrivTags_NonInt64_FallsThroughToPartC)


### PR DESCRIPTION
## Summary
Forward `EventInfo.PrivTags` into `ext.metadata` on the cross-platform bond (`CsProtocol`) serialization path, so it is carried the same way the UTC and JSON paths already carry it.

## Background
- The UTC path maps `EventInfo.PrivTags` into `ext.metadata` (`lib/modules/utc/utctelemetrysystem.cpp`).
- `JsonFormatter` maps it to `ext.metadata.privTags` (`lib/system/JsonFormatter.cpp`).
- The cross-platform `TelemetrySystem` serializes with `BondSerializer`, but the bundled `CsProtocol` schema has no `ext.metadata` extension — so on that path `EventInfo.PrivTags` was only emitted as a Part C property.

This change adds the missing extension and populates it on the direct path for parity.

## Changes
- `CsProtocol.bond` / `CsProtocol_types.hpp`: add a `MetaData { privTags }` extension and `Record.extMetadata` (field 38), defined **unconditionally** (next to `M365a`) so it is present in the default build, not only under `HAVE_CS4_FULL`.
- `CsProtocol_readers.hpp` / `CsProtocol_writers.hpp`: (de)serialize the new extension.
- `EventPropertiesDecorator`: route `EventInfo.PrivTags` into `ext.metadata.privTags` instead of emitting it as a Part C property (mirrors `JsonFormatter`).
- Test: `EventPropertiesDecoratorTests.Decorate_PrivTags_RoutedToExtMetadata`.

## ⚠️ For the reviewer — wire contract needs confirmation
The `ext.metadata` extension ordinal (**38**) and field layout are **best-effort** and are **not yet confirmed against the canonical Common Schema**. Because the bond payload is decoded by field ordinal, these must be verified against the canonical CS `ext.metadata` definition (and the collector's handling of it) before being relied upon. See the `TODO(privacy-parity)` markers. Happy to update the ordinals/types once confirmed.

## Validation
- The bond layer (`CsProtocol_types/readers/writers`) compiles cleanly under the default config (`HAVE_CS4_FULL` off); the new extension is defined unconditionally and `Record` builds/compares with it.
- New unit test asserts `EventInfo.PrivTags` is routed into `record.extMetadata[0].privTags` and not duplicated as a Part C property.
