### PR TITLE
[Android] Restore MAE SDK configuration cache

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -48,9 +48,6 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '17'
-    - name: Remove default github maven configuration
-      # Workaround for: 'Unable to decrypt local Maven settings credentials'
-      run: rm $Env:USERPROFILE\.m2\settings.xml
     - name: Setup Android SDK
       uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
     - name: Install NDK

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -109,8 +109,6 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '17'
-    - name: Remove default github maven configuration
-      run: rm $Env:USERPROFILE\.m2\settings.xml
     - name: Setup Android SDK
       uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
     - name: Install NDK

--- a/lib/android_build/maesdk/build.gradle
+++ b/lib/android_build/maesdk/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'maven-publish'
-    id 'net.linguica.maven-settings' version '0.5'
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
## Summary
- remove the abandoned `net.linguica.maven-settings` plugin from the MAE SDK module
- retain Gradle's built-in `maven-publish` plugin and its publishing task surface
- remove Windows CI workarounds that deleted the runner's Maven settings solely for the obsolete plugin

The authenticated Azure Artifacts repository and MAE SDK publication definitions were removed in 2020, so Maven settings credentials, mirrors, and profiles have had no repository or publication to configure since then. The default dependency repositories remain `google()` and `mavenCentral()`.

## Validation
- Windows: `gradlew.bat :maesdk:assembleRelease --configuration-cache` stored the configuration cache with no problems
- Windows: repeated the same command and Gradle reported `Configuration cache entry reused.`
- Windows: `gradlew.bat :maesdk:test` passed debug and release unit tests
- Windows: `gradlew.bat :maesdk:tasks --group publishing` confirmed `publish` and `publishToMavenLocal` remain available

Resolves microsoft/cpp_client_telemetry#1521