### PR TITLE
Surface per-batch record count (param2) in HTTP response debug events

### DIFF
--- a/lib/http/HttpResponseDecoder.cpp
+++ b/lib/http/HttpResponseDecoder.cpp
@@ -91,6 +91,7 @@ namespace MAT_NS_BEGIN {
                 DebugEvent evt;
                 evt.type = DebugEventType::EVT_HTTP_OK;
                 evt.param1 = response.GetStatusCode();
+                evt.param2 = ctx->recordIdsAndTenantIds.size();
                 evt.data = static_cast<void *>(request.GetBody().data());
                 evt.size = request.GetBody().size();
                 DispatchEvent(evt);
@@ -112,6 +113,7 @@ namespace MAT_NS_BEGIN {
                 // This is to be addressed with ETW trace API that can send
                 // a detailed error context to ETW provider.
                 evt.param1 = response.GetStatusCode();
+                evt.param2 = ctx->recordIdsAndTenantIds.size();
                 evt.data = static_cast<void *>(request.GetBody().data());
                 evt.size = request.GetBody().size();
                 DispatchEvent(evt);
@@ -127,6 +129,7 @@ namespace MAT_NS_BEGIN {
                 DebugEvent evt;
                 evt.type = DebugEventType::EVT_HTTP_FAILURE;
                 evt.param1 = 0; // response.GetStatusCode();
+                evt.param2 = ctx->recordIdsAndTenantIds.size();
                 DispatchEvent(evt);
             }
             ctx->httpResponse = nullptr;
@@ -144,6 +147,7 @@ namespace MAT_NS_BEGIN {
                 DebugEvent evt;
                 evt.type = DebugEventType::EVT_HTTP_FAILURE;
                 evt.param1 = response.GetStatusCode();
+                evt.param2 = ctx->recordIdsAndTenantIds.size();
                 DispatchEvent(evt);
             }
             temporaryServerFailure(ctx);
@@ -157,6 +161,7 @@ namespace MAT_NS_BEGIN {
                 DebugEvent evt;
                 evt.type = DebugEventType::EVT_HTTP_FAILURE;
                 evt.param1 = response.GetStatusCode();
+                evt.param2 = ctx->recordIdsAndTenantIds.size();
                 DispatchEvent(evt);
             }
             temporaryNetworkFailure(ctx);
@@ -253,4 +258,3 @@ namespace MAT_NS_BEGIN {
     }
 
 } MAT_NS_END
-


### PR DESCRIPTION
## Summary
 
 Populates `evt.param2` with `ctx->recordIdsAndTenantIds.size()` across
 all 5 HTTP debug-event dispatch paths in `HttpResponseDecoder.cpp`:
 
 - `EVT_HTTP_OK` (successful upload)
 - `EVT_HTTP_ERROR` (rejected by server)
 - `EVT_HTTP_FAILURE` × 3 (no response, temporary server failure,
   temporary network failure)
 
 ## Motivation
 
 Debug event listeners currently receive the HTTP status code in `param1`
 but have no way to know how many records were in the batch. This makes
 it impossible to accurately count events delivered vs. dropped per HTTP
 round-trip. The `EVT_REJECTED` path already sets `param2`; this change
 brings the other paths to parity.
 
 ## Impact
 
 - No behavioral change to existing consumers that ignore `param2`
 - Enables accurate per-batch attribution for telemetry drop tracking
