### PR TITLE
Fix GUID_t::operator< to be a valid strict-weak-ordering

### DIFF
--- a/lib/system/EventProperty.cpp
+++ b/lib/system/EventProperty.cpp
@@ -307,10 +307,13 @@ namespace MAT_NS_BEGIN {
     // How to sort 2 objects (needed for maps)
     bool GUID_t::operator<(GUID_t const& other) const
     {
-        return Data1 < other.Data1 ||
-            Data2 < other.Data2 ||
-            Data3 == other.Data3 ||
-            (memcmp(Data4, other.Data4, sizeof(Data4)) < 0);
+        if (Data1 != other.Data1)
+            return Data1 < other.Data1;
+        if (Data2 != other.Data2)
+            return Data2 < other.Data2;
+        if (Data3 != other.Data3)
+            return Data3 < other.Data3;
+        return memcmp(Data4, other.Data4, sizeof(Data4)) < 0;
     }
 
     void EventProperty::copydata(EventProperty const* source)

--- a/tests/unittests/GuidTests.cpp
+++ b/tests/unittests/GuidTests.cpp
@@ -7,6 +7,8 @@
 #include "utils/Utils.hpp"
 #include "EventProperties.hpp"
 
+#include <set>
+
 using namespace testing;
 using namespace MAT;
 
@@ -84,4 +86,23 @@ TEST(GuidTests, MoveAssignment_ValidInput_MovesCorrectly)
     GUID_t second{"BEE391C8-72B0-464F-93C3-1B27879AD103"};
     second = std::move(first);
     ASSERT_EQ("9D016D64-372E-4DCE-9FA3-0D0772217C54", second.to_string());
+}
+TEST(GuidTests, OperatorLess_IsStrictWeakOrdering)
+{
+    // a and b differ in Data1/Data2 such that a non-lexicographic chained-|| operator
+    // reported BOTH a < b and b < a (antisymmetry violation).
+    GUID_t a{ "00000001-0005-0000-0000-000000000000" };
+    GUID_t b{ "00000002-0003-0000-0000-000000000000" };
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+
+    // c and d differ ONLY in Data3; a '==' in that position made them compare equivalent.
+    GUID_t c{ "00000001-0001-0001-0000-000000000000" };
+    GUID_t d{ "00000001-0001-0002-0000-000000000000" };
+    EXPECT_TRUE(c < d);
+    EXPECT_FALSE(d < c);
+
+    // A std::set keyed on operator< must keep four distinct GUIDs distinct.
+    std::set<GUID_t> s{ a, b, c, d };
+    EXPECT_EQ(static_cast<size_t>(4), s.size());
 }


### PR DESCRIPTION
Fixes a latent undefined-behavior bug in the public `GUID_t` type found during a repo-wide review.

## Problem

`GUID_t::operator<` (lib/system/EventProperty.cpp) is not a valid [strict-weak-ordering](https://en.cppreference.com/w/cpp/named_req/Compare):

```cpp
return Data1 < other.Data1 ||
    Data2 < other.Data2 ||
    Data3 == other.Data3 ||                 // (1) '==' typo, should be '<'
    (memcmp(Data4, other.Data4, sizeof(Data4)) < 0);
```

1. The `Data3` line uses `==` instead of `<`, so two GUIDs that differ **only** in `Data3` compare as equivalent.
2. The chained-`||` form is not lexicographic and violates antisymmetry — e.g. `{Data1:1,Data2:5}` vs `{Data1:2,Data2:3}` reports **both** `a<b` and `b<a` true.

`GUID_t` is a **public header** type (`EventProperty.hpp`), and the comment on the operator says it is "needed for maps". Using a non-strict-weak-ordering as the comparator for `std::set<GUID_t>` / `std::map<GUID_t, …>` (via the default `std::less`) is **undefined behavior** — container corruption, infinite loops, or crashes for consumers.

## Fix

Proper lexicographic comparison: `Data1`, then `Data2`, then `Data3`, then `memcmp(Data4)`.

## Test

Added `GuidTests.OperatorLess_IsStrictWeakOrdering`. It **fails on the old operator** (`c < d` is `false` for GUIDs differing only in `Data3`; a `std::set` of 4 distinct GUIDs collapses to 3) and **passes after the fix**.

**Validated locally** by building and running `UnitTests` on Linux (host): all 12 `GuidTests` pass.
