### PR TITLE
Prepare for new release - 3.10.240.1

### DIFF
--- a/lib/include/public/Version.hpp
+++ b/lib/include/public/Version.hpp
@@ -6,8 +6,8 @@
 #define MAT_VERSION_HPP
 // WARNING: DO NOT MODIFY THIS FILE!
 // This file has been automatically generated, manual changes will be lost.
-#define BUILD_VERSION_STR "3.10.173.1"
-#define BUILD_VERSION 3,10,173,1
+#define BUILD_VERSION_STR "3.10.240.1"
+#define BUILD_VERSION 3,10,240,1
 
 #ifndef RESOURCE_COMPILER_INVOKED
 #include "ctmacros.hpp"
@@ -18,7 +18,7 @@ namespace MAT_NS_BEGIN {
 uint64_t const Version =
     ((uint64_t)3 << 48) |
     ((uint64_t)10 << 32) |
-    ((uint64_t)173 << 16) |
+    ((uint64_t)240 << 16) |
     ((uint64_t)1);
 
 } MAT_NS_END


### PR DESCRIPTION
Regenerates `lib/include/public/Version.hpp` to the next date-derived release version **3.10.240.1** (`3.<(year-2020)+4>.<dayOfYear>.1`), produced by `tools/gen-version.cmd`.

Only the generated version header changes:

```diff
-#define BUILD_VERSION_STR "3.10.173.1"
+#define BUILD_VERSION_STR "3.10.240.1"
```

Standard release-prep PR (same shape as #1489). After this merges to `main`, publish the `v3.10.240.1` tag as a non-draft, non-prerelease GitHub Release. That release event triggers the automated `cpp-client-telemetry` vcpkg port bump workflow.