### PR TITLE
Fix macOS/iOS test GoogleTest includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,9 @@ if(MATSDK_USE_VCPKG_DEPS)
     # distribution links them the same way), so the vcpkg sqlite3/zlib packages are
     # not pulled there -- find the system ones via CMake's standard find modules.
     find_package(SQLite3 REQUIRED)
+    if(NOT TARGET SQLite3::SQLite3)
+      add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+    endif()
     find_package(ZLIB REQUIRED)
     find_package(nlohmann_json CONFIG REQUIRED)
     set(MATSDK_APPLE_SYSTEM_DEPS ON)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -502,12 +502,12 @@ if(MATSDK_USE_VCPKG_DEPS)
   # These are PUBLIC so static-library consumers get the transitive link set
   # through the exported MSTelemetry::mat target.
   if(APPLE)
-    # macOS/iOS link the system libsqlite3 + libz (SQLite::SQLite3 / ZLIB::ZLIB
+    # macOS/iOS link the system libsqlite3 + libz (SQLite3::SQLite3 / ZLIB::ZLIB
     # resolve to the OS libraries via CMake's find modules), so the vcpkg
     # sqlite3/zlib packages are neither pulled nor linked here.
     target_link_libraries(mat
       PUBLIC
-        SQLite::SQLite3
+        SQLite3::SQLite3
         ZLIB::ZLIB
         nlohmann_json::nlohmann_json
         ${LIBS}
@@ -583,15 +583,19 @@ else()
     target_link_libraries(mat PRIVATE sqlite3 z ${LIBS})
   else()
     # Linux legacy: system zlib + system (or private minimal) sqlite3. ZLIB::ZLIB
-    # and SQLite::SQLite3 are imported targets that carry their own include dirs.
+    # and SQLite3::SQLite3 are imported targets that carry their own include dirs.
     find_package(ZLIB REQUIRED)
     if(MATSDK_BUNDLE_SQLITE)
       target_link_libraries(mat PRIVATE sqlite3_bundled ZLIB::ZLIB ${LIBS})
     else()
       # find_package(SQLite3) needs CMake >= 3.14, guaranteed by the project floor;
-      # SQLite::SQLite3 is an imported target carrying its own include dirs.
+      # SQLite3::SQLite3 is the canonical imported target. CMake < 4.3 only
+      # provides the deprecated SQLite::SQLite3 spelling.
       find_package(SQLite3 REQUIRED)
-      target_link_libraries(mat PRIVATE SQLite::SQLite3 ZLIB::ZLIB ${LIBS})
+      if(NOT TARGET SQLite3::SQLite3)
+        add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+      endif()
+      target_link_libraries(mat PRIVATE SQLite3::SQLite3 ZLIB::ZLIB ${LIBS})
     endif()
   endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,25 @@
 include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/../lib/include/public ${CMAKE_CURRENT_SOURCE_DIR}/../lib/include/mat ${CMAKE_CURRENT_SOURCE_DIR}/../lib/decoder ${CMAKE_CURRENT_SOURCE_DIR}/../sqlite )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/googletest/googletest/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/googletest/googlemock/include
-)
+set(MATSDK_GTEST_INCLUDE_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/googletest/googletest/include)
+set(MATSDK_GMOCK_INCLUDE_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/googletest/googlemock/include)
+if(NOT EXISTS "${MATSDK_GTEST_INCLUDE_DIR}/gtest/gtest.h")
+  message(FATAL_ERROR
+    "Tests require the third_party/googletest submodule at "
+    "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/googletest.")
+endif()
 
-include_directories(../lib)
+add_library(matsdk_test_includes INTERFACE)
+target_include_directories(matsdk_test_includes INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib/include/public
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib/include/mat
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib/decoder
+  ${CMAKE_CURRENT_SOURCE_DIR}/../sqlite
+  ${MATSDK_GTEST_INCLUDE_DIR}
+  ${MATSDK_GMOCK_INCLUDE_DIR})
 
 set(TESTS_COMMON_SRCS
   ../common/Common.cpp

--- a/tests/functests/CMakeLists.txt
+++ b/tests/functests/CMakeLists.txt
@@ -84,7 +84,10 @@ else()
     set (SQLITE3_LIB "/usr/local/opt/sqlite/lib/libsqlite3.a")
   else()
     find_package(SQLite3 REQUIRED)
-    set (SQLITE3_LIB SQLite::SQLite3)
+    if(NOT TARGET SQLite3::SQLite3)
+      add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+    endif()
+    set (SQLITE3_LIB SQLite3::SQLite3)
   endif()
 
   if(TARGET zlib_bundled)
@@ -153,5 +156,7 @@ else()
   endif()
 
 endif()
+
+target_link_libraries(FuncTests matsdk_test_includes)
 
 add_test(FuncTests FuncTests "--gtest_output=xml:${PROJECT_BINARY_DIR}/test-reports/FuncTests.xml")

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -148,7 +148,10 @@ else()
     set (SQLITE3_LIB "/opt/homebrew/opt/sqlite/lib/libsqlite3.a")
   else()
     find_package(SQLite3 REQUIRED)
-    set (SQLITE3_LIB SQLite::SQLite3)
+    if(NOT TARGET SQLite3::SQLite3)
+      add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+    endif()
+    set (SQLITE3_LIB SQLite3::SQLite3)
   endif()
 
   if(TARGET zlib_bundled)
@@ -220,5 +223,7 @@ else()
   endif()
 
 endif()
+
+target_link_libraries(UnitTests matsdk_test_includes)
 
 add_test(UnitTests UnitTests "--gtest_output=xml:${PROJECT_BINARY_DIR}/test-reports/UnitTests.xml")


### PR DESCRIPTION
## Summary

- Attach GoogleTest/GoogleMock include paths to FuncTests and UnitTests through a target-level interface configuration

- Fail at configure time with a clear message when the GoogleTest submodule is unavailable.
- Use canonical CMake 4.3+ SQLite3::SQLite3 targets, with compatibility aliases for older CMake versions.

## Validation
- CMake 4.4 configure succeeds with both test targets enabled.
- Functional test sources, including APITest.cpp, compile with the propagated GoogleTest headers.
- Full Windows link was blocked by the existing legacy out/gtest/gtest.lib path convention.