### PR TITLE
Add -PHAVE_CS4 Gradle property for Android CS4 builds (follow-up to #1476)

### DIFF
--- a/lib/android_build/gradle.properties
+++ b/lib/android_build/gradle.properties
@@ -17,6 +17,8 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-# Uncomment CXXFLAGS to set CXX flags
+# Enable Common Schema 4.0 via the dedicated property (preferred):
+#   ./gradlew <task> -PHAVE_CS4=1     (or -PHAVE_CS4_FULL=1)
+# Or pass arbitrary CXX flags via CXXFLAGS (uncomment):
 # CXXFLAGS=-DHAVE_CS4=1
 

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -32,11 +32,15 @@ android {
                     // propagated to consumers via the exported target). HAVE_CS4_FULL
                     // adds the server/service extensions.
                     String haveCs4 = project.findProperty("HAVE_CS4") ?: System.getenv("HAVE_CS4") ?: ""
-                    if (haveCs4.equalsIgnoreCase("1") || haveCs4.equalsIgnoreCase("true") || haveCs4.equalsIgnoreCase("on")) {
+                    String haveCs4Full = project.findProperty("HAVE_CS4_FULL") ?: System.getenv("HAVE_CS4_FULL") ?: ""
+                    boolean cs4Full = haveCs4Full.equalsIgnoreCase("1") || haveCs4Full.equalsIgnoreCase("true") || haveCs4Full.equalsIgnoreCase("on")
+                    // CS4_FULL implies CS4, so enable the base option too rather than
+                    // relying on the CMake-side implication.
+                    boolean cs4 = cs4Full || haveCs4.equalsIgnoreCase("1") || haveCs4.equalsIgnoreCase("true") || haveCs4.equalsIgnoreCase("on")
+                    if (cs4) {
                         args.add("-DMATSDK_HAVE_CS4=ON")
                     }
-                    String haveCs4Full = project.findProperty("HAVE_CS4_FULL") ?: System.getenv("HAVE_CS4_FULL") ?: ""
-                    if (haveCs4Full.equalsIgnoreCase("1") || haveCs4Full.equalsIgnoreCase("true") || haveCs4Full.equalsIgnoreCase("on")) {
+                    if (cs4Full) {
                         args.add("-DMATSDK_HAVE_CS4_FULL=ON")
                     }
                     // Passes optional arguments to CMake.

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -27,6 +27,18 @@ android {
                     if (!cxxFlag.isEmpty()) {
                         args.add("-DCMAKE_CXX_FLAGS=\"" + cxxFlag + "\"")
                     }
+                    // Common Schema 4.0: -PHAVE_CS4=1 (or HAVE_CS4 env) maps to the
+                    // MATSDK_HAVE_CS4 CMake option (preferred over a raw CXX flag, and
+                    // propagated to consumers via the exported target). HAVE_CS4_FULL
+                    // adds the server/service extensions.
+                    String haveCs4 = project.findProperty("HAVE_CS4") ?: System.getenv("HAVE_CS4") ?: ""
+                    if (haveCs4.equalsIgnoreCase("1") || haveCs4.equalsIgnoreCase("true") || haveCs4.equalsIgnoreCase("on")) {
+                        args.add("-DMATSDK_HAVE_CS4=ON")
+                    }
+                    String haveCs4Full = project.findProperty("HAVE_CS4_FULL") ?: System.getenv("HAVE_CS4_FULL") ?: ""
+                    if (haveCs4Full.equalsIgnoreCase("1") || haveCs4Full.equalsIgnoreCase("true") || haveCs4Full.equalsIgnoreCase("on")) {
+                        args.add("-DMATSDK_HAVE_CS4_FULL=ON")
+                    }
                     // Passes optional arguments to CMake.
                     arguments args.toArray(new String[args.size()])
                     println "cmake flag: " + arguments


### PR DESCRIPTION
Follow-up to #1476. Adds a discoverable, dedicated Gradle property for enabling Common Schema 4.0 on Android, instead of stuffing a raw `-DHAVE_CS4=1` into `CXXFLAGS`.

### Change
`lib/android_build/maesdk/build.gradle` maps:
- `-PHAVE_CS4=1` (or the `HAVE_CS4` env var) → `-DMATSDK_HAVE_CS4=ON`
- `-PHAVE_CS4_FULL=1` (or `HAVE_CS4_FULL` env) → `-DMATSDK_HAVE_CS4_FULL=ON`

This mirrors the existing `USE_ROOM` dedicated-parameter pattern, and uses the CMake option from #1476 — so `HAVE_CS4` is applied as a **PUBLIC** compile definition and propagates to consumers (the raw-`CXXFLAGS` path does not). `gradle.properties` is updated to document the property.

```
./gradlew <task> -PHAVE_CS4=1
```

The existing `CXXFLAGS` path is unchanged, and with no property set the build is byte-for-byte the same — so this is inert until the property is used.

### Depends on #1476
This maps to the `MATSDK_HAVE_CS4` CMake option added in #1476. Until that merges, `-DMATSDK_HAVE_CS4=ON` is a no-op; please merge #1476 first.

### Deferred: vcpkg `cs4` feature
The third CS4 follow-up — a `cs4` feature on the `cpp-client-telemetry` vcpkg port — is **intentionally not included**. Both the official port (microsoft/vcpkg#52316) and the in-repo overlay build from the `v3.10.161.1` release tag, which does **not** contain `MATSDK_HAVE_CS4` (it's #1476). A feature there would pass `-DMATSDK_HAVE_CS4=ON` to a source that ignores it — silently doing nothing. It should be added when the port bumps to a release that includes #1476 (e.g. via the `vcpkg-release-bump` workflow in #1475).
