### PR TITLE
Add Edge-specific DEPS file pinning lib/modules to c637015f

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,0 +1,21 @@
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+use_relative_paths = True
+
+git_dependencies = 'DEPS'
+
+vars = {
+  'edge_git': 'https://microsoft.visualstudio.com/edge/_git',
+  'edge_git_suffix': '',
+  'oneds_modules_revision': 'c637015fbbe904ed556d27e3b9072f6f2a5ee401',
+}
+
+deps = {
+  'lib/modules': {
+    'url': Var('edge_git') + '/microsoft.cpp_client_telemetry_modules' + Var('edge_git_suffix') + '@' + Var('oneds_modules_revision'),
+    'condition': 'checkout_ms_src_internal'
+  },
+}


### PR DESCRIPTION
Adds a top-level `DEPS` file so that gclient can resolve the `lib/modules` dependency (microsoft.cpp_client_telemetry_modules) when this SDK is consumed as a nested dependency of a larger gclient-managed source tree.

**What it does**
- Pins `lib/modules` to revision `c637015fbbe904ed556d27e3b9072f6f2a5ee401` via a `deps` entry.
- Uses `use_relative_paths = True` so the entry resolves relative to this repo's checkout location.

**Why**
Downstream consumers that vendor this SDK via gclient need an explicit `DEPS` entry to fetch `lib/modules`; without it the module sources are missing and dependent code fails to build.

**Notes**
- The pinned revision should be kept in sync with the `lib/modules` submodule pointer.