### PR TITLE
Fix unsafe resource lifetimes found by repository audit

### DIFF
--- a/examples/cpp/MacProxy/main.cpp
+++ b/examples/cpp/MacProxy/main.cpp
@@ -58,6 +58,8 @@ std::string GetProxyForURL(const std::string& url)
     urlProxArrayRef = CFNetworkCopyProxiesForURL(urlRef, proxyDicRef);
     if (!urlProxArrayRef)
         goto cleanup;
+    if (CFArrayGetCount(urlProxArrayRef) == 0)
+        goto cleanup;
 
     defProxyDic = (CFDictionaryRef)CFArrayGetValueAtIndex(urlProxArrayRef, 0);
     if (!defProxyDic)
@@ -82,11 +84,6 @@ std::string GetProxyForURL(const std::string& url)
 
 cleanup:
 
-    if (hostNameRef)
-    {
-        CFRelease(hostNameRef);
-        hostNameRef = NULL;
-    }
     if (urlProxArrayRef)
     {
         CFRelease(urlProxArrayRef);

--- a/lib/api/LogManagerFactory.cpp
+++ b/lib/api/LogManagerFactory.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <utility>
 
 #include <ctime>
@@ -33,9 +34,9 @@ namespace MAT_NS_BEGIN
     ILogManager* LogManagerFactory::Create(ILogConfiguration& configuration)
     {
         LOCKGUARD(ILogManagerInternal::managers_lock);
-        auto logManager = new LogManagerImpl(configuration);
-        ILogManagerInternal::managers.emplace(logManager);
-        return logManager;
+        auto logManager = std::make_unique<LogManagerImpl>(configuration);
+        ILogManagerInternal::managers.emplace(logManager.get());
+        return logManager.release();
     }
 
     /// <summary>
@@ -254,4 +255,3 @@ namespace MAT_NS_BEGIN
 
 }
 MAT_NS_END
-

--- a/lib/system/EventProperty.cpp
+++ b/lib/system/EventProperty.cpp
@@ -504,6 +504,11 @@ namespace MAT_NS_BEGIN {
     /// </summary>
     EventProperty& EventProperty::operator=(const EventProperty& source)
     {
+        if (this == &source)
+        {
+            return *this;
+        }
+
         clear();
         memcpy((void*)this, (void*)&source, sizeof(EventProperty));
         copydata(&source);
@@ -958,4 +963,3 @@ namespace MAT_NS_BEGIN {
     }
 
 } MAT_NS_END
-

--- a/lib/tracing/api/DebugProviders.hpp
+++ b/lib/tracing/api/DebugProviders.hpp
@@ -344,8 +344,8 @@ public:
         guid.Data4[6] = buffer2[14];
         guid.Data4[7] = buffer2[15];
 
-        delete buffer;
-        delete buffer2;
+        delete[] buffer;
+        delete[] buffer2;
 
         return guid;
     }
@@ -393,4 +393,3 @@ public:
 #endif
 
 #endif
-

--- a/tests/unittests/EventPropertiesTests.cpp
+++ b/tests/unittests/EventPropertiesTests.cpp
@@ -114,6 +114,15 @@ TEST(EventPropertiesTests, Properties)
     EXPECT_THAT(ep.GetPiiProperties(), IsEmpty());
 }
 
+TEST(EventPropertiesTests, SelfAssignmentPreservesValue)
+{
+    EventProperty property("value");
+
+    property = property;
+
+    EXPECT_EQ(property, EventProperty("value"));
+}
+
 TEST(EventPropertiesTests, NumericProperties)
 {
     EventProperties ep("test");


### PR DESCRIPTION
## Description

Fix four independent resource-lifetime defects found by a repository-wide audit of first-party cleanup and ownership paths:

- Do not release `hostNameRef` returned by `CFDictionaryGetValue`; it is borrowed from the proxy dictionary. Also avoid indexing an empty proxy array.
- Keep a newly constructed `LogManagerImpl` in a `unique_ptr` until insertion into the global manager registry succeeds, preventing an exception-path leak.
- Make `EventProperty` copy self-assignment a no-op instead of clearing its own source storage and then dereferencing it.
- Pair the two `new[]` allocations in ETW provider GUID generation with `delete[]` rather than scalar `delete`.

The audit excluded vendored/generated code. WinInet and curl cancellation lifetime findings are intentionally not duplicated here because #1520 already rewrites those ownership paths.

## Validation

- Configured and built the Linux SDK/unit-test targets with `MATSDK_WARNINGS_AS_ERRORS=ON`.
- Ran the targeted `EventPropertiesTests` suite.
- Ran all 645 Linux unit tests.
- Performed a focused ownership review of the resulting diff; an initially considered Objective-C configuration cleanup was removed because custom log managers retain that configuration by reference and require a broader lifecycle redesign.