### PR TITLE
Preserve sub-millisecond event timestamp precision

### DIFF
--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -433,12 +433,15 @@ namespace PAL_NS_BEGIN {
         // Resolve the precise API dynamically so the SDK retains its Windows 7
         // runtime compatibility and falls back when the API is unavailable.
         using GetSystemTimePreciseAsFileTimeProc = VOID (WINAPI*)(LPFILETIME);
-        HMODULE kernel32 = ::GetModuleHandleW(L"kernel32.dll");
-        auto getSystemTimePreciseAsFileTime =
-            kernel32
-            ? reinterpret_cast<GetSystemTimePreciseAsFileTimeProc>(
-                ::GetProcAddress(kernel32, "GetSystemTimePreciseAsFileTime"))
-            : nullptr;
+        static const GetSystemTimePreciseAsFileTimeProc getSystemTimePreciseAsFileTime =
+            []() -> GetSystemTimePreciseAsFileTimeProc
+            {
+                HMODULE kernel32 = ::GetModuleHandleW(L"kernel32.dll");
+                return kernel32
+                    ? reinterpret_cast<GetSystemTimePreciseAsFileTimeProc>(
+                        ::GetProcAddress(kernel32, "GetSystemTimePreciseAsFileTime"))
+                    : nullptr;
+            }();
         if (getSystemTimePreciseAsFileTime)
         {
             getSystemTimePreciseAsFileTime(&tocks);

--- a/lib/pal/PAL.cpp
+++ b/lib/pal/PAL.cpp
@@ -430,7 +430,23 @@ namespace PAL_NS_BEGIN {
     {
 #ifdef _WIN32
         FILETIME tocks;
-        ::GetSystemTimeAsFileTime(&tocks);
+        // Resolve the precise API dynamically so the SDK retains its Windows 7
+        // runtime compatibility and falls back when the API is unavailable.
+        using GetSystemTimePreciseAsFileTimeProc = VOID (WINAPI*)(LPFILETIME);
+        HMODULE kernel32 = ::GetModuleHandleW(L"kernel32.dll");
+        auto getSystemTimePreciseAsFileTime =
+            kernel32
+            ? reinterpret_cast<GetSystemTimePreciseAsFileTimeProc>(
+                ::GetProcAddress(kernel32, "GetSystemTimePreciseAsFileTime"))
+            : nullptr;
+        if (getSystemTimePreciseAsFileTime)
+        {
+            getSystemTimePreciseAsFileTime(&tocks);
+        }
+        else
+        {
+            ::GetSystemTimeAsFileTime(&tocks);
+        }
         ULONGLONG ticks = (ULONGLONG(tocks.dwHighDateTime) << 32) | tocks.dwLowDateTime;
         // number of days from beginning to 1601 multiplied by ticks per day
         return ticks + 0x701ce1722770000ULL;
@@ -440,10 +456,9 @@ namespace PAL_NS_BEGIN {
         // This UTC epoch contract has been signed in blood since C++20
         std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
         auto duration = now.time_since_epoch();
-        auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-        uint64_t ticks = millis;
-        ticks *= 10000; // convert millis to ticks (1 tick = 100ns)
-        ticks += 0x89F7FF5F7B58000ULL; // UTC time 0 in .NET ticks
+        auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+        int64_t ticks = nanos / 100; // convert nanoseconds to .NET ticks (1 tick = 100ns)
+        ticks += static_cast<int64_t>(0x89F7FF5F7B58000ULL); // UTC time 0 in .NET ticks
         return ticks;
 #endif
     }

--- a/tests/unittests/PalTests.cpp
+++ b/tests/unittests/PalTests.cpp
@@ -122,6 +122,22 @@ TEST_F(PalTests, SystemTime)
     EXPECT_THAT(t1, Lt(t0 + 1000));
 }
 
+#if !defined(_WIN32) && !defined(_WIN64)
+TEST_F(PalTests, SystemTimeInTicksPreservesSubMillisecondPrecision)
+{
+    constexpr int64_t TicksPerMillisecond = 10000;
+    bool observedSubMillisecondTick = false;
+
+    for (int i = 0; i < 1000 && !observedSubMillisecondTick; ++i)
+    {
+        observedSubMillisecondTick =
+            PAL::getUtcSystemTimeinTicks() % TicksPerMillisecond != 0;
+    }
+
+    EXPECT_TRUE(observedSubMillisecondTick);
+}
+#endif
+
 TEST_F(PalTests, FormatUtcTimestampMsAsISO8601)
 {
     EXPECT_THAT(PAL::formatUtcTimestampMsAsISO8601(0ll),             Eq("1970-01-01T00:00:00.000Z"));


### PR DESCRIPTION
## Summary

- preserve nanosecond-derived 100 ns precision for default POSIX event timestamps
- use `GetSystemTimePreciseAsFileTime` on Windows when available, with a Windows 7-compatible fallback
- add regression coverage for POSIX timestamps retaining sub-millisecond ticks

Fixes #1514.

## Validation

- `git diff --check` passed
- Fresh Windows CMake configuration succeeded
- The unit-test build was blocked by existing configuration issues: missing `gtest/gtest.lib` and `/WX` failures from pre-existing `HAVE_MAT_AI` macro redefinition / exception-mode warnings