### PR TITLE
Restore buildless C# CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -77,6 +77,27 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
+  analyze-csharp:
+    name: Analyze C#
+    runs-on: windows-2022
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      with:
+        languages: csharp
+        build-mode: none
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+
   analyze-java:
     name: Analyze Java
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL job for C# source
- use buildless analysis so legacy .NET Framework and Xamarin projects do not need to compile
- upload the C# snapshot required by the SFI-PS2.1 Continuous SDL KPI

## Rationale
PR #1357 removed C# from the language matrix after the Windows 2022 job could not observe a successful C# compilation. CodeQL now supports `build-mode: none` for C#, which analyzes the checked-in source without invoking those legacy build paths.

## Validation
- parsed `.github/workflows/codeql-analysis.yml` as YAML
- checked the branch diff for whitespace errors