### PR TITLE
Fix version.js JScript runtime error under Windows Script Host (cscript)

### DIFF
--- a/tools/version.js
+++ b/tools/version.js
@@ -44,8 +44,11 @@ function generateVersionHpp() {
 
   // Read version tag
   var ver1      = readAll("..\\Solutions\\version.txt");
-  // Remove end-of-line
-  ver1 = ver1.trim();
+  // Remove leading/trailing whitespace. Use a regex rather than String.trim() so this
+  // runs under the Windows Script Host JScript engine (cscript), which does not
+  // implement String.prototype.trim(); the global anchored pattern also fully strips
+  // trailing newlines (the CodeQL incomplete-sanitization concern).
+  ver1 = ver1.replace(/^\s+|\s+$/g, "");
   ver1 = updateYearAndDay(ver1);
   // console.log("version.txt => " + ver1 + "\n");
   var ver2 = ver1.split(".").join(",");


### PR DESCRIPTION
### Problem
Every Windows CI build logs:
```
tools/version.js(48, 3) Microsoft JScript runtime error: Object doesn't support this property or method
```
`version.js` is executed by the Windows Script Host JScript engine (`cscript`). #1455 replaced `ver1.replace("\n", "")` with `ver1.trim()` to satisfy CodeQL `js/incomplete-sanitization`, but the WSH JScript engine does not implement `String.prototype.trim()`, so the script throws at line 48.

### Fix
Replace `.trim()` with an ES3-compatible global-anchored regex:
```js
ver1 = ver1.replace(/^\s+|\s+$/g, "");
```
This strips leading/trailing whitespace (including all trailing newlines), so it keeps the complete-sanitization behavior CodeQL asked for while running under the JScript engine.

### Validation
- `cscript //nologo version.js` now exits 0 and regenerates `Version.hpp` / `version.txt`.
- Confirmed the same engine rejects `.trim()` with the exact CI error (`Object doesn't support property or method 'trim'`).