### PR TITLE
Add MATSDK_HAVE_CS4 CMake option with public propagation to consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,14 @@ option(LINK_STATIC_DEPENDS "Link dependencies for static build"     YES)
 # Enable Azure Monitor / Application Insights end-point support
 option(BUILD_AZMON        "Build for Azure Monitor" YES)
 
+# Common Schema 4.0 (CS4) protocol support (CS3 by default). HAVE_CS4 toggles
+# optional CsProtocol fields whose presence changes the public struct layout, so
+# it is applied as a PUBLIC compile definition on the exported target (see
+# lib/CMakeLists.txt) to keep the SDK and its consumers in sync. HAVE_CS4_FULL
+# adds server/service extensions and implies HAVE_CS4.
+option(MATSDK_HAVE_CS4      "Build with Common Schema 4.0 (CS4) support" OFF)
+option(MATSDK_HAVE_CS4_FULL "Build with CS4 plus server/service extensions" OFF)
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   option(BUILD_APPLE_HTTP "Build Apple HTTP client" YES)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,13 @@ option(BUILD_AZMON        "Build for Azure Monitor" YES)
 # adds server/service extensions and implies HAVE_CS4.
 option(MATSDK_HAVE_CS4      "Build with Common Schema 4.0 (CS4) support" OFF)
 option(MATSDK_HAVE_CS4_FULL "Build with CS4 plus server/service extensions" OFF)
+# CS4_FULL requires CS4. Force the options consistent so the cache state and any
+# downstream checks of MATSDK_HAVE_CS4 are reliable (rather than relying on a
+# downstream OR).
+if(MATSDK_HAVE_CS4_FULL AND NOT MATSDK_HAVE_CS4)
+  message(STATUS "MATSDK_HAVE_CS4_FULL implies MATSDK_HAVE_CS4; enabling MATSDK_HAVE_CS4.")
+  set(MATSDK_HAVE_CS4 ON CACHE BOOL "Build with Common Schema 4.0 (CS4) support" FORCE)
+endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   option(BUILD_APPLE_HTTP "Build Apple HTTP client" YES)

--- a/docs/building-custom-SKU.md
+++ b/docs/building-custom-SKU.md
@@ -30,8 +30,8 @@ Build recipe must contain the following preprocessor definitions:
 | HAVE_MAT_STORAGE | on | Enable SQLite persistent offline storage |
 | HAVE_MAT_NETDETECT | on | _Win32 Desktop only_: Use NLM COM object for network cost detection on Windows 8+ |
 | HAVE_MAT_SHORT_NS | off | Use short "MAT::" namespace instead of "Microsoft::Applications::Events::" to reduce the .DLL size |
-| HAVE_CS4 | off | Build with Common Schema 4.0 support (CS3 by default). Enable via the `-DMATSDK_HAVE_CS4=ON` CMake option, which defines `HAVE_CS4` as a PUBLIC compile definition on the exported `MSTelemetry::mat` target so consumers stay in sync (`HAVE_CS4` changes the public CsProtocol struct layout and must match across the SDK and its consumers). |
-| HAVE_CS4_FULL | off | Enable additional Common Schema 4.0 protocol features needed by server / services SDK. Enable via `-DMATSDK_HAVE_CS4_FULL=ON` (implies `HAVE_CS4`). |
+| HAVE_CS4 | off | Preprocessor define enabling Common Schema 4.0 (CS3 by default). Any build system can define it (e.g. via a custom config header or compiler flag); CMake builds should prefer `-DMATSDK_HAVE_CS4=ON`, which defines `HAVE_CS4` and propagates it to consumers via the exported `MSTelemetry::mat` target. It changes the public CsProtocol struct layout and must match across the SDK and its consumers. |
+| HAVE_CS4_FULL | off | Preprocessor define adding the Common Schema 4.0 server / services extensions (implies `HAVE_CS4`). CMake builds should use `-DMATSDK_HAVE_CS4_FULL=ON`. |
 | COMPACT_SDK | off | Built-in build recipe for smallest possible SDK. Turns most features off. Includes_mat/config-compact.h_ |
 
 ## Building custom SDK SKU: MSBuild example

--- a/docs/building-custom-SKU.md
+++ b/docs/building-custom-SKU.md
@@ -30,8 +30,8 @@ Build recipe must contain the following preprocessor definitions:
 | HAVE_MAT_STORAGE | on | Enable SQLite persistent offline storage |
 | HAVE_MAT_NETDETECT | on | _Win32 Desktop only_: Use NLM COM object for network cost detection on Windows 8+ |
 | HAVE_MAT_SHORT_NS | off | Use short "MAT::" namespace instead of "Microsoft::Applications::Events::" to reduce the .DLL size |
-| HAVE_CS4 | off | Build with Common Schema 4.0 support. Current default is `off`, i.e. building with Common Schema 3.0 support |
-| HAVE_CS4_FULL | off | Enable additional Common Schema 4.0 protocol features needed by server / services SDK |
+| HAVE_CS4 | off | Build with Common Schema 4.0 support (CS3 by default). Enable via the `-DMATSDK_HAVE_CS4=ON` CMake option, which defines `HAVE_CS4` as a PUBLIC compile definition on the exported `MSTelemetry::mat` target so consumers stay in sync (`HAVE_CS4` changes the public CsProtocol struct layout and must match across the SDK and its consumers). |
+| HAVE_CS4_FULL | off | Enable additional Common Schema 4.0 protocol features needed by server / services SDK. Enable via `-DMATSDK_HAVE_CS4_FULL=ON` (implies `HAVE_CS4`). |
 | COMPACT_SDK | off | Built-in build recipe for smallest possible SDK. Turns most features off. Includes_mat/config-compact.h_ |
 
 ## Building custom SDK SKU: MSBuild example

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -342,8 +342,9 @@ target_include_directories(mat
 # presence changes the public struct layout, so it must be defined consistently
 # across the SDK and its consumers. Expose it as a PUBLIC (propagating) compile
 # definition on the exported target rather than a raw build flag, so consumers
-# linking MSTelemetry::mat inherit it automatically. HAVE_CS4_FULL implies HAVE_CS4.
-if(MATSDK_HAVE_CS4 OR MATSDK_HAVE_CS4_FULL)
+# linking MSTelemetry::mat inherit it automatically. MATSDK_HAVE_CS4_FULL forces
+# MATSDK_HAVE_CS4 on in the root CMakeLists, so checking MATSDK_HAVE_CS4 suffices.
+if(MATSDK_HAVE_CS4)
   target_compile_definitions(mat PUBLIC HAVE_CS4)
 endif()
 if(MATSDK_HAVE_CS4_FULL)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -338,6 +338,18 @@ target_include_directories(mat
     ${CMAKE_CURRENT_SOURCE_DIR}/utils
 )
 
+# Common Schema 4.0 support. HAVE_CS4 toggles optional CsProtocol fields whose
+# presence changes the public struct layout, so it must be defined consistently
+# across the SDK and its consumers. Expose it as a PUBLIC (propagating) compile
+# definition on the exported target rather than a raw build flag, so consumers
+# linking MSTelemetry::mat inherit it automatically. HAVE_CS4_FULL implies HAVE_CS4.
+if(MATSDK_HAVE_CS4 OR MATSDK_HAVE_CS4_FULL)
+  target_compile_definitions(mat PUBLIC HAVE_CS4)
+endif()
+if(MATSDK_HAVE_CS4_FULL)
+  target_compile_definitions(mat PUBLIC HAVE_CS4_FULL)
+endif()
+
 if(APPLE AND BUILD_OBJC_WRAPPER)
   if(MATSDK_OBJC_PRIVACYGUARD_AVAILABLE)
     target_compile_definitions(mat PRIVATE MATSDK_OBJC_PRIVACYGUARD_AVAILABLE=1)


### PR DESCRIPTION
Makes Common Schema 4.0 (CS4) a first-class, propagating build option instead of a raw compiler flag.

### Problem
`HAVE_CS4` / `HAVE_CS4_FULL` toggle optional `CsProtocol` fields whose presence **changes the public struct layout** (29 `#ifdef HAVE_CS4` blocks in `CsProtocol_types.hpp`). Today CS4 can only be enabled via a raw `-DCMAKE_CXX_FLAGS=-DHAVE_CS4=1` or a custom config header — both define it **for the SDK build only**. A consumer that includes the CS-protocol / `IDecorator` headers without the same define gets a mismatched layout (silent ODR/ABI hazard), and there's no first-class CMake toggle.

### Change
- New **default-off** options `MATSDK_HAVE_CS4` and `MATSDK_HAVE_CS4_FULL` (the latter implies the former).
- When enabled, `HAVE_CS4` is applied as a **`PUBLIC`** compile definition on the exported `MSTelemetry::mat` target, so consumers inherit it automatically via `INTERFACE_COMPILE_DEFINITIONS` — keeping the SDK and its consumers in sync.
- Docs updated (`building-custom-SKU.md`).

**Default off ⇒ existing builds are unchanged.**

### Validation (x64-windows)
- `cmake -DMATSDK_HAVE_CS4=ON …` configures cleanly.
- The library builds with `-DHAVE_CS4` (CS4 code path compiles).
- The installed `MSTelemetryTargets.cmake` carries `INTERFACE_COMPILE_DEFINITIONS "HAVE_CS4"` — confirming propagation to consumers.

### Follow-ups (not in this PR)
- A dedicated Android `-PHAVE_CS4=1` Gradle property mapping to this option (instead of the generic `CXXFLAGS`).
- A `cs4` feature on the `cpp-client-telemetry` vcpkg port.

Note for schema/collector owners: with this change, consumers linking a CS4-built `MSTelemetry::mat` now inherit `HAVE_CS4` automatically.
