### PR TITLE
Expose setOsVersion/setOsBuild on Obj-C ODWSemanticContext (resolves #1093)

### DIFF
--- a/tests/unittests/obj-c/ODWSemanticContextTests.mm
+++ b/tests/unittests/obj-c/ODWSemanticContextTests.mm
@@ -22,11 +22,15 @@ public:
     virtual void SetUserId(const std::string& userId, PiiKind) override { m_userId = userId; }
     virtual void SetUserAdvertisingId(const std::string& userAdvertisingId) override { m_userAdvertisingId = userAdvertisingId; }
     virtual void SetAppExperimentETag(const std::string& eTag) override { m_eTag = eTag; }
+    virtual void SetOsVersion(const std::string& osVersion) override { m_osVersion = osVersion; }
+    virtual void SetOsBuild(const std::string& osBuild) override { m_osBuild = osBuild; }
 
     std::string m_appId {};
     std::string m_userId {};
     std::string m_userAdvertisingId {};
     std::string m_eTag {};
+    std::string m_osVersion {};
+    std::string m_osBuild {};
 };
 
 @interface ODWSemanticContextTests : XCTestCase
@@ -61,6 +65,20 @@ public:
     ODWSemanticContext* context = [[ODWSemanticContext alloc] initWithISemanticContext:&nativeContext];
     [context setAppExperimentETag:@"myETag"];
     XCTAssertEqual(nativeContext.m_eTag, "myETag");
+}
+
+- (void)testSetOsVersion {
+    TestSemanticContext nativeContext;
+    ODWSemanticContext* context = [[ODWSemanticContext alloc] initWithISemanticContext:&nativeContext];
+    [context setOsVersion:@"10.0.19041"];
+    XCTAssertEqual(nativeContext.m_osVersion, "10.0.19041");
+}
+
+- (void)testSetOsBuild {
+    TestSemanticContext nativeContext;
+    ODWSemanticContext* context = [[ODWSemanticContext alloc] initWithISemanticContext:&nativeContext];
+    [context setOsBuild:@"19041.1234"];
+    XCTAssertEqual(nativeContext.m_osBuild, "19041.1234");
 }
 
 @end

--- a/wrappers/obj-c/ODWSemanticContext.h
+++ b/wrappers/obj-c/ODWSemanticContext.h
@@ -54,6 +54,21 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) setDeviceId:(nonnull NSString*)deviceId;
 
 /*!
+ @brief Set the operating system version context information of telemetry event.
+ @details Overrides the OS version that the SDK populates automatically (Common Schema field `ext.os.ver`).
+ @param osVersion A string that contains the operating system version.
+ */
+-(void) setOsVersion:(nonnull NSString*)osVersion;
+
+/*!
+ @brief Set the operating system build context information of telemetry event.
+ @details In the CS3 schema the OS version field (`ext.os.ver`) is populated from the OS build,
+ so set this if setOsVersion: alone does not update `ext.os.ver`.
+ @param osBuild A string that contains the operating system build.
+ */
+-(void) setOsBuild:(nonnull NSString*)osBuild;
+
+/*!
  @brief Set the user time zone context information of telemetry event.
  @param userTimeZone user's time zone relative to UTC, in ISO 8601 time zone format
  */

--- a/wrappers/obj-c/ODWSemanticContext.h
+++ b/wrappers/obj-c/ODWSemanticContext.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @brief Set the operating system version context information of telemetry event.
- @details Overrides the OS version that the SDK populates automatically (Common Schema field `ext.os.ver`).
+ @details Overrides the OS version that the SDK populates automatically (the `DeviceInfo.OsVersion` field). Note: in the CS3 schema `ext.os.ver` is populated from the OS build, not this field, so use setOsBuild: to override `ext.os.ver`.
  @param osVersion A string that contains the operating system version.
  */
 -(void) setOsVersion:(nonnull NSString*)osVersion;

--- a/wrappers/obj-c/ODWSemanticContext.mm
+++ b/wrappers/obj-c/ODWSemanticContext.mm
@@ -64,6 +64,18 @@ using namespace MAT;
     _wrappedSemanticContext->SetDeviceId(strDeviceId);
 }
 
+-(void) setOsVersion:(nonnull NSString*)osVersion
+{
+    std::string strOsVersion = std::string([osVersion UTF8String]);
+    _wrappedSemanticContext->SetOsVersion(strOsVersion);
+}
+
+-(void) setOsBuild:(nonnull NSString*)osBuild
+{
+    std::string strOsBuild = std::string([osBuild UTF8String]);
+    _wrappedSemanticContext->SetOsBuild(strOsBuild);
+}
+
 -(void) setUserTimeZone:(nonnull NSString*)userTimeZone
 {
     std::string strUserTimeZone = std::string([userTimeZone UTF8String]);

--- a/wrappers/swift/Sources/OneDSSwift/SemanticContext.swift
+++ b/wrappers/swift/Sources/OneDSSwift/SemanticContext.swift
@@ -67,6 +67,30 @@ public class SemanticContext {
     }
 
     /**
+    Set the operating system version context information of the telemetry event.
+
+    - Note: Overrides the OS version that the SDK populates automatically (Common Schema field `ext.os.ver`).
+
+    - Parameters:
+        - osVersion: A `String` that contains the operating system version.
+    */
+    public func setOsVersion(_ osVersion: String) {
+        odwSemanticContext.setOsVersion(osVersion)
+    }
+
+    /**
+    Set the operating system build context information of the telemetry event.
+
+    - Note: In the CS3 schema the OS version field (`ext.os.ver`) is populated from the OS build, so set this if `setOsVersion(_:)` alone does not update `ext.os.ver`.
+
+    - Parameters:
+        - osBuild: A `String` that contains the operating system build.
+    */
+    public func setOsBuild(_ osBuild: String) {
+        odwSemanticContext.setOsBuild(osBuild)
+    }
+
+    /**
     Set the user time zone context information of telemetry event.
 
     - Parameters:

--- a/wrappers/swift/Sources/OneDSSwift/SemanticContext.swift
+++ b/wrappers/swift/Sources/OneDSSwift/SemanticContext.swift
@@ -69,7 +69,7 @@ public class SemanticContext {
     /**
     Set the operating system version context information of the telemetry event.
 
-    - Note: Overrides the OS version that the SDK populates automatically (Common Schema field `ext.os.ver`).
+    - Note: Overrides the OS version that the SDK populates automatically (the `DeviceInfo.OsVersion` field). In the CS3 schema `ext.os.ver` is populated from the OS build, not this field — use `setOsBuild(_:)` to override `ext.os.ver`.
 
     - Parameters:
         - osVersion: A `String` that contains the operating system version.

--- a/wrappers/xamarin/sdk/OneDsCppSdk.iOS.Bindings/ApiDefinitions.cs
+++ b/wrappers/xamarin/sdk/OneDsCppSdk.iOS.Bindings/ApiDefinitions.cs
@@ -281,6 +281,14 @@ namespace Microsoft.Applications.Events
         [Export ("setDeviceId:")]
         void SetDeviceId (string deviceId);
 
+        // -(void)setOsVersion:(NSString * _Nonnull)osVersion;
+        [Export ("setOsVersion:")]
+        void SetOsVersion (string osVersion);
+
+        // -(void)setOsBuild:(NSString * _Nonnull)osBuild;
+        [Export ("setOsBuild:")]
+        void SetOsBuild (string osBuild);
+
         // -(void)setUserTimeZone:(NSString * _Nonnull)userTimeZone;
         [Export ("setUserTimeZone:")]
         void SetUserTimeZone (string userTimeZone);


### PR DESCRIPTION
## What

Expose `setOsVersion:` and `setOsBuild:` on the Obj-C wrapper's `ODWSemanticContext`, so iOS/Obj-C clients can override the OS version (`DeviceInfo.OsVersion` / Common Schema `ext.os.ver`) the SDK populates automatically.

## Why

Per #1093, a client needed to set `DeviceInfo.OsVersion` from app code on iOS. The C++ core already provides `ISemanticContext::SetOsVersion()` / `SetOsBuild()` (`ISemanticContext.hpp` via `DECLARE_COMMONFIELD`), but the Obj-C wrapper exposed only app/user/device-id/experiment setters — no OS-version setter — so there was no way to do this from the Obj-C API. (As noted in the issue thread, in the CS3 schema `ext.os.ver` is populated from the OS *build* (`COMMONFIELDS_OS_BUILD`), so both setters are exposed.)

## Changes

- **`wrappers/obj-c/ODWSemanticContext.h` / `.mm`** — add `setOsVersion:` and `setOsBuild:`, each converting the `NSString` to `std::string` and forwarding to the wrapped `ISemanticContext` (`SetOsVersion` / `SetOsBuild`). Mirrors the existing `setDeviceId:` pattern.
- **`tests/unittests/obj-c/ODWSemanticContextTests.mm`** — add `testSetOsVersion` and `testSetOsBuild`; the existing `TestSemanticContext` mock now captures `SetOsVersion`/`SetOsBuild`.

## Usage

```objc
[logger.semanticContext setOsVersion:@"10.0.19041"];
// CS3 ext.os.ver comes from the OS build:
[logger.semanticContext setOsBuild:@"19041.1234"];
```

## Validation

`SetOsVersion`/`SetOsBuild` are non-pure `virtual void Set...(const std::string&)` generated by `DECLARE_COMMONFIELD` (`CommonFields.h`), so the wrapper calls and the test-mock `override`s match the core signatures. The Obj-C wrapper builds and the XCTest run on the macOS/iOS CI — this change couldn't be compiled locally (no Obj-C toolchain on the dev box), so it relies on CI for the build/test confirmation.

Resolves #1093.
