### PR TITLE
ci: Update Java distribution in Android build workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '17'
     - name: Setup Android SDK
       uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2


### PR DESCRIPTION
the upcoming v6 of the setup-java task won't recognize adopt anymore