### PR TITLE
Prepare for new release - 3.10.161.1

### DIFF
--- a/docs/building-with-vcpkg.md
+++ b/docs/building-with-vcpkg.md
@@ -1,6 +1,6 @@
 # Building 1DS C++ SDK with vcpkg
 
-[vcpkg](https://vcpkg.io/) is a Microsoft cross-platform open source C++ package manager. Onboarding instructions for Windows, Linux and Mac OS X [available here](https://docs.microsoft.com/en-us/cpp/build/vcpkg). This document assumes that the customer build system is already configured to use vcpkg ([getting started guide](https://learn.microsoft.com/en-us/vcpkg/get_started/overview)). 1DS C++ SDK maintainers provide a build recipe, `mstelemetry` port or CONTROL file for vcpkg. The mainline vcpkg repo is refreshed to point to latest stable open source release of 1DS C++ SDK.
+[vcpkg](https://vcpkg.io/) is a Microsoft cross-platform open source C++ package manager. Onboarding instructions for Windows, Linux and Mac OS X [available here](https://docs.microsoft.com/en-us/cpp/build/vcpkg). This document assumes that the customer build system is already configured to use vcpkg ([getting started guide](https://learn.microsoft.com/en-us/vcpkg/get_started/overview)). 1DS C++ SDK maintainers provide a build recipe, `cpp-client-telemetry` port or CONTROL file for vcpkg. The mainline vcpkg repo is refreshed to point to latest stable open source release of 1DS C++ SDK.
 
 The port provides the core SDK — the `MSTelemetry::mat` target and its public
 C++ headers. The optional Microsoft-proprietary modules (Privacy Guard,
@@ -19,7 +19,7 @@ git clone --recurse-submodules https://github.com/microsoft/cpp_client_telemetry
 Once a new port has been accepted into the official vcpkg registry, install with:
 
 ```console
-vcpkg install mstelemetry
+vcpkg install cpp-client-telemetry
 ```
 
 That's it! The package should be compiled for the current OS.
@@ -32,7 +32,7 @@ shipped in this repository:
 ```console
 git clone https://github.com/microsoft/cpp_client_telemetry
 cd cpp_client_telemetry
-vcpkg install --overlay-ports=tools/ports mstelemetry
+vcpkg install --overlay-ports=tools/ports cpp-client-telemetry
 ```
 
 ### Using in your CMake project
@@ -44,12 +44,12 @@ find_package(MSTelemetry CONFIG REQUIRED)
 target_link_libraries(your_target PRIVATE MSTelemetry::mat)
 ```
 
-If you use vcpkg manifest mode (recommended), add `mstelemetry` to your
+If you use vcpkg manifest mode (recommended), add `cpp-client-telemetry` to your
 project's `vcpkg.json`:
 
 ```json
 {
-  "dependencies": ["mstelemetry"]
+  "dependencies": ["cpp-client-telemetry"]
 }
 ```
 
@@ -58,29 +58,29 @@ project's `vcpkg.json`:
 ### Windows
 
 ```powershell
-vcpkg install mstelemetry --triplet=x64-windows-static
+vcpkg install cpp-client-telemetry --triplet=x64-windows-static
 ```
 
 ### Linux
 
 ```bash
-vcpkg install mstelemetry --triplet=x64-linux
+vcpkg install cpp-client-telemetry --triplet=x64-linux
 ```
 
 ### macOS
 
 ```bash
 # Apple Silicon
-vcpkg install mstelemetry --triplet=arm64-osx
+vcpkg install cpp-client-telemetry --triplet=arm64-osx
 
 # Intel
-vcpkg install mstelemetry --triplet=x64-osx
+vcpkg install cpp-client-telemetry --triplet=x64-osx
 ```
 
 ### iOS (cross-compile)
 
 ```bash
-vcpkg install mstelemetry --triplet=arm64-ios
+vcpkg install cpp-client-telemetry --triplet=arm64-ios
 ```
 
 ### iOS Simulator
@@ -88,7 +88,7 @@ vcpkg install mstelemetry --triplet=arm64-ios
 vcpkg ships a built-in community triplet for the iOS Simulator:
 
 ```bash
-vcpkg install mstelemetry --triplet=arm64-ios-simulator
+vcpkg install cpp-client-telemetry --triplet=arm64-ios-simulator
 ```
 
 See the [vcpkg triplet documentation](https://learn.microsoft.com/en-us/vcpkg/users/triplets)
@@ -100,7 +100,7 @@ Requires the Android NDK (`ANDROID_NDK_HOME` must be set). vcpkg's built-in
 Android triplets default to Android API 28:
 
 ```bash
-vcpkg install mstelemetry --triplet=arm64-android
+vcpkg install cpp-client-telemetry --triplet=arm64-android
 ```
 
 This repo's Android build declares `minSdk 23`. To build the SDK and all
@@ -121,7 +121,7 @@ set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DANDROID_ABI=arm64-v8a)
 Then install, pointing `--overlay-triplets` at that directory:
 
 ```bash
-vcpkg install mstelemetry \
+vcpkg install cpp-client-telemetry \
   --triplet=arm64-android-api23 \
   --overlay-triplets=<your-triplets-dir>
 ```
@@ -177,13 +177,13 @@ set(ZLIB_COMPAT ON)
 Then install `zlib-ng` instead of `zlib`:
 
 ```console
-vcpkg install zlib-ng mstelemetry --triplet=x64-windows-static
+vcpkg install zlib-ng cpp-client-telemetry --triplet=x64-windows-static
 ```
 
 With `ZLIB_COMPAT=ON`, zlib-ng installs as a drop-in replacement — it provides
 the same `zlib.h` header, the same function names (`deflate`, `inflate`,
 `crc32`), and the same `ZLIB::ZLIB` CMake target. All packages that depend on
-`zlib` (including `mstelemetry` and any other libraries like `onnxruntime`)
+`zlib` (including `cpp-client-telemetry` and any other libraries like `onnxruntime`)
 will automatically use the optimized zlib-ng build.
 
 > **Important:** All libraries in the same binary should link against the same
@@ -217,7 +217,7 @@ you relied on the old flow for the proprietary modules, build from a
 ## Troubleshooting
 
 vcpkg build log files are created under your vcpkg root in
-`buildtrees/mstelemetry/` (or wherever `--x-buildtrees-root` points). Review
+`buildtrees/cpp-client-telemetry/` (or wherever `--x-buildtrees-root` points). Review
 these logs if you encounter package installation failures:
 
 | File | Contents |

--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.10.159.1"
-#define BUILD_VERSION 3,10,159,1
+#define BUILD_VERSION_STR "3.10.161.1"
+#define BUILD_VERSION 3,10,161,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include "ctmacros.hpp"
@@ -18,7 +18,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)10 << 32) |
-    ((uint64_t)159 << 16) |
+    ((uint64_t)161 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END
@@ -27,4 +27,3 @@ namespace PAL_NS_BEGIN { } PAL_NS_END
 
 #endif // RESOURCE_COMPILER_INVOKED
 #endif
-

--- a/tests/vcpkg/CMakeLists.txt
+++ b/tests/vcpkg/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(mstelemetry_vcpkg_test LANGUAGES CXX)
+project(cpp-client-telemetry_vcpkg_test LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/tests/vcpkg/README.md
+++ b/tests/vcpkg/README.md
@@ -1,6 +1,6 @@
 # Vcpkg Port Integration Tests
 
-End-to-end tests that verify the `mstelemetry` vcpkg port can be installed, found via `find_package(MSTelemetry CONFIG)`, linked, and executed on all supported platforms.
+End-to-end tests that verify the `cpp-client-telemetry` vcpkg port can be installed, found via `find_package(MSTelemetry CONFIG)`, linked, and executed on all supported platforms.
 
 ## Prerequisites
 
@@ -100,7 +100,7 @@ Set `ANDROID_NDK_HOME` if the script can't find your NDK automatically. Cross-co
 
 Each script runs 3 steps:
 
-1. **Configure** — CMake configures a minimal consumer project with the vcpkg toolchain. Dependencies (including the `mstelemetry` overlay port) are installed automatically.
+1. **Configure** — CMake configures a minimal consumer project with the vcpkg toolchain. Dependencies (including the `cpp-client-telemetry` overlay port) are installed automatically.
 2. **Build** — The consumer links against `MSTelemetry::mat`
 3. **Run** — The test binary exercises `LogManager`, `EventProperties`, and verifies all symbols resolve
 

--- a/tests/vcpkg/main.cpp
+++ b/tests/vcpkg/main.cpp
@@ -1,4 +1,4 @@
-// Vcpkg integration test for mstelemetry
+// Vcpkg integration test for cpp-client-telemetry
 // Verifies that find_package(MSTelemetry) works and core APIs are callable
 
 #include <cstdio>

--- a/tests/vcpkg/test-vcpkg-android.sh
+++ b/tests/vcpkg/test-vcpkg-android.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test script: Verify mstelemetry vcpkg port for Android (cross-compile only)
+# Test script: Verify cpp-client-telemetry vcpkg port for Android (cross-compile only)
 # Usage: ./tests/vcpkg/test-vcpkg-android.sh [ABI] [API_LEVEL]
 #   ABI: arm64-v8a (default), armeabi-v7a, x86_64, x86
 #   API_LEVEL: 23 (default), 28, or another level with a matching overlay triplet

--- a/tests/vcpkg/test-vcpkg-ios.sh
+++ b/tests/vcpkg/test-vcpkg-ios.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test script: Verify mstelemetry vcpkg port for iOS
+# Test script: Verify cpp-client-telemetry vcpkg port for iOS
 # Usage: ./tests/vcpkg/test-vcpkg-ios.sh [--simulator]
 # Prerequisites: VCPKG_ROOT set, macOS with Xcode + iOS SDK, cmake
 #

--- a/tests/vcpkg/test-vcpkg-linux.sh
+++ b/tests/vcpkg/test-vcpkg-linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test script: Verify mstelemetry vcpkg port on Linux
+# Test script: Verify cpp-client-telemetry vcpkg port on Linux
 # Usage: ./tests/vcpkg/test-vcpkg-linux.sh
 # Prerequisites: VCPKG_ROOT set, gcc/g++, cmake
 set -e

--- a/tests/vcpkg/test-vcpkg-macos.sh
+++ b/tests/vcpkg/test-vcpkg-macos.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test script: Verify mstelemetry vcpkg port on macOS
+# Test script: Verify cpp-client-telemetry vcpkg port on macOS
 # Usage: ./tests/vcpkg/test-vcpkg-macos.sh
 # Prerequisites: VCPKG_ROOT set, Xcode command line tools, cmake
 set -e

--- a/tests/vcpkg/test-vcpkg-windows.ps1
+++ b/tests/vcpkg/test-vcpkg-windows.ps1
@@ -1,4 +1,4 @@
-# Test script: Verify mstelemetry vcpkg port on Windows
+# Test script: Verify cpp-client-telemetry vcpkg port on Windows
 # Usage: Run from a VS Developer Command Prompt, or the script will find VS automatically.
 #   .\tests\vcpkg\test-vcpkg-windows.ps1
 #   .\tests\vcpkg\test-vcpkg-windows.ps1 -Triplet x64-windows

--- a/tests/vcpkg/vcpkg.json
+++ b/tests/vcpkg/vcpkg.json
@@ -1,8 +1,8 @@
 {
-  "name": "mstelemetry-vcpkg-test",
+  "name": "cpp-client-telemetry-vcpkg-test",
   "version-string": "0.0.1",
-  "description": "Integration test for mstelemetry vcpkg port",
+  "description": "Integration test for cpp-client-telemetry vcpkg port",
   "dependencies": [
-    "mstelemetry"
+    "cpp-client-telemetry"
   ]
 }

--- a/tools/ports/cpp-client-telemetry/portfile.cmake
+++ b/tools/ports/cpp-client-telemetry/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cpp_client_telemetry
-    REF 65a0c754d2ee6a53bdcb3b79b36ac66483a7cf98
-    SHA512 75da6be4233bfb05bafb1b31d6b80737e6efde4596adb93582dc0175f0154b8a5df7bdf5434d957ccdc31653da160959fe09f5e9f2997e6c0796759af9651755
+    REF 4485b82005abf1d24336ace99b11df88dd578eb0
+    SHA512 1f3ee1c26f1ae9e7323262c9b4c8796efba2c6addcde432d6c6c77b8c1c2f254cb8ff334b1dd0a72dc8ecfbfbae04ab374ec5ac7e5d286d6042953d53e50fd5b
     HEAD_REF main
 )
 

--- a/tools/ports/cpp-client-telemetry/usage
+++ b/tools/ports/cpp-client-telemetry/usage
@@ -1,4 +1,4 @@
-mstelemetry provides CMake targets:
+cpp-client-telemetry provides CMake targets:
 
     find_package(MSTelemetry CONFIG REQUIRED)
     target_link_libraries(main PRIVATE MSTelemetry::mat)

--- a/tools/ports/cpp-client-telemetry/vcpkg.json
+++ b/tools/ports/cpp-client-telemetry/vcpkg.json
@@ -1,6 +1,6 @@
 {
-  "name": "mstelemetry",
-  "version": "3.10.100.1",
+  "name": "cpp-client-telemetry",
+  "version": "3.10.161.1",
   "description": "Microsoft 1DS C/C++ Client Telemetry Library",
   "homepage": "https://github.com/microsoft/cpp_client_telemetry",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepares the SDK for the **3.10.161.1** release and aligns the vcpkg port naming with the official microsoft/vcpkg submission.

### Changes
- **Version bump** — regenerated `lib/include/public/Version.hpp` (`3.10.159.1` → `3.10.161.1`) via `tools/gen-version` (date-derived `3.<(year-2020)+4>.<dayOfYear>.1`).
- **Port rename** — renamed the in-repo vcpkg overlay port `tools/ports/mstelemetry/` → `tools/ports/cpp-client-telemetry/`, bumped its version to `3.10.161.1`, and pointed its `REF` at the CI-validated commit. The official microsoft/vcpkg port uses the `cpp-client-telemetry` name (matches the GitHub repo / `Owner-Project` discoverability convention); `mstelemetry` did not.
- **Docs/tests** — updated `docs/building-with-vcpkg.md` and `tests/vcpkg/*` to the new port name.

### Not changed
- The CMake **package/target name is unchanged**: consumers still use `find_package(MSTelemetry CONFIG REQUIRED)` and link `MSTelemetry::mat`. Only the lowercase vcpkg *port* identifier changed.

### Release follow-up (after merge)
1. Tag `v3.10.161.1` at the merge commit and publish the GitHub Release.
2. Finalize the official port PR (microsoft/vcpkg#52316): repoint `REF` → the `v3.10.161.1` tag, recompute SHA512, set version `3.10.161.1`, and mark it ready.
