### PR TITLE
Fix inverted oneds_memcpy_s result in CompactBinaryProtocolReader::ReadBlob

### DIFF
--- a/lib/bond/CompactBinaryProtocolReader.hpp
+++ b/lib/bond/CompactBinaryProtocolReader.hpp
@@ -69,7 +69,7 @@ class CompactBinaryProtocolReader {
             return false;
         }
 #ifdef HAVE_ONEDS_BOUNDCHECK_METHODS
-        bool result = MAT::BoundCheckFunctions::oneds_memcpy_s(static_cast<uint8_t*>(data), size, &(m_input[m_ofs]), size);
+        bool result = (MAT::BoundCheckFunctions::oneds_memcpy_s(static_cast<uint8_t*>(data), size, &(m_input[m_ofs]), size) == 0);
 #else
         bool result = (memcpy_s(static_cast<uint8_t*>(data), size, &(m_input[m_ofs]), size) == 0);
 #endif


### PR DESCRIPTION
Fixes an inverted return value found during a repo-wide review.

## Problem

In `CompactBinaryProtocolReader::ReadBlob`, the `USE_ONEDS_BOUNDCHECK_METHODS` branch assigns the `errno_t` returned by `MAT::BoundCheckFunctions::oneds_memcpy_s` (`0` == success) **directly** to a `bool`:

```cpp
#ifdef HAVE_ONEDS_BOUNDCHECK_METHODS
    bool result = MAT::BoundCheckFunctions::oneds_memcpy_s(...);   // false on success, true on failure
#else
    bool result = (memcpy_s(...) == 0);                            // correct
#endif
```

So `result` is `false` on success and `true` on failure — inverted. `ReadBlob` (and therefore `ReadFloat`/`ReadDouble`, which call it) returns "failure" for every **successful** read, breaking decode of any payload with a blob/float/double field whenever the SDK is built with `USE_ONEDS_BOUNDCHECK_METHODS`. The non-boundcheck branch one line below already does it correctly.

## Fix

Compare the `errno_t` against `0`, matching the `memcpy_s` branch.

## Validation

TDD with a standalone reader round-trip compiled with `-DHAVE_ONEDS_BOUNDCHECK_METHODS`: `ReadDouble` of a written `double` returns **`false` before the fix** and **`true` (correct value) after**. The bug is gated behind the non-default `USE_ONEDS_BOUNDCHECK_METHODS` option (the default build is unaffected — the changed line is `#ifdef`'d out), and the existing `bondlite` `CompactBinaryProtocolTests` already assert `ReadBlob == true` under that option.
