### PR TITLE
Enable function-level linking in the CMake build (smaller downstream footprint)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,26 @@ endif()
 
 endif() # NOT MATSDK_USE_VCPKG_DEPS (compiler flags)
 
+# --- Dead-strip enablement (applies in BOTH vendored and vcpkg modes) ---------
+# Split functions/data into separate COMDATs/sections so a consumer's linker can
+# drop unreferenced SDK code: MSVC /OPT:REF + /OPT:ICF, GNU/Clang --gc-sections,
+# Apple ld -dead_strip. The vendored-deps flag block above sets these only when
+# NOT MATSDK_USE_VCPKG_DEPS, and never sets /Gy at all on MSVC -- so the vcpkg
+# build (the one packaged for downstream consumers) and every MSVC build link
+# whole .obj files instead of individual functions. This block closes that gap
+# and matches the MSBuild Release projects, which already enable
+# FunctionLevelLinking + OptimizeReferences + EnableCOMDATFolding.
+if(MSVC)
+  add_compile_options(/Gy /Gw)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  # -fdata-sections historically conflicted with bitcode on AppleClang, and the
+  # mach-o linker already dead-strips at symbol granularity with -dead_strip.
+  add_compile_options(-ffunction-sections)
+else()
+  # GCC / Clang (Linux, Android, MinGW)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
 include(tools/Utils.cmake)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
## Problem

The compiler-flags block in `CMakeLists.txt` (lines ~139–207) that sets `-ffunction-sections` / `-fdata-sections` / `--gc-sections` is wrapped entirely in `if(NOT MATSDK_USE_VCPKG_DEPS)`, and its **MSVC branch only sets warning flags — never `/Gy`**.

So the **CMake/vcpkg build — the one packaged for downstream consumers (e.g. Foundry Local) — compiles every TU without function-level COMDATs**. Referencing a single symbol then drags the whole `.obj` into the consumer's image, because the linker can only include/exclude entire object files, not individual functions. Measured impact downstream: linking 1DS adds ~3.86 MB to a consumer DLL even when only a slice of the API is used.

The MSBuild Release projects already do the right thing:
```
Solutions/win32-lib/win32-lib.vcxproj:396  <FunctionLevelLinking>true</FunctionLevelLinking>   (/Gy)
Solutions/win32-dll/win32-dll.vcxproj:298  <EnableCOMDATFolding>true</EnableCOMDATFolding>      (/OPT:ICF)
Solutions/win32-dll/win32-dll.vcxproj:299  <OptimizeReferences>true</OptimizeReferences>        (/OPT:REF)
```
The CMake path just never got the equivalent.

## Change

Add a small block, applied in **both** vendored and vcpkg modes, that splits functions/data into separate COMDATs/sections:

| Toolchain | Flags |
|---|---|
| MSVC | `/Gy /Gw` |
| GCC / Clang | `-ffunction-sections -fdata-sections` |
| AppleClang | `-ffunction-sections` (mach-o dead-strips per symbol) |

This lets a consumer's linker dead-strip unreferenced SDK code (`/OPT:REF` + `/OPT:ICF`, `--gc-sections`, `-dead_strip`). **No source or ABI change** — purely a code-generation/linkage hint.

## Validation

- Confirmed `/Gy /Gw` reach the SDK target's compile line under `MATSDK_USE_VCPKG_DEPS=ON` with the MSVC + Ninja generator.
- Cross-platform CI (Windows/Linux/macOS/iOS/Android + vcpkg) exercises the full build.

## Consumer note (not in this repo)

MSVC defaults `/OPT:REF` and `/OPT:ICF` **off** when `/DEBUG` is set (e.g. `RelWithDebInfo`), so the **consuming** link must enable them explicitly to realize the savings. This PR only enables the compile-side prerequisite.

A follow-up could also add `/OPT:REF,ICF` / `--gc-sections` to the SDK's own shared-library link for dynamic vcpkg consumers.
