### PR TITLE
Guard POSIX pipe cleanup when popen fails

### DIFF
--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -114,11 +114,8 @@ static std::string Exec(const char* cmd)
 {
     std::array<char, 128> buffer;
     std::string result;
-    std::shared_ptr<FILE> pipe(popen(cmd, "r"), [](FILE* file) {
-        if (file != nullptr) {
-            pclose(file);
-        }
-    });
+    auto close_pipe = [](FILE* file) { pclose(file); };
+    std::unique_ptr<FILE, decltype(close_pipe)> pipe(popen(cmd, "r"), close_pipe);
     if (!pipe)
     {
         // throw std::runtime_error("popen() failed!");

--- a/lib/pal/posix/sysinfo_sources.cpp
+++ b/lib/pal/posix/sysinfo_sources.cpp
@@ -114,7 +114,11 @@ static std::string Exec(const char* cmd)
 {
     std::array<char, 128> buffer;
     std::string result;
-    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+    std::shared_ptr<FILE> pipe(popen(cmd, "r"), [](FILE* file) {
+        if (file != nullptr) {
+            pclose(file);
+        }
+    });
     if (!pipe)
     {
         // throw std::runtime_error("popen() failed!");
@@ -349,4 +353,3 @@ sysinfo_sources_impl::sysinfo_sources_impl() : sysinfo_sources()
     }
 
 }
-


### PR DESCRIPTION
## Description

Own the POSIX `popen` handle with `unique_ptr` so a failed acquisition never calls `pclose(nullptr)`.

`std::shared_ptr` invokes a supplied deleter even when its stored pointer is null. On shell-less Linux images, `popen()` returns null; the existing deleter then passes that null pointer to `pclose()`, which crashes during PAL/device-information initialization. The pipe has one owner, so a lambda-deleter `unique_ptr` models its lifetime directly and naturally skips cleanup for a null handle.

This is the upstream fix for microsoft/onnxruntime#32173 and microsoft/onnxruntime#32226.

## Validation

- Built the Linux SDK and unit tests with `MATSDK_WARNINGS_AS_ERRORS=ON`.
- Ran the full Linux `UnitTests` suite.
- Rebuilt telemetry-enabled ONNX Runtime with this exact unique-ownership implementation.
- Ran `OrtEnv.Instance()` as UID 1654 in the extracted `mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled` filesystem, which has neither `/bin/sh` nor `/etc/machine-id`; initialization succeeds with telemetry enabled and disabled.
