### PR TITLE
Make public headers safe for consumers building with -Werror

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -352,7 +352,13 @@ endif()
 # BUILD_INTERFACE is used during the SDK build; INSTALL_INTERFACE is used
 # by consumers after cmake --install.
 target_include_directories(mat
-  PUBLIC
+  SYSTEM PUBLIC
+    # SYSTEM marks the public headers as system includes for consumers, so a
+    # consumer building with -Wall -Wextra -Werror is not broken by warnings
+    # originating inside the SDK's headers (e.g. -Wpedantic variadic-macro or
+    # -Wconversion diagnostics). find_package consumers already treat an imported
+    # target's includes as system; SYSTEM extends the same courtesy to
+    # add_subdirectory/FetchContent consumers.
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/mat>
   PRIVATE

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -351,16 +351,21 @@ endif()
 # PUBLIC propagates to consumers; PRIVATE is SDK-internal only.
 # BUILD_INTERFACE is used during the SDK build; INSTALL_INTERFACE is used
 # by consumers after cmake --install.
+#
+# The public headers are added in a separate SYSTEM call: SYSTEM marks them as
+# system includes for consumers, so a consumer building with -Wall -Wextra
+# -Werror is not broken by warnings originating inside the SDK's headers (e.g.
+# -Wpedantic variadic-macro or -Wconversion diagnostics). find_package consumers
+# already treat an imported target's includes as system; SYSTEM extends the same
+# courtesy to add_subdirectory/FetchContent consumers. The PRIVATE internal
+# include dirs are deliberately kept out of this SYSTEM call so the SDK's own
+# -Werror build still diagnoses warnings in its internal headers.
 target_include_directories(mat
   SYSTEM PUBLIC
-    # SYSTEM marks the public headers as system includes for consumers, so a
-    # consumer building with -Wall -Wextra -Werror is not broken by warnings
-    # originating inside the SDK's headers (e.g. -Wpedantic variadic-macro or
-    # -Wconversion diagnostics). find_package consumers already treat an imported
-    # target's includes as system; SYSTEM extends the same courtesy to
-    # add_subdirectory/FetchContent consumers.
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/public>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/mat>
+)
+target_include_directories(mat
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/lib/include/public/ISemanticContext.hpp
+++ b/lib/include/public/ISemanticContext.hpp
@@ -141,7 +141,7 @@ namespace MAT_NS_BEGIN
                 break;
 
             default:
-                assert(!"Unknown NetworkCost enum value");
+                assert(false && "Unknown NetworkCost enum value");
                 value = "";
                 break;
             }
@@ -180,7 +180,7 @@ namespace MAT_NS_BEGIN
                 break;
 
             default:
-                assert(!"Unknown NetworkType enum value");
+                assert(false && "Unknown NetworkType enum value");
                 value = "";
                 break;
             }

--- a/lib/include/public/ctmacros.hpp
+++ b/lib/include/public/ctmacros.hpp
@@ -67,9 +67,13 @@
 #  endif
 #endif
 
-// TODO: [MG] - ideally we'd like to use __attribute__((unused)) with gcc/clang
+// Cast the argument(s) to void so the parameter is genuinely referenced. An empty
+// expansion left the parameter unused under -Wunused-parameter, which broke
+// consumers compiling the SDK headers with -Wextra -Werror. On Windows the Win32
+// SDK provides its own UNREFERENCED_PARAMETER, so this definition only applies
+// where that macro is not already defined.
 #ifndef UNREFERENCED_PARAMETER
-#define UNREFERENCED_PARAMETER(...)
+#define UNREFERENCED_PARAMETER(...) (void)(__VA_ARGS__)
 #endif
 
 #define OACR_USE_PTR(...)


### PR DESCRIPTION
## Summary

Consumers that embed this SDK and compile their own code with `-Wall -Wextra -Werror` (e.g. ONNX Runtime / Foundry Local, which consume the SDK via `add_subdirectory`) were broken by warnings emitted from **inside the SDK's public headers**. This PR makes the public headers safe to include under strict, warning-as-error builds.

Two complementary changes:

### 1. Mark the exported public include dir as `SYSTEM` (primary fix)

`lib/CMakeLists.txt` now uses `target_include_directories(mat SYSTEM PUBLIC ...)`. `find_package` consumers already treat an imported target's includes as system headers (so their warnings are suppressed); the `SYSTEM` keyword extends the same courtesy to `add_subdirectory`/`FetchContent` consumers. This covers **every** consumer and **every** warning flag — including diagnostics that have no clean C++11 header-level fix (`-Wpedantic` variadic-macro warnings from the `LM_SAFE_CALL` family, `-Wsign-conversion` in the `Variant` union).

### 2. Header hygiene (defense in depth)

Also fixes the actual warnings, which helps non-CMake consumers (Bazel/Buck/Make copying the headers) and CMake consumers that set `NO_SYSTEM_FROM_IMPORTED`:

- **`ctmacros.hpp`** — `UNREFERENCED_PARAMETER(...)` expanded to *nothing* on gcc/clang (there was a `TODO` acknowledging this), so the parameter stayed unused and tripped `-Wunused-parameter`. It now casts the argument to `void`, eliminating **5** `-Wunused-parameter` warnings across `NullObjects.hpp` and `LogManagerProvider.hpp`.
- **`ISemanticContext.hpp`** — the `assert(!"message")` idiom triggers clang's `-Wstring-conversion`; switched to the canonical `assert(false && "message")` (2 sites).

## Impact on a consumer including the main public headers

| Consumer flags | Before | After (headers only) | After (with SYSTEM) |
|---|---:|---:|---:|
| `-Wall -Wextra` | 5 | **0** | 0 |
| `+ -Wpedantic` | 22 | 17 | **0** |
| `+ -Wshadow -Wconversion` (clang) | 9 | 2 | **0** |

## Validation

- **Header re-measure** (gcc 13 + clang 18, including `LogManager.hpp`, `EventProperties.hpp`, `CorrelationVector.hpp`, `PayloadDecoder.hpp`, `Variant.hpp`, `LogManagerProvider.hpp`): `-Wall -Wextra` drops **5 → 0**.
- **SYSTEM propagation**: configured the SDK via `add_subdirectory` and confirmed `mat`'s `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` contains the public include dir.
- **End-to-end**: a consumer treating the public dir as `-isystem` compiles **clean** under `-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Werror` on both gcc and clang; and a minimal `add_subdirectory` reproduction confirmed a consumer's `-Werror` fails without `SYSTEM` and passes with it.
- **No SDK regression**: the SDK's own top-level legacy build (`libmat.so`) compiles cleanly with the `UNREFERENCED_PARAMETER` change across all 75 call sites.

Public API and ABI are unchanged (`UNREFERENCED_PARAMETER` is a no-side-effect discard; the `assert` change is textual). The default build is otherwise unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
